### PR TITLE
refactor(privacy): async-first export signer contracts

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -45752,7 +45752,7 @@
       "kind": "record",
       "project": "Granit.Privacy.BlobStorage",
       "file": "src/Granit.Privacy.BlobStorage/DataExport/PrivacyExportAssemblyService.cs",
-      "line": 619,
+      "line": 621,
       "members": []
     },
     {
@@ -46791,16 +46791,16 @@
       "line": 22,
       "members": [
         {
-          "name": "SignBytes",
+          "name": "SignBytesAsync",
           "kind": "method",
-          "signature": "SignBytes(ReadOnlySpan<byte> payload)",
-          "returnType": "string"
+          "signature": "SignBytesAsync(ReadOnlyMemory<byte> payload, CancellationToken cancellationToken = default)",
+          "returnType": "Task<string>"
         },
         {
-          "name": "VerifyBytes",
+          "name": "VerifyBytesAsync",
           "kind": "method",
-          "signature": "VerifyBytes(ReadOnlySpan<byte> payload, string tag)",
-          "returnType": "bool"
+          "signature": "VerifyBytesAsync(ReadOnlyMemory<byte> payload, string tag, CancellationToken cancellationToken = default)",
+          "returnType": "Task<bool>"
         }
       ]
     },
@@ -46813,16 +46813,16 @@
       "line": 26,
       "members": [
         {
-          "name": "Sign",
+          "name": "SignAsync",
           "kind": "method",
-          "signature": "Sign(in ExportHmacParameters parameters)",
-          "returnType": "string"
+          "signature": "SignAsync(ExportHmacParameters parameters, CancellationToken cancellationToken = default)",
+          "returnType": "Task<string>"
         },
         {
-          "name": "Verify",
+          "name": "VerifyAsync",
           "kind": "method",
-          "signature": "Verify(in ExportHmacParameters parameters, string tag)",
-          "returnType": "bool"
+          "signature": "VerifyAsync(ExportHmacParameters parameters, string tag, CancellationToken cancellationToken = default)",
+          "returnType": "Task<bool>"
         }
       ]
     },
@@ -46832,7 +46832,7 @@
       "kind": "record",
       "project": "Granit.Privacy",
       "file": "src/Granit.Privacy/DataExport/Security/IExportHmacSigner.cs",
-      "line": 59,
+      "line": 60,
       "members": []
     },
     {
@@ -48930,7 +48930,7 @@
       "kind": "class",
       "project": "Granit.Privacy.Vault",
       "file": "src/Granit.Privacy.Vault/VaultExportHmacSigner.cs",
-      "line": 32,
+      "line": 27,
       "members": []
     },
     {

--- a/src/Granit.Privacy.BlobStorage/DataExport/PrivacyExportAssemblyService.cs
+++ b/src/Granit.Privacy.BlobStorage/DataExport/PrivacyExportAssemblyService.cs
@@ -44,7 +44,7 @@ namespace Granit.Privacy.BlobStorage.DataExport;
 /// </para>
 /// <para>
 /// <b>HMAC verification.</b> Each fragment is verified via
-/// <see cref="IExportHmacSigner.Verify"/> with parameters reconstructed from the
+/// <see cref="IExportHmacSigner.VerifyAsync"/> with parameters reconstructed from the
 /// <see cref="ReceivedFragment"/> values. Empty-sentinel fragments
 /// (<see cref="PrivacyFragmentUploader.EmptyFragmentKind"/>) carry no HMAC and
 /// are recorded in the manifest's <c>emptyProviders</c> list without a blob
@@ -361,18 +361,19 @@ internal sealed partial class PrivacyExportAssemblyService(
             .ConfigureAwait(false);
     }
 
-    private bool VerifyFragmentTag(
+    private Task<bool> VerifyFragmentTagAsync(
         ExportCompletedEto completion,
         ReceivedFragment fragment,
         Guid blobId,
-        DateTimeOffset expiry)
+        DateTimeOffset expiry,
+        CancellationToken cancellationToken)
     {
         if (string.IsNullOrEmpty(fragment.IntegrityTag))
         {
-            return false;
+            return Task.FromResult(false);
         }
 
-        return hmacSigner.Verify(
+        return hmacSigner.VerifyAsync(
             new ExportHmacParameters(
                 RequestId: completion.RequestId,
                 SubjectUserId: completion.UserId,
@@ -382,7 +383,8 @@ internal sealed partial class PrivacyExportAssemblyService(
                 SourceBlobId: blobId,
                 EntryPath: fragment.EntryPath ?? string.Empty,
                 ExpiresAt: expiry),
-            fragment.IntegrityTag);
+            fragment.IntegrityTag,
+            cancellationToken);
     }
 
     private async Task<BlobReference> UploadManifestAsync(
@@ -422,7 +424,7 @@ internal sealed partial class PrivacyExportAssemblyService(
         };
 
         byte[] payloadBytes = JsonSerializer.SerializeToUtf8Bytes(manifestPayload, ManifestJsonOptions);
-        string integrityTag = contentSigner.SignBytes(payloadBytes);
+        string integrityTag = await contentSigner.SignBytesAsync(payloadBytes, cancellationToken).ConfigureAwait(false);
 
         byte[] signedEnvelope = BuildSignedEnvelope(payloadBytes, integrityTag);
 
@@ -525,7 +527,7 @@ internal sealed partial class PrivacyExportAssemblyService(
             return shardStartTimestamp;
         }
 
-        if (!VerifyFragmentTag(completion, fragment, blobId, ctx.HmacExpiryWindow))
+        if (!await VerifyFragmentTagAsync(completion, fragment, blobId, ctx.HmacExpiryWindow, cancellationToken).ConfigureAwait(false))
         {
             LogIntegrityTagRejected(logger, fragment.ProviderName, completion.RequestId);
             throw new InvalidOperationException(

--- a/src/Granit.Privacy.BlobStorage/StagedFragmentBuilder.cs
+++ b/src/Granit.Privacy.BlobStorage/StagedFragmentBuilder.cs
@@ -84,7 +84,7 @@ public sealed partial class StagedFragmentBuilder(
 
         DateTimeOffset expiresAt = timeProvider.GetUtcNow()
             + TimeSpan.FromMinutes(options.Value.ExportTimeoutMinutes * 4);
-        string integrityTag = hmacSigner.Sign(new ExportHmacParameters(
+        string integrityTag = await hmacSigner.SignAsync(new ExportHmacParameters(
             RequestId: context.RequestId,
             SubjectUserId: context.SubjectUserId,
             ProviderName: providerName,
@@ -92,7 +92,7 @@ public sealed partial class StagedFragmentBuilder(
             SourceContainer: PrivacyExportContainerNames.FragmentContainer,
             SourceBlobId: ticket.BlobId,
             EntryPath: safeEntryPath,
-            ExpiresAt: expiresAt));
+            ExpiresAt: expiresAt), cancellationToken).ConfigureAwait(false);
 
         var stagedBlob = BlobReference.Create(ticket.BlobId.ToString());
 

--- a/src/Granit.Privacy.BlobStorage/Streaming/BlobBackedExportSource.cs
+++ b/src/Granit.Privacy.BlobStorage/Streaming/BlobBackedExportSource.cs
@@ -51,7 +51,7 @@ public sealed class BlobBackedExportSource(
             string safeEntryPath = EntryPathSanitizer.Sanitize(item.EntryPath);
             Guid sourceBlobId = ParseBlobId(item.SourceBlob.Value);
 
-            string integrityTag = hmacSigner.Sign(new ExportHmacParameters(
+            string integrityTag = await hmacSigner.SignAsync(new ExportHmacParameters(
                 RequestId: context.RequestId,
                 SubjectUserId: context.SubjectUserId,
                 ProviderName: providerName,
@@ -59,7 +59,7 @@ public sealed class BlobBackedExportSource(
                 SourceContainer: item.SourceContainer,
                 SourceBlobId: sourceBlobId,
                 EntryPath: safeEntryPath,
-                ExpiresAt: expiresAt));
+                ExpiresAt: expiresAt), cancellationToken).ConfigureAwait(false);
 
             yield return new PassThroughExportFragment
             {

--- a/src/Granit.Privacy.Vault/VaultExportHmacSigner.cs
+++ b/src/Granit.Privacy.Vault/VaultExportHmacSigner.cs
@@ -13,14 +13,9 @@ namespace Granit.Privacy.Vault;
 /// </summary>
 /// <remarks>
 /// <para>
-/// <b>Why Sync interfaces over an async primitive:</b> the privacy export saga
-/// signs every fragment inside a Wolverine handler that already runs on the
-/// async path — but the <see cref="IExportHmacSigner"/> contract is synchronous
-/// because the assembler verifies in tight loops where the surrounding I/O is
-/// blocking (FileStream reads). The sync→async bridge uses
-/// <c>GetAwaiter().GetResult()</c>; the call is rare (one per fragment, on the
-/// order of seconds between calls) and avoids cascading the interface change
-/// through every existing caller.
+/// The signer contracts are async-first, so the underlying
+/// <see cref="ITransitMacService"/> calls are awaited directly — no
+/// sync-over-async bridge.
 /// </para>
 /// <para>
 /// <b>Tag format:</b> <c>gpv1:{providerOpaqueTag}</c>. The <c>gpv1</c> prefix lets
@@ -35,32 +30,34 @@ public sealed partial class VaultExportHmacSigner : IExportHmacSigner, IExportCo
 
     private readonly ITransitMacService _macService;
     private readonly VaultExportSignerOptions _options;
+    private readonly TimeProvider _timeProvider;
 
     /// <summary>Initializes a new instance.</summary>
     public VaultExportHmacSigner(
         ITransitMacService macService,
-        IOptions<VaultExportSignerOptions> options)
+        IOptions<VaultExportSignerOptions> options,
+        TimeProvider? timeProvider = null)
     {
         ArgumentNullException.ThrowIfNull(macService);
         ArgumentNullException.ThrowIfNull(options);
 
         _macService = macService;
         _options = options.Value;
+        _timeProvider = timeProvider ?? TimeProvider.System;
     }
 
     /// <inheritdoc />
-    public string Sign(in ExportHmacParameters parameters)
+    public async Task<string> SignAsync(ExportHmacParameters parameters, CancellationToken cancellationToken = default)
     {
         byte[] canonical = ExportHmacCanonicalizer.Canonicalize(parameters);
-        TransitMacResult result = _macService
-            .MacAsync(_options.FragmentKeyName, canonical, CancellationToken.None)
-            .GetAwaiter()
-            .GetResult();
+        TransitMacResult result = await _macService
+            .MacAsync(_options.FragmentKeyName, canonical, cancellationToken)
+            .ConfigureAwait(false);
         return $"{TagPrefix}{result.Mac}";
     }
 
     /// <inheritdoc />
-    public bool Verify(in ExportHmacParameters parameters, string tag)
+    public async Task<bool> VerifyAsync(ExportHmacParameters parameters, string tag, CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrEmpty(tag);
 
@@ -69,33 +66,29 @@ public sealed partial class VaultExportHmacSigner : IExportHmacSigner, IExportCo
             return false;
         }
 
-        if (parameters.ExpiresAt <= TimeProvider.System.GetUtcNow())
+        if (parameters.ExpiresAt <= _timeProvider.GetUtcNow())
         {
             return false;
         }
 
         string providerTag = tag[TagPrefix.Length..];
         byte[] canonical = ExportHmacCanonicalizer.Canonicalize(parameters);
-        return _macService
-            .VerifyAsync(_options.FragmentKeyName, canonical, providerTag, CancellationToken.None)
-            .GetAwaiter()
-            .GetResult();
+        return await _macService
+            .VerifyAsync(_options.FragmentKeyName, canonical, providerTag, cancellationToken)
+            .ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public string SignBytes(ReadOnlySpan<byte> payload)
+    public async Task<string> SignBytesAsync(ReadOnlyMemory<byte> payload, CancellationToken cancellationToken = default)
     {
-        // Copy span to heap — ITransitMacService is async and span is stack-only.
-        byte[] heap = payload.ToArray();
-        TransitMacResult result = _macService
-            .MacAsync(_options.ContentKeyName, heap, CancellationToken.None)
-            .GetAwaiter()
-            .GetResult();
+        TransitMacResult result = await _macService
+            .MacAsync(_options.ContentKeyName, payload.ToArray(), cancellationToken)
+            .ConfigureAwait(false);
         return $"{TagPrefix}{result.Mac}";
     }
 
     /// <inheritdoc />
-    public bool VerifyBytes(ReadOnlySpan<byte> payload, string tag)
+    public async Task<bool> VerifyBytesAsync(ReadOnlyMemory<byte> payload, string tag, CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrEmpty(tag);
 
@@ -105,10 +98,8 @@ public sealed partial class VaultExportHmacSigner : IExportHmacSigner, IExportCo
         }
 
         string providerTag = tag[TagPrefix.Length..];
-        byte[] heap = payload.ToArray();
-        return _macService
-            .VerifyAsync(_options.ContentKeyName, heap, providerTag, CancellationToken.None)
-            .GetAwaiter()
-            .GetResult();
+        return await _macService
+            .VerifyAsync(_options.ContentKeyName, payload.ToArray(), providerTag, cancellationToken)
+            .ConfigureAwait(false);
     }
 }

--- a/src/Granit.Privacy/DataExport/Fragments/ExportFragment.cs
+++ b/src/Granit.Privacy/DataExport/Fragments/ExportFragment.cs
@@ -44,7 +44,7 @@ public abstract record ExportFragment
     /// <summary>
     /// HMAC capability tag binding the fragment to its request, subject, source blob, and
     /// entry path. Format: <c>v{N}:Base64Url(HMAC-SHA256(K_export, ...))</c>.
-    /// Verified by <see cref="Security.IExportHmacSigner.Verify"/> before the assembler
+    /// Verified by <see cref="Security.IExportHmacSigner.VerifyAsync"/> before the assembler
     /// opens the source stream.
     /// </summary>
     public required string IntegrityTag { get; init; }

--- a/src/Granit.Privacy/DataExport/IPrivacyDataProvider.cs
+++ b/src/Granit.Privacy/DataExport/IPrivacyDataProvider.cs
@@ -74,7 +74,7 @@ public interface IPrivacyDataProvider
     /// </summary>
     /// <remarks>
     /// Fragments MUST be signed with
-    /// <see cref="Security.IExportHmacSigner.Sign"/>; the archive assembler rejects unsigned
+    /// <see cref="Security.IExportHmacSigner.SignAsync"/>; the archive assembler rejects unsigned
     /// or tampered fragments and routes them to the DLQ (closes VULN-001 / VULN-102).
     /// Yielding an empty enumerable is legal and translates to <c>EmptyProviders</c> in the
     /// manifest.

--- a/src/Granit.Privacy/DataExport/Security/EphemeralExportHmacSigner.cs
+++ b/src/Granit.Privacy/DataExport/Security/EphemeralExportHmacSigner.cs
@@ -25,46 +25,49 @@ public sealed partial class EphemeralExportHmacSigner : IExportHmacSigner, IExpo
     private readonly ILogger<EphemeralExportHmacSigner> _logger;
     private bool _disposed;
 
+    private readonly TimeProvider _timeProvider;
+
     /// <summary>Creates a signer with a fresh random key.</summary>
-    public EphemeralExportHmacSigner(ILogger<EphemeralExportHmacSigner> logger)
+    public EphemeralExportHmacSigner(ILogger<EphemeralExportHmacSigner> logger, TimeProvider? timeProvider = null)
     {
         ArgumentNullException.ThrowIfNull(logger);
         _logger = logger;
+        _timeProvider = timeProvider ?? TimeProvider.System;
         _key = RandomNumberGenerator.GetBytes(KeySizeBytes);
         LogEphemeralKeyGenerated(_logger, KeySizeBytes * 8);
     }
 
     /// <inheritdoc />
-    public string Sign(in ExportHmacParameters parameters)
+    public Task<string> SignAsync(ExportHmacParameters parameters, CancellationToken cancellationToken = default)
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
 
         byte[] canonical = Canonicalize(parameters);
         byte[] mac = HMACSHA256.HashData(_key, canonical);
-        return $"{Version}:{Base64UrlEncode(mac)}";
+        return Task.FromResult($"{Version}:{Base64UrlEncode(mac)}");
     }
 
     /// <inheritdoc />
-    public bool Verify(in ExportHmacParameters parameters, string tag)
+    public Task<bool> VerifyAsync(ExportHmacParameters parameters, string tag, CancellationToken cancellationToken = default)
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
         ArgumentException.ThrowIfNullOrEmpty(tag);
 
-        if (parameters.ExpiresAt <= TimeProvider.System.GetUtcNow())
+        if (parameters.ExpiresAt <= _timeProvider.GetUtcNow())
         {
-            return false;
+            return Task.FromResult(false);
         }
 
         int colonIndex = tag.IndexOf(':', StringComparison.Ordinal);
         if (colonIndex <= 0)
         {
-            return false;
+            return Task.FromResult(false);
         }
 
         // Only the single key version is known to the ephemeral signer.
         if (!tag.AsSpan(0, colonIndex).SequenceEqual(Version))
         {
-            return false;
+            return Task.FromResult(false);
         }
 
         string presented = tag[(colonIndex + 1)..];
@@ -77,22 +80,22 @@ public sealed partial class EphemeralExportHmacSigner : IExportHmacSigner, IExpo
         }
         catch (FormatException)
         {
-            return false;
+            return Task.FromResult(false);
         }
 
-        return CryptographicOperations.FixedTimeEquals(expected, decoded);
+        return Task.FromResult(CryptographicOperations.FixedTimeEquals(expected, decoded));
     }
 
     /// <inheritdoc />
-    public string SignBytes(ReadOnlySpan<byte> payload)
+    public Task<string> SignBytesAsync(ReadOnlyMemory<byte> payload, CancellationToken cancellationToken = default)
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
-        byte[] mac = HMACSHA256.HashData(_key, payload);
-        return $"{Version}:{Base64UrlEncode(mac)}";
+        byte[] mac = HMACSHA256.HashData(_key, payload.Span);
+        return Task.FromResult($"{Version}:{Base64UrlEncode(mac)}");
     }
 
     /// <inheritdoc />
-    public bool VerifyBytes(ReadOnlySpan<byte> payload, string tag)
+    public Task<bool> VerifyBytesAsync(ReadOnlyMemory<byte> payload, string tag, CancellationToken cancellationToken = default)
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
         ArgumentException.ThrowIfNullOrEmpty(tag);
@@ -100,16 +103,16 @@ public sealed partial class EphemeralExportHmacSigner : IExportHmacSigner, IExpo
         int colonIndex = tag.IndexOf(':', StringComparison.Ordinal);
         if (colonIndex <= 0)
         {
-            return false;
+            return Task.FromResult(false);
         }
 
         if (!tag.AsSpan(0, colonIndex).SequenceEqual(Version))
         {
-            return false;
+            return Task.FromResult(false);
         }
 
         string presented = tag[(colonIndex + 1)..];
-        byte[] expected = HMACSHA256.HashData(_key, payload);
+        byte[] expected = HMACSHA256.HashData(_key, payload.Span);
         byte[] decoded;
         try
         {
@@ -117,10 +120,10 @@ public sealed partial class EphemeralExportHmacSigner : IExportHmacSigner, IExpo
         }
         catch (FormatException)
         {
-            return false;
+            return Task.FromResult(false);
         }
 
-        return CryptographicOperations.FixedTimeEquals(expected, decoded);
+        return Task.FromResult(CryptographicOperations.FixedTimeEquals(expected, decoded));
     }
 
     /// <inheritdoc />
@@ -135,7 +138,7 @@ public sealed partial class EphemeralExportHmacSigner : IExportHmacSigner, IExpo
         _disposed = true;
     }
 
-    private static byte[] Canonicalize(in ExportHmacParameters p) => ExportHmacCanonicalizer.Canonicalize(p);
+    private static byte[] Canonicalize(ExportHmacParameters p) => ExportHmacCanonicalizer.Canonicalize(p);
 
     private static string Base64UrlEncode(ReadOnlySpan<byte> bytes) =>
         Convert.ToBase64String(bytes)

--- a/src/Granit.Privacy/DataExport/Security/IExportContentSigner.cs
+++ b/src/Granit.Privacy/DataExport/Security/IExportContentSigner.cs
@@ -22,11 +22,11 @@ namespace Granit.Privacy.DataExport.Security;
 public interface IExportContentSigner
 {
     /// <summary>Produces an integrity tag over the canonical byte payload.</summary>
-    string SignBytes(ReadOnlySpan<byte> payload);
+    Task<string> SignBytesAsync(ReadOnlyMemory<byte> payload, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Returns <see langword="true"/> when <paramref name="tag"/> verifies against
     /// <paramref name="payload"/> under any key version known to the signer.
     /// </summary>
-    bool VerifyBytes(ReadOnlySpan<byte> payload, string tag);
+    Task<bool> VerifyBytesAsync(ReadOnlyMemory<byte> payload, string tag, CancellationToken cancellationToken = default);
 }

--- a/src/Granit.Privacy/DataExport/Security/IExportHmacSigner.cs
+++ b/src/Granit.Privacy/DataExport/Security/IExportHmacSigner.cs
@@ -30,15 +30,16 @@ public interface IExportHmacSigner
     /// </summary>
     /// <param name="parameters">Identity inputs (deterministic order — see
     /// <see cref="ExportHmacParameters"/>).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The opaque versioned tag to store in
     /// <see cref="ExportFragment.IntegrityTag"/>.</returns>
-    string Sign(in ExportHmacParameters parameters);
+    Task<string> SignAsync(ExportHmacParameters parameters, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Returns <see langword="true"/> when <paramref name="tag"/> verifies under any key
     /// version known to the signer (supports rolling rotation).
     /// </summary>
-    bool Verify(in ExportHmacParameters parameters, string tag);
+    Task<bool> VerifyAsync(ExportHmacParameters parameters, string tag, CancellationToken cancellationToken = default);
 }
 
 /// <summary>

--- a/tests/Granit.Privacy.BlobStorage.Tests/DataExport/PrivacyExportAssemblyServiceTests.cs
+++ b/tests/Granit.Privacy.BlobStorage.Tests/DataExport/PrivacyExportAssemblyServiceTests.cs
@@ -77,8 +77,8 @@ public sealed class PrivacyExportAssemblyServiceTests : IDisposable
         ExportCompletedEto evt = BuildEvent(
             requestId, userId,
             [
-                BuildSignedFragment(requestId, userId, "identity", blobA, "identity.json", "application/json"),
-                BuildSignedFragment(requestId, userId, "auditing", blobB, "audit.json", "application/json"),
+                await BuildSignedFragmentAsync(requestId, userId, "identity", blobA, "identity.json", "application/json"),
+                await BuildSignedFragmentAsync(requestId, userId, "auditing", blobB, "audit.json", "application/json"),
             ]);
 
         await CreateSut().AssembleAsync(evt, TestContext.Current.CancellationToken);
@@ -114,7 +114,7 @@ public sealed class PrivacyExportAssemblyServiceTests : IDisposable
 
         ExportCompletedEto evt = BuildEvent(
             requestId, userId,
-            [BuildSignedFragment(requestId, userId, "identity", blobA, "identity.json", "application/json")]);
+            [await BuildSignedFragmentAsync(requestId, userId, "identity", blobA, "identity.json", "application/json")]);
 
         await CreateSut().AssembleAsync(evt, TestContext.Current.CancellationToken);
 
@@ -140,7 +140,7 @@ public sealed class PrivacyExportAssemblyServiceTests : IDisposable
 
         // Verify the HMAC by feeding the payload's UTF-8 raw text back through the signer.
         byte[] payloadBytes = Encoding.UTF8.GetBytes(payloadElement.GetRawText());
-        _hmacSigner.VerifyBytes(payloadBytes, tag).ShouldBeTrue("the assembly service must sign over the payload's raw bytes");
+        (await _hmacSigner.VerifyBytesAsync(payloadBytes, tag, TestContext.Current.CancellationToken)).ShouldBeTrue("the assembly service must sign over the payload's raw bytes");
 
         // schemaVersion stamp is mandatory — verifiers branch on it.
         payloadElement.GetProperty("schemaVersion").GetInt32().ShouldBe(1);
@@ -167,7 +167,7 @@ public sealed class PrivacyExportAssemblyServiceTests : IDisposable
 
         ExportCompletedEto evt = BuildEvent(
             requestId, userId,
-            [BuildSignedFragment(requestId, userId, "identity", blobA, "identity.json", "application/json")]);
+            [await BuildSignedFragmentAsync(requestId, userId, "identity", blobA, "identity.json", "application/json")]);
 
         await CreateSut().AssembleAsync(evt, TestContext.Current.CancellationToken);
 
@@ -243,7 +243,7 @@ public sealed class PrivacyExportAssemblyServiceTests : IDisposable
             .Returns((BlobDescriptor?)null);
         SetupManifestUpload();
 
-        ReceivedFragment fragment = BuildSignedFragment(requestId, userId, "identity", blobA, "identity.json", "application/json");
+        ReceivedFragment fragment = await BuildSignedFragmentAsync(requestId, userId, "identity", blobA, "identity.json", "application/json");
         ExportCompletedEto evt = BuildEvent(requestId, userId, [fragment]);
 
         PrivacyExportAssemblyException ex = await Should.ThrowAsync<PrivacyExportAssemblyException>(() =>
@@ -265,10 +265,10 @@ public sealed class PrivacyExportAssemblyServiceTests : IDisposable
         // Sign with WRONG provider name → verify will reject when the assembler
         // reconstructs parameters from fragment.ProviderName = "identity".
         DateTimeOffset expiry = _timeProvider.GetUtcNow() + TimeSpan.FromMinutes(20);
-        string forgedTag = _hmacSigner.Sign(new ExportHmacParameters(
+        string forgedTag = await _hmacSigner.SignAsync(new ExportHmacParameters(
             requestId, userId, ProviderName: "wrong-provider", FragmentKind: "staged",
             SourceContainer: PrivacyExportContainerNames.FragmentContainer,
-            SourceBlobId: blobA, EntryPath: "identity.json", ExpiresAt: expiry));
+            SourceBlobId: blobA, EntryPath: "identity.json", ExpiresAt: expiry), TestContext.Current.CancellationToken);
 
         ReceivedFragment fragment = new(
             ProviderName: "identity",
@@ -311,7 +311,7 @@ public sealed class PrivacyExportAssemblyServiceTests : IDisposable
         ExportCompletedEto evt = BuildEvent(
             requestId, userId,
             [
-                BuildSignedFragment(requestId, userId, "identity", blobA, "identity.json", "application/json"),
+                await BuildSignedFragmentAsync(requestId, userId, "identity", blobA, "identity.json", "application/json"),
                 emptyFragment,
             ]);
 
@@ -354,9 +354,9 @@ public sealed class PrivacyExportAssemblyServiceTests : IDisposable
         ExportCompletedEto evt = BuildEvent(
             requestId, userId,
             [
-                BuildSignedFragment(requestId, userId, "p0", blobs[0], "p0.bin", "application/octet-stream"),
-                BuildSignedFragment(requestId, userId, "p1", blobs[1], "p1.bin", "application/octet-stream"),
-                BuildSignedFragment(requestId, userId, "p2", blobs[2], "p2.bin", "application/octet-stream"),
+                await BuildSignedFragmentAsync(requestId, userId, "p0", blobs[0], "p0.bin", "application/octet-stream"),
+                await BuildSignedFragmentAsync(requestId, userId, "p1", blobs[1], "p1.bin", "application/octet-stream"),
+                await BuildSignedFragmentAsync(requestId, userId, "p2", blobs[2], "p2.bin", "application/octet-stream"),
             ]);
 
         GranitPrivacyOptions opts = new() { ExportShardMaxSizeMb = 1 };
@@ -390,9 +390,9 @@ public sealed class PrivacyExportAssemblyServiceTests : IDisposable
         ExportCompletedEto evt = BuildEvent(
             requestId, userId,
             [
-                BuildSignedFragment(requestId, userId, "p0", blobs[0], "p0.bin", "application/octet-stream"),
-                BuildSignedFragment(requestId, userId, "p1", blobs[1], "p1.bin", "application/octet-stream"),
-                BuildSignedFragment(requestId, userId, "p2", blobs[2], "p2.bin", "application/octet-stream"),
+                await BuildSignedFragmentAsync(requestId, userId, "p0", blobs[0], "p0.bin", "application/octet-stream"),
+                await BuildSignedFragmentAsync(requestId, userId, "p1", blobs[1], "p1.bin", "application/octet-stream"),
+                await BuildSignedFragmentAsync(requestId, userId, "p2", blobs[2], "p2.bin", "application/octet-stream"),
             ]);
 
         GranitPrivacyOptions opts = new() { ExportShardMaxSizeMb = 1 };
@@ -449,9 +449,9 @@ public sealed class PrivacyExportAssemblyServiceTests : IDisposable
         ExportCompletedEto evt = BuildEvent(
             requestId, userId,
             [
-                BuildSignedFragment(requestId, userId, "p0", blobs[0], "p0.json", "application/json"),
-                BuildSignedFragment(requestId, userId, "p1", blobs[1], "p1.json", "application/json"),
-                BuildSignedFragment(requestId, userId, "p2", blobs[2], "p2.json", "application/json"),
+                await BuildSignedFragmentAsync(requestId, userId, "p0", blobs[0], "p0.json", "application/json"),
+                await BuildSignedFragmentAsync(requestId, userId, "p1", blobs[1], "p1.json", "application/json"),
+                await BuildSignedFragmentAsync(requestId, userId, "p2", blobs[2], "p2.json", "application/json"),
             ]);
 
         await CreateSut().AssembleAsync(evt, TestContext.Current.CancellationToken);
@@ -534,13 +534,13 @@ public sealed class PrivacyExportAssemblyServiceTests : IDisposable
         return manifestBlobId;
     }
 
-    private ReceivedFragment BuildSignedFragment(
+    private async Task<ReceivedFragment> BuildSignedFragmentAsync(
         Guid requestId, Guid userId, string providerName, Guid blobId, string entryPath, string contentType)
     {
         DateTimeOffset expiry = _timeProvider.GetUtcNow() + TimeSpan.FromMinutes(20);
-        string tag = _hmacSigner.Sign(new ExportHmacParameters(
+        string tag = await _hmacSigner.SignAsync(new ExportHmacParameters(
             requestId, userId, providerName, "staged",
-            PrivacyExportContainerNames.FragmentContainer, blobId, entryPath, expiry));
+            PrivacyExportContainerNames.FragmentContainer, blobId, entryPath, expiry), TestContext.Current.CancellationToken);
 
         return new ReceivedFragment(
             ProviderName: providerName,

--- a/tests/Granit.Privacy.BlobStorage.Tests/Streaming/BlobBackedExportSourceTests.cs
+++ b/tests/Granit.Privacy.BlobStorage.Tests/Streaming/BlobBackedExportSourceTests.cs
@@ -75,7 +75,7 @@ public sealed class BlobBackedExportSourceTests
         DateTimeOffset expectedExpiry =
             clock.GetUtcNow() + TimeSpan.FromMinutes(new GranitPrivacyOptions().ExportTimeoutMinutes * 4);
 
-        signer.Verify(
+        (await signer.VerifyAsync(
             new ExportHmacParameters(
                 Context.RequestId,
                 Context.SubjectUserId,
@@ -85,7 +85,8 @@ public sealed class BlobBackedExportSourceTests
                 SourceBlobId: Guid.Parse(blob.Value),
                 EntryPath: "Documents/x.pdf",
                 ExpiresAt: expectedExpiry),
-            fragment.IntegrityTag).ShouldBeTrue();
+            fragment.IntegrityTag,
+            TestContext.Current.CancellationToken)).ShouldBeTrue();
     }
 
     [Fact]

--- a/tests/Granit.Privacy.Tests/DataExport/Security/EphemeralExportContentSignerTests.cs
+++ b/tests/Granit.Privacy.Tests/DataExport/Security/EphemeralExportContentSignerTests.cs
@@ -12,51 +12,51 @@ public sealed class EphemeralExportContentSignerTests
         new(NullLogger<EphemeralExportHmacSigner>.Instance);
 
     [Fact]
-    public void SignBytes_then_VerifyBytes_returns_true()
+    public async Task SignBytes_then_VerifyBytes_returns_true()
     {
         using EphemeralExportHmacSigner signer = CreateSigner();
         byte[] payload = Encoding.UTF8.GetBytes("""{"schemaVersion":1,"shards":[]}""");
 
-        string tag = signer.SignBytes(payload);
-        signer.VerifyBytes(payload, tag).ShouldBeTrue();
+        string tag = await signer.SignBytesAsync(payload, TestContext.Current.CancellationToken);
+        (await signer.VerifyBytesAsync(payload, tag, TestContext.Current.CancellationToken)).ShouldBeTrue();
     }
 
     [Fact]
-    public void VerifyBytes_returns_false_when_payload_tampered_with()
+    public async Task VerifyBytes_returns_false_when_payload_tampered_with()
     {
         using EphemeralExportHmacSigner signer = CreateSigner();
         byte[] original = Encoding.UTF8.GetBytes("""{"shardCount":3}""");
-        string tag = signer.SignBytes(original);
+        string tag = await signer.SignBytesAsync(original, TestContext.Current.CancellationToken);
 
         byte[] tampered = Encoding.UTF8.GetBytes("""{"shardCount":4}""");
-        signer.VerifyBytes(tampered, tag).ShouldBeFalse();
+        (await signer.VerifyBytesAsync(tampered, tag, TestContext.Current.CancellationToken)).ShouldBeFalse();
     }
 
     [Fact]
-    public void VerifyBytes_returns_false_for_unknown_version()
+    public async Task VerifyBytes_returns_false_for_unknown_version()
     {
         using EphemeralExportHmacSigner signer = CreateSigner();
         byte[] payload = Encoding.UTF8.GetBytes("anything");
-        string realTag = signer.SignBytes(payload);
+        string realTag = await signer.SignBytesAsync(payload, TestContext.Current.CancellationToken);
 
         // Swap version prefix to v99 — even if the MAC happens to be valid for v1,
         // the version mismatch must reject.
         string forged = "v99" + realTag[realTag.IndexOf(':')..];
-        signer.VerifyBytes(payload, forged).ShouldBeFalse();
+        (await signer.VerifyBytesAsync(payload, forged, TestContext.Current.CancellationToken)).ShouldBeFalse();
     }
 
     [Fact]
-    public void VerifyBytes_returns_false_on_malformed_tag()
+    public async Task VerifyBytes_returns_false_on_malformed_tag()
     {
         using EphemeralExportHmacSigner signer = CreateSigner();
         byte[] payload = Encoding.UTF8.GetBytes("data");
 
-        signer.VerifyBytes(payload, "no-colon").ShouldBeFalse();
-        signer.VerifyBytes(payload, "v1:%%%bad-base64%%%").ShouldBeFalse();
+        (await signer.VerifyBytesAsync(payload, "no-colon", TestContext.Current.CancellationToken)).ShouldBeFalse();
+        (await signer.VerifyBytesAsync(payload, "v1:%%%bad-base64%%%", TestContext.Current.CancellationToken)).ShouldBeFalse();
     }
 
     [Fact]
-    public void FragmentTag_and_ContentTag_dont_cross_verify()
+    public async Task FragmentTag_and_ContentTag_dont_cross_verify()
     {
         // Even though both interfaces share the same key, a fragment-identity tag
         // must not validate against a content payload of the same bytes (the
@@ -73,10 +73,10 @@ public sealed class EphemeralExportContentSignerTests
             EntryPath: "identity-local.json",
             ExpiresAt: DateTimeOffset.UtcNow.AddMinutes(30));
 
-        string fragmentTag = signer.Sign(fragmentParams);
+        string fragmentTag = await signer.SignAsync(fragmentParams, TestContext.Current.CancellationToken);
         byte[] fragmentCanonicalBytes = Encoding.UTF8.GetBytes(fragmentParams.RequestId.ToString());
 
         // Fragment tag should NOT verify when treated as a content tag over arbitrary bytes.
-        signer.VerifyBytes(fragmentCanonicalBytes, fragmentTag).ShouldBeFalse();
+        (await signer.VerifyBytesAsync(fragmentCanonicalBytes, fragmentTag, TestContext.Current.CancellationToken)).ShouldBeFalse();
     }
 }

--- a/tests/Granit.Privacy.Tests/DataExport/Security/EphemeralExportHmacSignerTests.cs
+++ b/tests/Granit.Privacy.Tests/DataExport/Security/EphemeralExportHmacSignerTests.cs
@@ -34,35 +34,35 @@ public class EphemeralExportHmacSignerTests
     // ────────────────────────────────────────────────────────────────────────
 
     [Fact]
-    public void Sign_then_verify_returns_true()
+    public async Task Sign_then_verify_returns_true()
     {
         using EphemeralExportHmacSigner signer = CreateSigner();
         ExportHmacParameters p = SampleParameters();
 
-        string tag = signer.Sign(in p);
+        string tag = await signer.SignAsync(p, TestContext.Current.CancellationToken);
 
-        signer.Verify(in p, tag).ShouldBeTrue();
+        (await signer.VerifyAsync(p, tag, TestContext.Current.CancellationToken)).ShouldBeTrue();
     }
 
     [Fact]
-    public void Tag_starts_with_v1_prefix()
+    public async Task Tag_starts_with_v1_prefix()
     {
         using EphemeralExportHmacSigner signer = CreateSigner();
         ExportHmacParameters p = SampleParameters();
 
-        string tag = signer.Sign(in p);
+        string tag = await signer.SignAsync(p, TestContext.Current.CancellationToken);
 
         tag.ShouldStartWith("v1:");
     }
 
     [Fact]
-    public void Tag_is_deterministic_for_same_parameters_and_key()
+    public async Task Tag_is_deterministic_for_same_parameters_and_key()
     {
         using EphemeralExportHmacSigner signer = CreateSigner();
         ExportHmacParameters p = SampleParameters();
 
-        string first = signer.Sign(in p);
-        string second = signer.Sign(in p);
+        string first = await signer.SignAsync(p, TestContext.Current.CancellationToken);
+        string second = await signer.SignAsync(p, TestContext.Current.CancellationToken);
 
         first.ShouldBe(second);
     }
@@ -72,87 +72,87 @@ public class EphemeralExportHmacSignerTests
     // ────────────────────────────────────────────────────────────────────────
 
     [Fact]
-    public void Verify_rejects_when_request_id_differs()
+    public async Task Verify_rejects_when_request_id_differs()
     {
         using EphemeralExportHmacSigner signer = CreateSigner();
         ExportHmacParameters signed = SampleParameters();
-        string tag = signer.Sign(in signed);
+        string tag = await signer.SignAsync(signed, TestContext.Current.CancellationToken);
 
         ExportHmacParameters tampered = signed with { RequestId = Guid.NewGuid() };
 
-        signer.Verify(in tampered, tag).ShouldBeFalse();
+        (await signer.VerifyAsync(tampered, tag, TestContext.Current.CancellationToken)).ShouldBeFalse();
     }
 
     [Fact]
-    public void Verify_rejects_when_subject_differs()
+    public async Task Verify_rejects_when_subject_differs()
     {
         using EphemeralExportHmacSigner signer = CreateSigner();
         ExportHmacParameters signed = SampleParameters();
-        string tag = signer.Sign(in signed);
+        string tag = await signer.SignAsync(signed, TestContext.Current.CancellationToken);
 
         ExportHmacParameters tampered = signed with { SubjectUserId = Guid.NewGuid() };
 
-        signer.Verify(in tampered, tag).ShouldBeFalse();
+        (await signer.VerifyAsync(tampered, tag, TestContext.Current.CancellationToken)).ShouldBeFalse();
     }
 
     [Fact]
-    public void Verify_rejects_when_source_blob_id_differs()
+    public async Task Verify_rejects_when_source_blob_id_differs()
     {
         using EphemeralExportHmacSigner signer = CreateSigner();
         ExportHmacParameters signed = SampleParameters();
-        string tag = signer.Sign(in signed);
+        string tag = await signer.SignAsync(signed, TestContext.Current.CancellationToken);
 
         ExportHmacParameters tampered = signed with { SourceBlobId = Guid.NewGuid() };
 
-        signer.Verify(in tampered, tag).ShouldBeFalse();
+        (await signer.VerifyAsync(tampered, tag, TestContext.Current.CancellationToken)).ShouldBeFalse();
     }
 
     [Fact]
-    public void Verify_rejects_when_entry_path_differs()
+    public async Task Verify_rejects_when_entry_path_differs()
     {
         using EphemeralExportHmacSigner signer = CreateSigner();
         ExportHmacParameters signed = SampleParameters(entryPath: "identity-local.json");
-        string tag = signer.Sign(in signed);
+        string tag = await signer.SignAsync(signed, TestContext.Current.CancellationToken);
 
         ExportHmacParameters tampered = signed with { EntryPath = "auditing.json" };
 
-        signer.Verify(in tampered, tag).ShouldBeFalse();
+        (await signer.VerifyAsync(tampered, tag, TestContext.Current.CancellationToken)).ShouldBeFalse();
     }
 
     [Fact]
-    public void Verify_rejects_when_fragment_kind_differs()
+    public async Task Verify_rejects_when_fragment_kind_differs()
     {
         using EphemeralExportHmacSigner signer = CreateSigner();
         ExportHmacParameters signed = SampleParameters(fragmentKind: "staged");
-        string tag = signer.Sign(in signed);
+        string tag = await signer.SignAsync(signed, TestContext.Current.CancellationToken);
 
         ExportHmacParameters tampered = signed with { FragmentKind = "passthrough" };
 
-        signer.Verify(in tampered, tag).ShouldBeFalse();
+        (await signer.VerifyAsync(tampered, tag, TestContext.Current.CancellationToken)).ShouldBeFalse();
     }
 
     [Fact]
-    public void Verify_rejects_when_source_container_differs()
+    public async Task Verify_rejects_when_source_container_differs()
     {
         using EphemeralExportHmacSigner signer = CreateSigner();
         ExportHmacParameters signed = SampleParameters(sourceContainer: "gdpr-exports");
-        string tag = signer.Sign(in signed);
+        string tag = await signer.SignAsync(signed, TestContext.Current.CancellationToken);
 
         ExportHmacParameters tampered = signed with { SourceContainer = "other-container" };
 
-        signer.Verify(in tampered, tag).ShouldBeFalse();
+        (await signer.VerifyAsync(tampered, tag, TestContext.Current.CancellationToken)).ShouldBeFalse();
     }
 
     [Fact]
-    public void Verify_rejects_when_provider_name_differs()
+    public async Task Verify_rejects_when_provider_name_differs()
     {
         using EphemeralExportHmacSigner signer = CreateSigner();
         ExportHmacParameters signed = SampleParameters(providerName: "identity-local");
-        string tag = signer.Sign(in signed);
+        string tag = await signer.SignAsync(signed, TestContext.Current.CancellationToken);
 
         ExportHmacParameters tampered = signed with { ProviderName = "auditing" };
 
-        signer.Verify(in tampered, tag).ShouldBeFalse();
+        (await signer.VerifyAsync(tampered, tag, TestContext.Current.CancellationToken)).ShouldBeFalse();
     }
 
     // ────────────────────────────────────────────────────────────────────────
@@ -160,11 +160,11 @@ public class EphemeralExportHmacSignerTests
     // ────────────────────────────────────────────────────────────────────────
 
     [Fact]
-    public void Verify_rejects_single_byte_flip_in_tag()
+    public async Task Verify_rejects_single_byte_flip_in_tag()
     {
         using EphemeralExportHmacSigner signer = CreateSigner();
         ExportHmacParameters p = SampleParameters();
-        string tag = signer.Sign(in p);
+        string tag = await signer.SignAsync(p, TestContext.Current.CancellationToken);
 
         // Flip the first char after "v1:" — base64url has a wide enough alphabet that
         // shifting by 1 stays valid syntactically but the HMAC bytes no longer match.
@@ -173,7 +173,7 @@ public class EphemeralExportHmacSignerTests
         char swapped = first == 'A' ? 'B' : 'A';
         string tampered = prefix + swapped + tag[(prefix.Length + 1)..];
 
-        signer.Verify(in p, tampered).ShouldBeFalse();
+        (await signer.VerifyAsync(p, tampered, TestContext.Current.CancellationToken)).ShouldBeFalse();
     }
 
     [Theory]
@@ -182,33 +182,33 @@ public class EphemeralExportHmacSignerTests
     [InlineData(":payload")]
     [InlineData("v1:")]
     [InlineData("v1:not_valid_base64!")]
-    public void Verify_rejects_malformed_tag(string malformed)
+    public async Task Verify_rejects_malformed_tag(string malformed)
     {
         using EphemeralExportHmacSigner signer = CreateSigner();
         ExportHmacParameters p = SampleParameters();
 
         if (string.IsNullOrEmpty(malformed))
         {
-            Should.Throw<ArgumentException>(() => signer.Verify(in p, malformed));
+            await Should.ThrowAsync<ArgumentException>(() => signer.VerifyAsync(p, malformed, TestContext.Current.CancellationToken));
         }
         else
         {
-            signer.Verify(in p, malformed).ShouldBeFalse();
+            (await signer.VerifyAsync(p, malformed, TestContext.Current.CancellationToken)).ShouldBeFalse();
         }
     }
 
     [Fact]
-    public void Verify_rejects_unknown_version_prefix()
+    public async Task Verify_rejects_unknown_version_prefix()
     {
         using EphemeralExportHmacSigner signer = CreateSigner();
         ExportHmacParameters p = SampleParameters();
-        string tag = signer.Sign(in p);
+        string tag = await signer.SignAsync(p, TestContext.Current.CancellationToken);
 
         // Strip the v1 prefix, replace with v2 — same payload bytes but wrong version.
         string payload = tag["v1:".Length..];
         string forged = "v2:" + payload;
 
-        signer.Verify(in p, forged).ShouldBeFalse();
+        (await signer.VerifyAsync(p, forged, TestContext.Current.CancellationToken)).ShouldBeFalse();
     }
 
     // ────────────────────────────────────────────────────────────────────────
@@ -216,23 +216,23 @@ public class EphemeralExportHmacSignerTests
     // ────────────────────────────────────────────────────────────────────────
 
     [Fact]
-    public void Verify_rejects_expired_tag()
+    public async Task Verify_rejects_expired_tag()
     {
         using EphemeralExportHmacSigner signer = CreateSigner();
         ExportHmacParameters expired = SampleParameters(expiresAt: DateTimeOffset.UtcNow.AddMinutes(-1));
-        string tag = signer.Sign(in expired);
+        string tag = await signer.SignAsync(expired, TestContext.Current.CancellationToken);
 
-        signer.Verify(in expired, tag).ShouldBeFalse();
+        (await signer.VerifyAsync(expired, tag, TestContext.Current.CancellationToken)).ShouldBeFalse();
     }
 
     [Fact]
-    public void Verify_accepts_tag_about_to_expire()
+    public async Task Verify_accepts_tag_about_to_expire()
     {
         using EphemeralExportHmacSigner signer = CreateSigner();
         ExportHmacParameters nearExpiry = SampleParameters(expiresAt: DateTimeOffset.UtcNow.AddSeconds(5));
-        string tag = signer.Sign(in nearExpiry);
+        string tag = await signer.SignAsync(nearExpiry, TestContext.Current.CancellationToken);
 
-        signer.Verify(in nearExpiry, tag).ShouldBeTrue();
+        (await signer.VerifyAsync(nearExpiry, tag, TestContext.Current.CancellationToken)).ShouldBeTrue();
     }
 
     // ────────────────────────────────────────────────────────────────────────
@@ -240,15 +240,15 @@ public class EphemeralExportHmacSignerTests
     // ────────────────────────────────────────────────────────────────────────
 
     [Fact]
-    public void Tags_signed_by_one_signer_do_not_verify_under_another()
+    public async Task Tags_signed_by_one_signer_do_not_verify_under_another()
     {
         using EphemeralExportHmacSigner alice = CreateSigner();
         using EphemeralExportHmacSigner bob = CreateSigner();
         ExportHmacParameters p = SampleParameters();
 
-        string aliceTag = alice.Sign(in p);
+        string aliceTag = await alice.SignAsync(p, TestContext.Current.CancellationToken);
 
-        bob.Verify(in p, aliceTag).ShouldBeFalse();
+        (await bob.VerifyAsync(p, aliceTag, TestContext.Current.CancellationToken)).ShouldBeFalse();
     }
 
     // ────────────────────────────────────────────────────────────────────────
@@ -256,22 +256,22 @@ public class EphemeralExportHmacSignerTests
     // ────────────────────────────────────────────────────────────────────────
 
     [Fact]
-    public void Sign_after_dispose_throws()
+    public async Task Sign_after_dispose_throws()
     {
         EphemeralExportHmacSigner signer = CreateSigner();
         signer.Dispose();
 
-        Should.Throw<ObjectDisposedException>(() => signer.Sign(SampleParameters()));
+        await Should.ThrowAsync<ObjectDisposedException>(() => signer.SignAsync(SampleParameters(), TestContext.Current.CancellationToken));
     }
 
     [Fact]
-    public void Verify_after_dispose_throws()
+    public async Task Verify_after_dispose_throws()
     {
         EphemeralExportHmacSigner signer = CreateSigner();
         ExportHmacParameters p = SampleParameters();
         signer.Dispose();
 
-        Should.Throw<ObjectDisposedException>(() => signer.Verify(in p, "v1:foo"));
+        await Should.ThrowAsync<ObjectDisposedException>(() => signer.VerifyAsync(p, "v1:foo", TestContext.Current.CancellationToken));
     }
 
     [Fact]

--- a/tests/Granit.Privacy.Vault.Tests/VaultExportHmacSignerTests.cs
+++ b/tests/Granit.Privacy.Vault.Tests/VaultExportHmacSignerTests.cs
@@ -36,7 +36,7 @@ public sealed class VaultExportHmacSignerTests
         ExpiresAt: expiry ?? DateTimeOffset.UtcNow.AddMinutes(30));
 
     [Fact]
-    public void Sign_WrapsProviderTag_WithFrameworkPrefix()
+    public async Task Sign_WrapsProviderTag_WithFrameworkPrefix()
     {
         _macService.MacAsync(
                 "fragment-key",
@@ -44,13 +44,13 @@ public sealed class VaultExportHmacSignerTests
                 Arg.Any<CancellationToken>())
             .Returns(new TransitMacResult("vault:v1:opaque", 1));
 
-        string tag = _sut.Sign(MakeParameters());
+        string tag = await _sut.SignAsync(MakeParameters(), TestContext.Current.CancellationToken);
 
         tag.ShouldBe("gpv1:vault:v1:opaque");
     }
 
     [Fact]
-    public void Verify_StripsPrefix_AndDelegatesToMacService()
+    public async Task Verify_StripsPrefix_AndDelegatesToMacService()
     {
         _macService.VerifyAsync(
                 "fragment-key",
@@ -59,25 +59,26 @@ public sealed class VaultExportHmacSignerTests
                 Arg.Any<CancellationToken>())
             .Returns(true);
 
-        _sut.Verify(MakeParameters(), "gpv1:vault:v1:opaque").ShouldBeTrue();
+        (await _sut.VerifyAsync(MakeParameters(), "gpv1:vault:v1:opaque", TestContext.Current.CancellationToken)).ShouldBeTrue();
     }
 
     [Fact]
-    public void Verify_ReturnsFalse_ForLegacyEphemeralTagFormat() =>
+    public async Task Verify_ReturnsFalse_ForLegacyEphemeralTagFormat() =>
         // Tag from EphemeralExportHmacSigner — vN:base64 with no gpv1 prefix.
-        _sut.Verify(MakeParameters(), "v1:abc123").ShouldBeFalse();
+        (await _sut.VerifyAsync(MakeParameters(), "v1:abc123", TestContext.Current.CancellationToken)).ShouldBeFalse();
 
     [Fact]
-    public void Verify_ReturnsFalse_WhenTagIsExpired()
+    public async Task Verify_ReturnsFalse_WhenTagIsExpired()
     {
-        _sut.Verify(
+        (await _sut.VerifyAsync(
                 MakeParameters(expiry: DateTimeOffset.UtcNow.AddMinutes(-1)),
-                "gpv1:vault:v1:opaque")
+                "gpv1:vault:v1:opaque",
+                TestContext.Current.CancellationToken))
             .ShouldBeFalse();
     }
 
     [Fact]
-    public void SignBytes_UsesContentKeyName()
+    public async Task SignBytes_UsesContentKeyName()
     {
         _macService.MacAsync(
                 "content-key",
@@ -85,12 +86,12 @@ public sealed class VaultExportHmacSignerTests
                 Arg.Any<CancellationToken>())
             .Returns(new TransitMacResult("provider:tag", 1));
 
-        string tag = _sut.SignBytes(Encoding.UTF8.GetBytes("manifest-bytes"));
+        string tag = await _sut.SignBytesAsync(Encoding.UTF8.GetBytes("manifest-bytes"), TestContext.Current.CancellationToken);
 
         tag.ShouldBe("gpv1:provider:tag");
     }
 
     [Fact]
-    public void VerifyBytes_RejectsLegacyTagFormat() =>
-        _sut.VerifyBytes(Encoding.UTF8.GetBytes("manifest-bytes"), "v1:abc").ShouldBeFalse();
+    public async Task VerifyBytes_RejectsLegacyTagFormat() =>
+        (await _sut.VerifyBytesAsync(Encoding.UTF8.GetBytes("manifest-bytes"), "v1:abc", TestContext.Current.CancellationToken)).ShouldBeFalse();
 }


### PR DESCRIPTION
## Context

From the `Granit.Privacy*` framework audit: `IExportHmacSigner` / `IExportContentSigner` were synchronous contracts, forcing `VaultExportHmacSigner` to bridge the async `ITransitMacService` with `GetAwaiter().GetResult()` on **every fragment sign/verify and manifest seal** — thread-blocking sync-over-async in the export hot path. The audit also flagged the ambient `TimeProvider.System` in the expiry check.

## Changes

- Contracts become `SignAsync` / `VerifyAsync` / `SignBytesAsync` / `VerifyBytesAsync` (CancellationToken last). `in ExportHmacParameters` and `ReadOnlySpan<byte>` become by-value / `ReadOnlyMemory<byte>` — ref-structs can't cross `await`.
- `VaultExportHmacSigner` awaits `ITransitMacService` directly; the sync-over-async bridge and its justifying remark are gone. `TimeProvider` is injected (optional, defaults to `System`) — same fix applied to `EphemeralExportHmacSigner`, whose expiry check also used the ambient clock.
- Callers updated (all already async): `StagedFragmentBuilder`, `BlobBackedExportSource`, `PrivacyExportAssemblyService` (`VerifyFragmentTag` → `VerifyFragmentTagAsync`; manifest sealing awaits `SignBytesAsync`). Cancellation now propagates into the MAC provider calls instead of `CancellationToken.None`.

## Compatibility

Tag formats (`v1:` / `gpv1:`) and verification semantics unchanged — only the call shape is async. Breaking for any custom `IExportHmacSigner`/`IExportContentSigner` implementation (framework ships the only two known).

## Verification

`Granit.Privacy.Tests` 216 · `Vault.Tests` 6 · `BlobStorage.Tests` 62 · Endpoints/BlobStorage.Endpoints build clean — all green; `dotnet format` clean on all six touched projects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)