### PR TITLE
docs(privacy): fix three XML doc drifts + reconcile CLAUDE.md jobs-handler rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,7 +97,7 @@ Wolverine discovers via `Assembly.ExportedTypes` and needs **public types with p
 ### Background Jobs
 
 - `sealed record *Job : IBackgroundJob` with `[RecurringJob("cron", "name")]`, in `Granit.{Module}.BackgroundJobs/Jobs/`. Job name `{module-kebab}-{action-kebab}` (globally unique).
-- Handler `{Action}Handler` — `public static partial class`. Same Wolverine visibility rules.
+- Handler `{Action}Handler` — `public sealed class` (non-static) with `public static` Handle methods, per the CRITICAL Wolverine visibility rules above (which take precedence; reference: `DeletionDeadlineEnforcerHandler`).
 - Dedicated `Granit.{Module}.BackgroundJobs` sub-project keeps base module free of the `Granit.BackgroundJobs` dep. Never create a `.Wolverine` package for jobs (handled by `Granit.BackgroundJobs.Wolverine`).
 - NEVER `*Command` suffix — commands are CQRS, jobs are scheduled work units.
 

--- a/src/Granit.Privacy.AI/Extensions/PrivacyAIHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Privacy.AI/Extensions/PrivacyAIHostApplicationBuilderExtensions.cs
@@ -19,7 +19,7 @@ public static class PrivacyAIHostApplicationBuilderExtensions
     /// from the <c>Privacy:AI</c> configuration section.
     /// </summary>
     /// <remarks>
-    /// Registers <see cref="IAIPiiDetector"/> backed by an LLM via <see cref="Granit.AI.IAIChatClientFactory"/>.
+    /// Registers <see cref="IAIPiiDetector"/> backed by an LLM via <see cref="Granit.AI.IStructuredCompletion"/> (ADR-064).
     /// Ensure the configured workspace points to a local model (Ollama) or a provider with
     /// a Data Processing Agreement to keep PII within the security perimeter.
     /// </remarks>

--- a/src/Granit.Privacy.EntityFrameworkCore/DataExport/Internal/EfExportAssemblyCheckpointStore.cs
+++ b/src/Granit.Privacy.EntityFrameworkCore/DataExport/Internal/EfExportAssemblyCheckpointStore.cs
@@ -25,10 +25,11 @@ namespace Granit.Privacy.EntityFrameworkCore.DataExport.Internal;
 /// <para>
 /// <b>Concurrency.</b> The row implements <see cref="Granit.Domain.IConcurrencyAware"/>;
 /// a duplicate dispatcher racing on the same tuple loses on
-/// <see cref="DbContext.SaveChangesAsync(CancellationToken)"/> with
-/// <see cref="DbUpdateConcurrencyException"/>. This store currently rethrows the
-/// EF exception — Wolverine's retry-with-cooldown surface wraps it for DLQ
-/// (lands in P6.3c.5).
+/// <see cref="DbContext.SaveChangesAsync(CancellationToken)"/> — with
+/// <see cref="DbUpdateConcurrencyException"/> on the update path, or with a plain
+/// <see cref="DbUpdateException"/> (primary-key violation) when both racers observed no
+/// existing row and try to insert. This store currently rethrows the EF exception —
+/// Wolverine's retry-with-cooldown surface wraps it for DLQ (lands in P6.3c.5).
 /// </para>
 /// </remarks>
 internal sealed class EfExportAssemblyCheckpointStore(

--- a/src/Granit.Privacy.EntityFrameworkCore/Internal/LegalDocumentPublicationService.cs
+++ b/src/Granit.Privacy.EntityFrameworkCore/Internal/LegalDocumentPublicationService.cs
@@ -12,7 +12,9 @@ namespace Granit.Privacy.EntityFrameworkCore.Internal;
 
 /// <summary>
 /// Publishes a legal document draft. Archives the previous published version in the same
-/// transaction and dispatches <see cref="LegalAgreementObsoleteEto"/> for re-consent flows.
+/// transaction (the aggregate's <c>Archive()</c> raises <see cref="LegalAgreementObsoleteEto"/>
+/// as a domain event for re-consent flows) and dispatches
+/// <see cref="LegalDocumentCacheInvalidatedEto"/> so all pods refresh their registry.
 /// </summary>
 internal sealed class LegalDocumentPublicationService(
     IDbContextFactory<PrivacyDbContext> contextFactory,


### PR DESCRIPTION
Doc-accuracy findings from the Granit.Privacy* audit — no code changes.

- **LegalDocumentPublicationService**: class doc claimed it dispatches `LegalAgreementObsoleteEto`; the aggregate's `Archive()` raises that as a domain event — the service publishes `LegalDocumentCacheInvalidatedEto`.
- **EfExportAssemblyCheckpointStore**: the insert race surfaces as `DbUpdateException` (PK violation), not `DbUpdateConcurrencyException` (update path only).
- **Privacy.AI**: detection is backed by `IStructuredCompletion` (ADR-064), not `IAIChatClientFactory`.
- **CLAUDE.md**: Background Jobs subsection contradicted the CRITICAL Wolverine visibility rule the code actually follows — reconciled in favour of the CRITICAL rule.

Builds green (EF Core + AI packages), markdownlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)