### PR TITLE
fix(privacy): dot-separate the deadline-slip metric name

### DIFF
--- a/src/Granit.Privacy/Diagnostics/PrivacyMetrics.cs
+++ b/src/Granit.Privacy/Diagnostics/PrivacyMetrics.cs
@@ -105,7 +105,7 @@ public sealed class PrivacyMetrics
             description: "Duration of IPrivacyDataProvider.HasDataAsync probes during scope visibility resolution.");
 
         _deletionDeadlineSlip = meter.CreateHistogram<double>(
-            "granit.privacy.deletion.deadline_slip",
+            "granit.privacy.deletion.deadline.slip",
             unit: "s",
             description:
                 "Seconds between a deferred deletion's scheduled deadline and its actual execution. "


### PR DESCRIPTION
Last remaining (deliberately deferred) finding from the `Granit.Privacy*` audit — the cosmetic metric rename, now shipped since the framework is pre-release and the telemetry contract break is riskless.

`granit.privacy.deletion.deadline_slip` was the only metric in the module with an underscore inside a name segment — every other multi-word name uses dotted segments (`export.archive.duration`, `scope.probe.duration`). Renamed to **`granit.privacy.deletion.deadline.slip`**.

Verified: the old name is referenced nowhere else — no tests pin it, no granit-docs page, no granit-business dashboard/metric definition.

`Granit.Privacy` builds, `PrivacyMetricsTests` 7/7, `dotnet format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)