### PR TITLE
feat(odata): $filter translated to QueryPredicate — single enforcement point

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -26327,7 +26327,7 @@
       "kind": "class",
       "project": "Granit.Http.ODataExposure",
       "file": "src/Granit.Http.ODataExposure/Extensions/ODataExposureEndpointRouteBuilderExtensions.cs",
-      "line": 31,
+      "line": 37,
       "members": [
         {
           "name": "MapGranitODataEndpoints",

--- a/src/Granit.Http.ODataExposure/Diagnostics/ODataExposureMetrics.cs
+++ b/src/Granit.Http.ODataExposure/Diagnostics/ODataExposureMetrics.cs
@@ -37,9 +37,9 @@ public sealed class ODataExposureMetrics
             description: "OData queries whose user-supplied $top exceeded the EntitySet's MaxTop and was silently clamped. The OData-MaxTop-Applied response header surfaces the same event.");
     }
 
-    /// <summary>Records a rejection at the C3 hardening layer.</summary>
+    /// <summary>Records a rejection at the C3 hardening layer or the #3004 $filter translation layer.</summary>
     /// <param name="entitySet">EntitySet name surfaced on the route (e.g. <c>"Invoices"</c>).</param>
-    /// <param name="reason">Stable snake_case reason tag (<c>"count_disabled"</c>, <c>"expand_not_whitelisted"</c>).</param>
+    /// <param name="reason">Stable snake_case reason tag (<c>"count_disabled"</c>, <c>"expand_not_whitelisted"</c>, <c>"filter_not_translatable"</c>, <c>"filter_field_rejected"</c>, <c>"odata_validation_failed"</c>).</param>
     /// <param name="tenantId">Resolved tenant id, or <see langword="null"/> when no tenant is active. Coalesced to <c>"global"</c> on the metric.</param>
     /// <param name="feedKind">Feed origin (<c>"tenant"</c> or <c>"host"</c>) — distinguishes per-tenant exposure events from cross-tenant host-feed events for audit dashboards.</param>
     public void RecordRejectedQuery(string entitySet, string reason, string? tenantId, string feedKind) =>

--- a/src/Granit.Http.ODataExposure/Extensions/ODataExposureEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Http.ODataExposure/Extensions/ODataExposureEndpointRouteBuilderExtensions.cs
@@ -9,6 +9,9 @@ using Granit.Http.ODataExposure.Options;
 using Granit.Http.RateLimiting.AspNetCore;
 using Granit.MultiTenancy;
 using Granit.QueryEngine;
+using Granit.QueryEngine.Filtering;
+using Granit.QueryEngine.Filtering.Exceptions;
+using Granit.QueryEngine.Meta;
 using Granit.Validation.AspNetCore;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
@@ -16,10 +19,13 @@ using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.OData;
 using Microsoft.AspNetCore.OData.Query;
+using Microsoft.AspNetCore.OData.Query.Validator;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Primitives;
+using Microsoft.OData;
 using Microsoft.OData.Edm;
+using Microsoft.OData.UriParser;
 
 namespace Granit.Http.ODataExposure.Extensions;
 
@@ -49,8 +55,10 @@ public static class ODataExposureEndpointRouteBuilderExtensions
     ///   <item>Permission gate — when the set declared one via <see cref="ODataEntitySetBuilder{TEntity}.RequirePermission"/>.</item>
     ///   <item>C3 hardening (#1392) — <c>$count</c>, <c>$expand</c> whitelist enforcement against the per-set descriptor.</item>
     ///   <item>Resolve <c>IQueryableSource&lt;TEntity&gt;</c> — emits a queryable already filtered by tenant + soft-delete (via <c>ApplyGranitConventions</c> on the host's DbContext).</item>
-    ///   <item>Apply the <c>QueryDefinition</c> filter pipeline via <c>IQueryEngine.BuildFilteredQuery</c> with an empty <c>QueryRequest</c> — composes the framework's required filters.</item>
-    ///   <item>Layer the user's <c>$filter</c> / <c>$select</c> / <c>$top</c> / <c>$skip</c> / <c>$orderby</c> via <c>ODataQueryOptions&lt;TEntity&gt;.ApplyTo</c> with the per-set <c>PageSize</c> and <c>MaxTop</c> caps applied — user filters compose ON TOP of framework filters, never bypassing them.</item>
+    ///   <item>Translate the user's <c>$filter</c> AST into the engine's strict <c>QueryPredicate</c> tree (#3004) — untranslatable constructs return <c>400</c> with an actionable detail.</item>
+    ///   <item>Apply the <c>QueryDefinition</c> filter pipeline via <c>IQueryEngine.BuildFilteredQuery(source, request, predicate)</c> — the framework's required filters AND the user's <c>$filter</c> are enforced by the engine's single enforcement point (filterable-column whitelist, operator inference, structural guards). Violations return <c>400</c> listing every offending field.</item>
+    ///   <item>Validate the remaining query options against the per-route <c>ODataValidationSettings</c> (allowed options, <c>$orderby</c> whitelist derived from the definition's sortable columns, node-count caps).</item>
+    ///   <item>Layer <c>$select</c> / <c>$top</c> / <c>$skip</c> / <c>$orderby</c> via <c>ODataQueryOptions&lt;TEntity&gt;.ApplyTo</c> with the per-set <c>PageSize</c> and <c>MaxTop</c> caps applied. <c>$filter</c> is passed as the ignore flag so it is never applied a second time.</item>
     /// </list>
     /// </summary>
     /// <param name="endpoints">Endpoint route builder (the host's <c>app</c>).</param>
@@ -388,6 +396,10 @@ public static class ODataExposureEndpointRouteBuilderExtensions
         // Captured once at Map time — typed Func used per-request without a cast.
         var crossTenantBypass = descriptor.CrossTenantBypass as Func<IQueryable<TEntity>, IQueryable<TEntity>>;
 
+        // Per-route validation settings, computed once on first request (QueryDefinition
+        // metadata is immutable) and shared by every subsequent request to this route.
+        ODataValidationSettingsCache validationSettingsCache = new();
+
         RouteHandlerBuilder route = root.MapGet(descriptor.EntitySetName, async Task<object?> (
                 ODataQueryOptions<TEntity> options,
                 HttpContext httpContext,
@@ -399,6 +411,7 @@ public static class ODataExposureEndpointRouteBuilderExtensions
                 CancellationToken cancellationToken) => await HandleEntitySetRequestAsync(
                     descriptor,
                     crossTenantBypass,
+                    validationSettingsCache,
                     options,
                     httpContext,
                     source,
@@ -432,13 +445,16 @@ public static class ODataExposureEndpointRouteBuilderExtensions
 
     /// <summary>
     /// Executes one OData EntitySet GET: permission gate, $count / $expand rejection
-    /// gates, MaxTop header emission, and finally the filtered queryable returned to
-    /// the <c>WithODataResult</c> filter. Extracted from the route lambda to keep both
-    /// the parameter list and the cognitive complexity tractable.
+    /// gates, MaxTop header emission, $filter → <see cref="QueryPredicate"/> translation
+    /// (#3004), engine-side strict predicate enforcement, per-route OData validation, and
+    /// finally the filtered queryable returned to the <c>WithODataResult</c> filter.
+    /// Extracted from the route lambda to keep both the parameter list and the cognitive
+    /// complexity tractable.
     /// </summary>
     private static async Task<object?> HandleEntitySetRequestAsync<TEntity>(
         ODataEntitySetDescriptor descriptor,
         Func<IQueryable<TEntity>, IQueryable<TEntity>>? crossTenantBypass,
+        ODataValidationSettingsCache validationSettingsCache,
         ODataQueryOptions<TEntity> options,
         HttpContext httpContext,
         IQueryableSource<TEntity> source,
@@ -464,6 +480,16 @@ public static class ODataExposureEndpointRouteBuilderExtensions
 
         ApplyMaxTopAppliedHeader(httpContext, descriptor, metrics, tenantTag, feedKindTag);
 
+        // #3004 — the user's $filter is translated into the engine's strict predicate tree
+        // instead of being composed as arbitrary LINQ by ApplyTo. Untranslatable constructs
+        // return 400 here; field-level violations return 400 from BuildFilteredQuery below.
+        (QueryPredicate? predicate, ProblemHttpResult? filterRejection) =
+            TranslateFilter(options, descriptor, metrics, tenantTag, feedKindTag);
+        if (filterRejection is not null)
+        {
+            return filterRejection;
+        }
+
         // Host-feed: apply the host-supplied per-query bypass BEFORE the QueryEngine
         // pipeline runs, so the QueryEngine sees an already-untenanted queryable.
         // Tenant-feed: no bypass; the QueryEngine receives the source as-is.
@@ -473,7 +499,39 @@ public static class ODataExposureEndpointRouteBuilderExtensions
             baseQueryable = crossTenantBypass(baseQueryable);
         }
 
-        IQueryable<TEntity> filtered = engine.BuildFilteredQuery(baseQueryable, new QueryRequest());
+        IQueryable<TEntity> filtered;
+        try
+        {
+            filtered = engine.BuildFilteredQuery(baseQueryable, new QueryRequest(), predicate);
+        }
+        catch (QueryPredicateValidationException ex)
+        {
+            // BREAKING (#3004): filtering on an EDM-visible but non-Filterable() column used
+            // to pass through ApplyTo silently; the engine's strict validation now rejects it
+            // with the offending fields listed.
+            metrics.RecordRejectedQuery(descriptor.EntitySetName, "filter_field_rejected", tenantTag, feedKindTag);
+            return TypedResults.Problem(
+                detail: "The $filter was rejected by the query definition: "
+                    + string.Join("; ", ex.Errors.Select(e =>
+                        e.Field is null ? $"[{e.Code}] {e.Message}" : $"[{e.Code}] {e.Field}: {e.Message}")),
+                statusCode: StatusCodes.Status400BadRequest,
+                title: "Query option not supported");
+        }
+
+        ODataValidationSettings validationSettings = validationSettingsCache.GetOrCreate(
+            () => CreateValidationSettings(descriptor, engine.GetMetadata()));
+        try
+        {
+            options.Validate(validationSettings);
+        }
+        catch (ODataException ex)
+        {
+            metrics.RecordRejectedQuery(descriptor.EntitySetName, "odata_validation_failed", tenantTag, feedKindTag);
+            return TypedResults.Problem(
+                detail: ex.Message,
+                statusCode: StatusCodes.Status400BadRequest,
+                title: "Query option not supported");
+        }
 
         ODataQuerySettings querySettings = new() { PageSize = descriptor.PageSize };
 
@@ -482,7 +540,110 @@ public static class ODataExposureEndpointRouteBuilderExtensions
         // would short-circuit the filter — its IResult-check returns the inner
         // Ok<IQueryable> unwrapped, which serializes as a bare JSON array and breaks
         // every BI-tool consumer expecting v4.
-        return options.ApplyTo(filtered, querySettings);
+        // AllowedQueryOptions.Filter is the IGNORE flag: $filter was already enforced by
+        // the engine above, so ApplyTo must never apply it a second time.
+        return options.ApplyTo(filtered, querySettings, AllowedQueryOptions.Filter);
+    }
+
+    /// <summary>
+    /// Translates <c>options.Filter</c> (when present) into the engine's strict
+    /// <see cref="QueryPredicate"/> tree. Returns the predicate on success, or a
+    /// <c>400</c> Problem when the clause fails to parse (<c>odata_validation_failed</c>)
+    /// or contains constructs the translation layer rejects
+    /// (<c>filter_not_translatable</c>).
+    /// </summary>
+    private static (QueryPredicate? Predicate, ProblemHttpResult? Rejection) TranslateFilter<TEntity>(
+        ODataQueryOptions<TEntity> options,
+        ODataEntitySetDescriptor descriptor,
+        ODataExposureMetrics metrics,
+        string? tenantTag,
+        string feedKindTag)
+        where TEntity : class
+    {
+        if (options.Filter is null)
+        {
+            return (null, null);
+        }
+
+        FilterClause filterClause;
+        try
+        {
+            // FilterClause parses lazily — a malformed $filter (or one referencing a
+            // property absent from the EDM) surfaces here as an ODataException.
+            filterClause = options.Filter.FilterClause;
+        }
+        catch (ODataException ex)
+        {
+            metrics.RecordRejectedQuery(descriptor.EntitySetName, "odata_validation_failed", tenantTag, feedKindTag);
+            return (null, TypedResults.Problem(
+                detail: ex.Message,
+                statusCode: StatusCodes.Status400BadRequest,
+                title: "Query option not supported"));
+        }
+
+        ODataFilterTranslationResult translation = ODataFilterTranslator.Translate(filterClause);
+        if (translation.RejectionDetail is not null)
+        {
+            metrics.RecordRejectedQuery(descriptor.EntitySetName, "filter_not_translatable", tenantTag, feedKindTag);
+            return (null, TypedResults.Problem(
+                detail: translation.RejectionDetail,
+                statusCode: StatusCodes.Status400BadRequest,
+                title: "Query option not supported"));
+        }
+
+        return (translation.Predicate, null);
+    }
+
+    /// <summary>
+    /// Builds the per-route <see cref="ODataValidationSettings"/> from the descriptor and the
+    /// query definition's immutable metadata. <c>$orderby</c> is whitelisted from the
+    /// definition's sortable columns; when the definition declares none, the OrderBy option is
+    /// removed entirely (an empty <see cref="ODataValidationSettings.AllowedOrderByProperties"/>
+    /// set means "allow all" upstream — the opposite of what an empty whitelist must mean).
+    /// <c>MaxTop</c> is deliberately NOT set: the existing contract is a silent clamp via
+    /// <c>SetMaxTop</c> (pinned by <c>QueryHardeningTests</c>), not a validation rejection.
+    /// <c>MaxExpansionDepth</c> and the <c>$expand</c> whitelist stay with the dedicated
+    /// request-time gate (#3005 owns their evolution).
+    /// </summary>
+    private static ODataValidationSettings CreateValidationSettings(
+        ODataEntitySetDescriptor descriptor,
+        QueryMetadata metadata)
+    {
+        // SkipToken stays allowed alongside Skip/Top: server-driven paging (PageSize) emits
+        // @odata.nextLink continuations that BI clients follow with $skiptoken.
+        AllowedQueryOptions allowed = AllowedQueryOptions.Filter
+            | AllowedQueryOptions.Select
+            | AllowedQueryOptions.Top
+            | AllowedQueryOptions.Skip
+            | AllowedQueryOptions.SkipToken;
+
+        if (descriptor.CountEnabled)
+        {
+            allowed |= AllowedQueryOptions.Count;
+        }
+
+        if (descriptor.ExpandWhitelist is { Count: > 0 })
+        {
+            allowed |= AllowedQueryOptions.Expand;
+        }
+
+        ODataValidationSettings settings = new()
+        {
+            MaxAnyAllExpressionDepth = 1,
+            MaxNodeCount = 100,
+        };
+
+        if (metadata.SortableFields.Count > 0)
+        {
+            allowed |= AllowedQueryOptions.OrderBy;
+            foreach (SortableField field in metadata.SortableFields)
+            {
+                settings.AllowedOrderByProperties.Add(field.Name);
+            }
+        }
+
+        settings.AllowedQueryOptions = allowed;
+        return settings;
     }
 
     /// <summary>

--- a/src/Granit.Http.ODataExposure/Internal/ODataFilterTranslationResult.cs
+++ b/src/Granit.Http.ODataExposure/Internal/ODataFilterTranslationResult.cs
@@ -1,0 +1,42 @@
+using Granit.QueryEngine.Filtering;
+
+namespace Granit.Http.ODataExposure.Internal;
+
+/// <summary>
+/// Outcome of translating an OData <c>$filter</c> AST into a
+/// <see cref="QueryPredicate"/> tree. A <see langword="null"/>
+/// <see cref="RejectionDetail"/> means the translation succeeded and
+/// <see cref="Predicate"/> carries the engine-consumable predicate; otherwise
+/// <see cref="RejectionDetail"/> is the actionable message returned to the BI
+/// client in the 400 Problem body and <see cref="RejectedNodeKind"/> names the
+/// offending AST node kind for diagnostics.
+/// </summary>
+internal sealed record ODataFilterTranslationResult
+{
+    /// <summary>The translated predicate tree; non-null exactly when <see cref="RejectionDetail"/> is null.</summary>
+    public QueryPredicate? Predicate { get; init; }
+
+    /// <summary>Actionable rejection message for the 400 Problem body, or <see langword="null"/> on success.</summary>
+    public string? RejectionDetail { get; init; }
+
+    /// <summary>Name of the OData AST node kind that caused the rejection, or <see langword="null"/> on success.</summary>
+    public string? RejectedNodeKind { get; init; }
+
+    /// <summary>Creates a successful result.</summary>
+    /// <param name="predicate">The translated predicate tree.</param>
+    public static ODataFilterTranslationResult Success(QueryPredicate predicate)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        return new() { Predicate = predicate };
+    }
+
+    /// <summary>Creates a rejection result.</summary>
+    /// <param name="nodeKind">The offending OData AST node kind.</param>
+    /// <param name="detail">Actionable message returned to the client.</param>
+    public static ODataFilterTranslationResult Rejected(string nodeKind, string detail)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(nodeKind);
+        ArgumentException.ThrowIfNullOrWhiteSpace(detail);
+        return new() { RejectedNodeKind = nodeKind, RejectionDetail = detail };
+    }
+}

--- a/src/Granit.Http.ODataExposure/Internal/ODataFilterTranslator.cs
+++ b/src/Granit.Http.ODataExposure/Internal/ODataFilterTranslator.cs
@@ -1,0 +1,512 @@
+using System.Globalization;
+using Granit.QueryEngine.Filtering;
+using Microsoft.OData;
+using Microsoft.OData.Edm;
+using Microsoft.OData.UriParser;
+
+namespace Granit.Http.ODataExposure.Internal;
+
+/// <summary>
+/// Pure translation of an OData <c>$filter</c> AST (<see cref="FilterClause"/>) into the
+/// QueryEngine's strict <see cref="QueryPredicate"/> tree — the single enforcement point for
+/// filterable-column whitelists and filter semantics. Anything the engine cannot express is
+/// rejected explicitly with an actionable detail instead of being composed as arbitrary LINQ
+/// on top of the engine (the pre-#3004 behaviour, which re-derived none of the
+/// QueryDefinition's rules).
+/// </summary>
+/// <remarks>
+/// <para>Supported constructs:</para>
+/// <list type="bullet">
+///   <item><c>and</c> / <c>or</c> / <c>not</c> → <see cref="QueryPredicate.And"/> / <see cref="QueryPredicate.Or"/> / <see cref="QueryPredicate.Not"/>.</item>
+///   <item><c>eq</c> / <c>ne</c> → <see cref="FilterOperator.Eq"/> / <see cref="FilterOperator.Ne"/>; a <c>null</c> literal on either side becomes <see cref="FilterOperator.IsNull"/> / <see cref="FilterOperator.IsNotNull"/>.</item>
+///   <item><c>gt</c> / <c>ge</c> / <c>lt</c> / <c>le</c> → <see cref="FilterOperator.Gt"/> / <see cref="FilterOperator.Gte"/> / <see cref="FilterOperator.Lt"/> / <see cref="FilterOperator.Lte"/> (operator mirrored when the literal is on the left).</item>
+///   <item><c>contains</c> / <c>startswith</c> / <c>endswith</c> over an entity-local property and a string literal.</item>
+///   <item><c>in</c> with a literal list → <see cref="FilterOperator.In"/> (comma-joined values).</item>
+///   <item><see cref="ConvertNode"/>s are unwrapped transparently (the parser inserts them around promoted literals and nullable properties).</item>
+/// </list>
+/// <para>
+/// Everything else — lambdas (<c>any</c>/<c>all</c>), arithmetic, <c>has</c>, unary minus,
+/// cross-navigation property access, every other canonical function, dynamic properties,
+/// <c>$count</c> segments — is rejected with a distinct <see cref="ODataFilterTranslationResult.RejectionDetail"/>.
+/// </para>
+/// <para>
+/// Literals are stringified to exactly what the engine's value parser
+/// (<c>FilterExpressionBuilder.ConvertValue</c>) round-trips with
+/// <see cref="CultureInfo.InvariantCulture"/>: <see cref="DateTimeOffset"/> as ISO-8601
+/// round-trip (<c>"O"</c>), <c>Edm.Date</c> as <c>yyyy-MM-dd</c>, enums as the member name,
+/// <see cref="Guid"/>/<see cref="bool"/>/numerics invariant.
+/// </para>
+/// </remarks>
+internal static class ODataFilterTranslator
+{
+    /// <summary>
+    /// Translates the given <c>$filter</c> clause. Never throws for unsupported shapes —
+    /// rejections are carried on the result so the caller can emit a 400 Problem + metric.
+    /// </summary>
+    /// <param name="filterClause">The parsed filter clause from <c>ODataQueryOptions.Filter.FilterClause</c>.</param>
+    public static ODataFilterTranslationResult Translate(FilterClause filterClause)
+    {
+        ArgumentNullException.ThrowIfNull(filterClause);
+        return TranslateBoolean(filterClause.Expression);
+    }
+
+    /// <summary>Dispatches one boolean-valued node of the AST.</summary>
+    private static ODataFilterTranslationResult TranslateBoolean(QueryNode node) =>
+        Unwrap(node) switch
+        {
+            BinaryOperatorNode binary => TranslateBinary(binary),
+            UnaryOperatorNode unary => TranslateUnary(unary),
+            SingleValueFunctionCallNode function => TranslateFunction(function),
+            InNode inNode => TranslateIn(inNode),
+            AnyNode => ODataFilterTranslationResult.Rejected(
+                nameof(AnyNode),
+                "The any(...) lambda operator is not supported. Filter on entity-local columns only; ask the API owner to expose the aggregated value as a dedicated column if you need it."),
+            AllNode => ODataFilterTranslationResult.Rejected(
+                nameof(AllNode),
+                "The all(...) lambda operator is not supported. Filter on entity-local columns only; ask the API owner to expose the aggregated value as a dedicated column if you need it."),
+            CountNode => ODataFilterTranslationResult.Rejected(
+                nameof(CountNode),
+                "Filtering on a collection $count segment is not supported. Ask the API owner to expose the count as a dedicated column if you need it."),
+            SingleValueOpenPropertyAccessNode open => ODataFilterTranslationResult.Rejected(
+                nameof(SingleValueOpenPropertyAccessNode),
+                $"Dynamic property '{open.Name}' is not supported — only properties declared in $metadata can be filtered."),
+            SingleValuePropertyAccessNode property => ODataFilterTranslationResult.Rejected(
+                nameof(SingleValuePropertyAccessNode),
+                $"A bare boolean property is not supported as a filter — compare it explicitly: '{property.Property.Name} eq true'."),
+            var other => ODataFilterTranslationResult.Rejected(
+                other.GetType().Name,
+                $"The OData construct '{other.GetType().Name}' is not supported in $filter on this feed."),
+        };
+
+    private static ODataFilterTranslationResult TranslateBinary(BinaryOperatorNode binary) =>
+        binary.OperatorKind switch
+        {
+            BinaryOperatorKind.And => TranslateComposite(binary, static (l, r) => QueryPredicate.And(l, r)),
+            BinaryOperatorKind.Or => TranslateComposite(binary, static (l, r) => QueryPredicate.Or(l, r)),
+            BinaryOperatorKind.Equal => TranslateEquality(binary, negated: false),
+            BinaryOperatorKind.NotEqual => TranslateEquality(binary, negated: true),
+            BinaryOperatorKind.GreaterThan or BinaryOperatorKind.GreaterThanOrEqual
+                or BinaryOperatorKind.LessThan or BinaryOperatorKind.LessThanOrEqual =>
+                TranslateComparison(binary),
+            BinaryOperatorKind.Add or BinaryOperatorKind.Subtract or BinaryOperatorKind.Multiply
+                or BinaryOperatorKind.Divide or BinaryOperatorKind.Modulo =>
+                RejectArithmetic(),
+            BinaryOperatorKind.Has => ODataFilterTranslationResult.Rejected(
+                nameof(BinaryOperatorNode),
+                "The 'has' flag-enum operator is not supported. Use 'eq' against a single enum member instead."),
+            _ => ODataFilterTranslationResult.Rejected(
+                nameof(BinaryOperatorNode),
+                $"The OData binary operator '{binary.OperatorKind}' is not supported in $filter on this feed."),
+        };
+
+    private static ODataFilterTranslationResult TranslateComposite(
+        BinaryOperatorNode binary,
+        Func<QueryPredicate, QueryPredicate, QueryPredicate> combine)
+    {
+        ODataFilterTranslationResult left = TranslateBoolean(binary.Left);
+        if (left.RejectionDetail is not null)
+        {
+            return left;
+        }
+
+        ODataFilterTranslationResult right = TranslateBoolean(binary.Right);
+        if (right.RejectionDetail is not null)
+        {
+            return right;
+        }
+
+        return ODataFilterTranslationResult.Success(combine(left.Predicate!, right.Predicate!));
+    }
+
+    private static ODataFilterTranslationResult TranslateUnary(UnaryOperatorNode unary)
+    {
+        if (unary.OperatorKind != UnaryOperatorKind.Not)
+        {
+            return ODataFilterTranslationResult.Rejected(
+                nameof(UnaryOperatorNode),
+                "The unary minus operator is not supported — compare against the literal value directly.");
+        }
+
+        ODataFilterTranslationResult operand = TranslateBoolean(unary.Operand);
+        return operand.RejectionDetail is not null
+            ? operand
+            : ODataFilterTranslationResult.Success(QueryPredicate.Not(operand.Predicate!));
+    }
+
+    /// <summary>
+    /// <c>eq</c> / <c>ne</c>: a <c>null</c> literal on either side becomes an
+    /// <see cref="FilterOperator.IsNull"/> / <see cref="FilterOperator.IsNotNull"/> null check
+    /// on the property operand; otherwise a plain Eq/Ne leaf (property on either side).
+    /// </summary>
+    private static ODataFilterTranslationResult TranslateEquality(BinaryOperatorNode binary, bool negated)
+    {
+        QueryNode left = Unwrap(binary.Left);
+        QueryNode right = Unwrap(binary.Right);
+
+        bool leftIsNull = left is ConstantNode { Value: null };
+        bool rightIsNull = right is ConstantNode { Value: null };
+
+        if (leftIsNull || rightIsNull)
+        {
+            if (leftIsNull && rightIsNull)
+            {
+                return ODataFilterTranslationResult.Rejected(
+                    nameof(BinaryOperatorNode),
+                    "Comparing null to null is not supported — one side of eq/ne must be an entity-local property.");
+            }
+
+            QueryNode propertyOperand = leftIsNull ? right : left;
+            if (!TryResolveEntityLocalProperty(propertyOperand, out string nullCheckedField, out ODataFilterTranslationResult? nullRejection))
+            {
+                return nullRejection
+                    ?? ClassifyOperandRejection(propertyOperand)
+                    ?? ODataFilterTranslationResult.Rejected(
+                        nameof(BinaryOperatorNode),
+                        "A null comparison must have an entity-local property on the other side.");
+            }
+
+            return ODataFilterTranslationResult.Success(
+                QueryPredicate.Criterion(nullCheckedField, negated ? FilterOperator.IsNotNull : FilterOperator.IsNull));
+        }
+
+        if (!TryResolvePropertyAndConstant(left, right, out string field, out ConstantNode? constant, out _,
+                out ODataFilterTranslationResult? rejection))
+        {
+            return rejection!;
+        }
+
+        if (!TryStringifyConstant(constant!, out string? value, out ODataFilterTranslationResult? constantRejection))
+        {
+            return constantRejection!;
+        }
+
+        return ODataFilterTranslationResult.Success(
+            QueryPredicate.Criterion(field, negated ? FilterOperator.Ne : FilterOperator.Eq, value!));
+    }
+
+    /// <summary>
+    /// <c>gt</c> / <c>ge</c> / <c>lt</c> / <c>le</c>. A <c>null</c> literal is rejected (null has
+    /// no ordering — the engine's range operators require a value). When the literal is on the
+    /// left (<c>100 lt Amount</c>) the operator is mirrored (<c>Amount gt 100</c>).
+    /// </summary>
+    private static ODataFilterTranslationResult TranslateComparison(BinaryOperatorNode binary)
+    {
+        QueryNode left = Unwrap(binary.Left);
+        QueryNode right = Unwrap(binary.Right);
+
+        if (left is ConstantNode { Value: null } || right is ConstantNode { Value: null })
+        {
+            return ODataFilterTranslationResult.Rejected(
+                nameof(BinaryOperatorNode),
+                $"A null literal cannot be ordered with '{binary.OperatorKind}' — use 'eq null' or 'ne null' for null checks.");
+        }
+
+        if (!TryResolvePropertyAndConstant(left, right, out string field, out ConstantNode? constant, out bool mirrored,
+                out ODataFilterTranslationResult? rejection))
+        {
+            return rejection!;
+        }
+
+        if (!TryStringifyConstant(constant!, out string? value, out ODataFilterTranslationResult? constantRejection))
+        {
+            return constantRejection!;
+        }
+
+        FilterOperator op = (binary.OperatorKind, mirrored) switch
+        {
+            (BinaryOperatorKind.GreaterThan, false) or (BinaryOperatorKind.LessThan, true) => FilterOperator.Gt,
+            (BinaryOperatorKind.GreaterThanOrEqual, false) or (BinaryOperatorKind.LessThanOrEqual, true) => FilterOperator.Gte,
+            (BinaryOperatorKind.LessThan, false) or (BinaryOperatorKind.GreaterThan, true) => FilterOperator.Lt,
+            _ => FilterOperator.Lte,
+        };
+
+        return ODataFilterTranslationResult.Success(QueryPredicate.Criterion(field, op, value!));
+    }
+
+    /// <summary>
+    /// <c>contains</c> / <c>startswith</c> / <c>endswith</c> over an entity-local property and a
+    /// string literal. Every other canonical function is rejected by name.
+    /// </summary>
+    private static ODataFilterTranslationResult TranslateFunction(SingleValueFunctionCallNode function)
+    {
+        FilterOperator? op = function.Name.ToLowerInvariant() switch
+        {
+            "contains" => FilterOperator.Contains,
+            "startswith" => FilterOperator.StartsWith,
+            "endswith" => FilterOperator.EndsWith,
+            _ => null,
+        };
+
+        if (op is null)
+        {
+            return ODataFilterTranslationResult.Rejected(
+                nameof(SingleValueFunctionCallNode),
+                $"The OData function '{function.Name}' is not supported. Supported functions: contains(Property, 'value'), startswith(Property, 'value'), endswith(Property, 'value') over an entity-local string column.");
+        }
+
+        QueryNode[] parameters = [.. function.Parameters];
+        if (parameters.Length != 2)
+        {
+            return RejectFunctionShape(function.Name);
+        }
+
+        if (!TryResolveEntityLocalProperty(parameters[0], out string field, out ODataFilterTranslationResult? rejection))
+        {
+            return rejection ?? RejectFunctionShape(function.Name);
+        }
+
+        if (Unwrap(parameters[1]) is not ConstantNode { Value: string text })
+        {
+            return RejectFunctionShape(function.Name);
+        }
+
+        return ODataFilterTranslationResult.Success(QueryPredicate.Criterion(field, op.Value, text));
+    }
+
+    /// <summary>
+    /// <c>in</c> with a literal list. The engine's <see cref="FilterOperator.In"/> parser splits
+    /// the criterion value on commas (trimming entries and dropping empty ones), so items that
+    /// would not round-trip — strings containing a comma, empty/whitespace-only strings, strings
+    /// with leading or trailing whitespace, and <c>null</c> — are rejected instead of silently
+    /// changing the match semantics.
+    /// </summary>
+    private static ODataFilterTranslationResult TranslateIn(InNode inNode)
+    {
+        if (!TryResolveEntityLocalProperty(inNode.Left, out string field, out ODataFilterTranslationResult? rejection))
+        {
+            return rejection ?? ODataFilterTranslationResult.Rejected(
+                nameof(InNode),
+                "The left operand of 'in' must be an entity-local property.");
+        }
+
+        if (inNode.Right is not CollectionConstantNode collection || collection.Collection.Count == 0)
+        {
+            return ODataFilterTranslationResult.Rejected(
+                nameof(InNode),
+                "The right operand of 'in' must be a non-empty parenthesised list of literals, e.g. Status in ('Paid','Sent').");
+        }
+
+        List<string> items = new(collection.Collection.Count);
+        foreach (ConstantNode item in collection.Collection)
+        {
+            if (!TryStringifyConstant(item, out string? value, out ODataFilterTranslationResult? itemRejection))
+            {
+                return itemRejection!;
+            }
+
+            if (value is null)
+            {
+                return ODataFilterTranslationResult.Rejected(
+                    nameof(InNode),
+                    $"A null literal cannot appear in an 'in' list — combine with 'or {field} eq null' instead.");
+            }
+
+            if (value.Contains(',', StringComparison.Ordinal))
+            {
+                return ODataFilterTranslationResult.Rejected(
+                    nameof(InNode),
+                    $"The 'in' list item '{value}' contains a comma, which the query engine uses as the list separator — use separate 'eq' comparisons combined with 'or' instead.");
+            }
+
+            if (value.Length == 0 || !string.Equals(value, value.Trim(), StringComparison.Ordinal))
+            {
+                return ODataFilterTranslationResult.Rejected(
+                    nameof(InNode),
+                    "An 'in' list item that is empty, whitespace-only, or has leading/trailing whitespace would not round-trip through the query engine's list parser — use separate 'eq' comparisons combined with 'or' instead.");
+            }
+
+            items.Add(value);
+        }
+
+        return ODataFilterTranslationResult.Success(
+            QueryPredicate.Criterion(field, FilterOperator.In, string.Join(',', items)));
+    }
+
+    /// <summary>
+    /// Finds the (property, literal) pair of a binary comparison, accepting either operand order.
+    /// <paramref name="mirrored"/> is <see langword="true"/> when the property sat on the right
+    /// (the caller must mirror relational operators). Produces the most specific rejection
+    /// available when neither shape matches (cross-navigation, arithmetic, function, …).
+    /// </summary>
+    private static bool TryResolvePropertyAndConstant(
+        QueryNode left,
+        QueryNode right,
+        out string field,
+        out ConstantNode? constant,
+        out bool mirrored,
+        out ODataFilterTranslationResult? rejection)
+    {
+        constant = null;
+        mirrored = false;
+
+        if (TryResolveEntityLocalProperty(left, out field, out ODataFilterTranslationResult? leftRejection)
+            && right is ConstantNode rightConstant)
+        {
+            constant = rightConstant;
+            rejection = null;
+            return true;
+        }
+
+        if (TryResolveEntityLocalProperty(right, out field, out ODataFilterTranslationResult? rightRejection)
+            && left is ConstantNode leftConstant)
+        {
+            constant = leftConstant;
+            mirrored = true;
+            rejection = null;
+            return true;
+        }
+
+        rejection = leftRejection ?? rightRejection
+            ?? ClassifyOperandRejection(left) ?? ClassifyOperandRejection(right)
+            ?? ODataFilterTranslationResult.Rejected(
+                nameof(BinaryOperatorNode),
+                "A comparison must have an entity-local property on one side and a literal on the other.");
+        return false;
+    }
+
+    /// <summary>
+    /// Resolves an operand to an entity-local property name: a
+    /// <see cref="SingleValuePropertyAccessNode"/> whose source (through
+    /// <see cref="ConvertNode"/>s) is the entity range variable. Cross-navigation access
+    /// (<c>Customer/Name</c>) and dynamic properties produce a specific rejection; any other
+    /// shape returns <see langword="false"/> with a <see langword="null"/> rejection so the
+    /// caller can supply context.
+    /// </summary>
+    private static bool TryResolveEntityLocalProperty(
+        QueryNode node,
+        out string field,
+        out ODataFilterTranslationResult? rejection)
+    {
+        field = string.Empty;
+        rejection = null;
+
+        switch (Unwrap(node))
+        {
+            case SingleValueOpenPropertyAccessNode open:
+                rejection = ODataFilterTranslationResult.Rejected(
+                    nameof(SingleValueOpenPropertyAccessNode),
+                    $"Dynamic property '{open.Name}' is not supported — only properties declared in $metadata can be filtered.");
+                return false;
+
+            case SingleValuePropertyAccessNode property when Unwrap(property.Source) is ResourceRangeVariableReferenceNode:
+                field = property.Property.Name;
+                return true;
+
+            case SingleValuePropertyAccessNode property:
+                rejection = ODataFilterTranslationResult.Rejected(
+                    nameof(SingleValuePropertyAccessNode),
+                    $"Cross-navigation property access ('.../{property.Property.Name}') is not supported — filter on the EntitySet's own columns; ask the API owner to expose the related value as a dedicated column if you need it.");
+                return false;
+
+            default:
+                return false;
+        }
+    }
+
+    /// <summary>
+    /// Maps a non-property, non-literal operand to the most actionable rejection: arithmetic,
+    /// unary minus, unsupported function. Returns <see langword="null"/> when no specific
+    /// classification applies.
+    /// </summary>
+    private static ODataFilterTranslationResult? ClassifyOperandRejection(QueryNode node) =>
+        Unwrap(node) switch
+        {
+            BinaryOperatorNode
+            {
+                OperatorKind: BinaryOperatorKind.Add or BinaryOperatorKind.Subtract
+                    or BinaryOperatorKind.Multiply or BinaryOperatorKind.Divide or BinaryOperatorKind.Modulo,
+            } => RejectArithmetic(),
+            UnaryOperatorNode { OperatorKind: UnaryOperatorKind.Negate } => ODataFilterTranslationResult.Rejected(
+                nameof(UnaryOperatorNode),
+                "The unary minus operator is not supported — compare against the literal value directly."),
+            SingleValueFunctionCallNode function => ODataFilterTranslationResult.Rejected(
+                nameof(SingleValueFunctionCallNode),
+                $"The OData function '{function.Name}' is not supported. Supported functions: contains(Property, 'value'), startswith(Property, 'value'), endswith(Property, 'value') over an entity-local string column."),
+            CountNode => ODataFilterTranslationResult.Rejected(
+                nameof(CountNode),
+                "Filtering on a collection $count segment is not supported. Ask the API owner to expose the count as a dedicated column if you need it."),
+            _ => null,
+        };
+
+    /// <summary>
+    /// Stringifies a literal to the exact format the engine's value parser
+    /// (<c>FilterExpressionBuilder.ConvertValue</c>, invariant culture) round-trips.
+    /// A <c>null</c> literal yields <paramref name="value"/> = <see langword="null"/> with
+    /// success — the caller decides whether null is meaningful in its position.
+    /// </summary>
+    private static bool TryStringifyConstant(
+        ConstantNode constant,
+        out string? value,
+        out ODataFilterTranslationResult? rejection)
+    {
+        rejection = null;
+        switch (constant.Value)
+        {
+            case null:
+                value = null;
+                return true;
+            case string s:
+                value = s;
+                return true;
+            case bool b:
+                value = b ? "true" : "false";
+                return true;
+            case Guid g:
+                value = g.ToString("D");
+                return true;
+            case DateTimeOffset dto:
+                value = dto.ToString("O", CultureInfo.InvariantCulture);
+                return true;
+            case Date d:
+                // Edm.Date — the engine parses DateOnly with yyyy-MM-dd.
+                value = string.Create(CultureInfo.InvariantCulture, $"{d.Year:D4}-{d.Month:D2}-{d.Day:D2}");
+                return true;
+            case DateOnly dateOnly:
+                value = dateOnly.ToString("O", CultureInfo.InvariantCulture);
+                return true;
+            case TimeOnly timeOnly:
+                value = timeOnly.ToString("O", CultureInfo.InvariantCulture);
+                return true;
+            case TimeOfDay timeOfDay:
+                // Edm.TimeOfDay ToString emits HH:mm:ss.fffffff — parseable by TimeOnly.Parse.
+                value = timeOfDay.ToString();
+                return true;
+            case ODataEnumValue enumValue:
+                value = enumValue.Value;
+                return true;
+            case byte or sbyte or short or ushort or int or uint or long or ulong or float or double or decimal:
+                value = ((IFormattable)constant.Value).ToString(null, CultureInfo.InvariantCulture);
+                return true;
+            default:
+                value = null;
+                rejection = ODataFilterTranslationResult.Rejected(
+                    nameof(ConstantNode),
+                    $"A literal of type '{constant.Value.GetType().Name}' is not supported in $filter on this feed.");
+                return false;
+        }
+    }
+
+    private static ODataFilterTranslationResult RejectArithmetic() =>
+        ODataFilterTranslationResult.Rejected(
+            nameof(BinaryOperatorNode),
+            "Arithmetic operators (add, sub, mul, div, mod) are not supported in $filter — compare the column against a pre-computed literal instead.");
+
+    private static ODataFilterTranslationResult RejectFunctionShape(string functionName) =>
+        ODataFilterTranslationResult.Rejected(
+            nameof(SingleValueFunctionCallNode),
+            $"The '{functionName}' function requires the shape {functionName}(Property, 'literal') with an entity-local string property and a string literal.");
+
+    /// <summary>
+    /// Transparently unwraps <see cref="ConvertNode"/>s — the parser inserts them around
+    /// promoted literals (<c>Amount gt 100</c> → int-to-decimal) and nullable property access.
+    /// </summary>
+    private static QueryNode Unwrap(QueryNode node)
+    {
+        while (node is ConvertNode convert)
+        {
+            node = convert.Source;
+        }
+
+        return node;
+    }
+}

--- a/src/Granit.Http.ODataExposure/Internal/ODataValidationSettingsCache.cs
+++ b/src/Granit.Http.ODataExposure/Internal/ODataValidationSettingsCache.cs
@@ -1,0 +1,23 @@
+using Microsoft.AspNetCore.OData.Query.Validator;
+
+namespace Granit.Http.ODataExposure.Internal;
+
+/// <summary>
+/// Per-route single-assignment cache for the <see cref="ODataValidationSettings"/> computed
+/// from the EntitySet descriptor and the query definition's metadata. One instance is captured
+/// in each mapped route's closure; the settings are computed on the first request because
+/// <c>IQueryEngine&lt;TEntity&gt;.GetMetadata()</c> needs a scoped engine instance, but the
+/// result is derived exclusively from immutable QueryDefinition metadata, so it never changes.
+/// </summary>
+internal sealed class ODataValidationSettingsCache
+{
+    // volatile: settings are published once and read from many request threads. A duplicate
+    // computation under a benign first-request race is fine — both factories produce identical
+    // values from the same immutable metadata; the reference assignment is atomic.
+    private volatile ODataValidationSettings? _settings;
+
+    /// <summary>Returns the cached settings, computing them via <paramref name="factory"/> on first use.</summary>
+    /// <param name="factory">Factory deriving the settings from immutable QueryDefinition metadata.</param>
+    public ODataValidationSettings GetOrCreate(Func<ODataValidationSettings> factory) =>
+        _settings ??= factory();
+}

--- a/src/Granit.Http.ODataExposure/README.md
+++ b/src/Granit.Http.ODataExposure/README.md
@@ -102,14 +102,80 @@ Per EntitySet `GET /api/{version}/odata/{Name}?$filter=…&$select=…&$top=…`
 3. **`IQueryableSource<TEntity>`** is resolved from DI — emits an
    `IQueryable<TEntity>` already filtered by the host's
    `ApplyGranitConventions` (tenant + soft-delete).
-4. **`IQueryEngine.BuildFilteredQuery(source, new QueryRequest())`** layers
-   the `QueryDefinition`'s filter pipeline (presets, quick filters, global
-   search). User filters compose ON TOP of these — never instead of them.
-5. **`ODataQueryOptions<TEntity>.ApplyTo(filtered)`** layers the user's
-   `$filter` / `$select` / `$top` / `$skip` / `$orderby` on top.
+4. **`$filter` translation** — the OData filter AST is translated into the
+   QueryEngine's strict `QueryPredicate` tree. Untranslatable constructs
+   return `400 Bad Request` (see [`$filter` support](#filter-support) below).
+5. **`IQueryEngine.BuildFilteredQuery(source, new QueryRequest(), predicate)`**
+   layers the `QueryDefinition`'s filter pipeline (presets, quick filters,
+   global search) AND the translated user predicate through the engine's
+   single enforcement point — filterable-column whitelist, operator
+   inference, structural guards. Violations return `400` listing every
+   offending field.
+6. **Per-route validation** — `ODataQueryOptions.Validate` runs against
+   settings derived from the descriptor and the `QueryDefinition`:
+   `$orderby` is whitelisted from the definition's `Sortable()` columns
+   (no sortable columns → `$orderby` rejected entirely).
+7. **`ODataQueryOptions<TEntity>.ApplyTo(filtered, settings, AllowedQueryOptions.Filter)`**
+   layers `$select` / `$top` / `$skip` / `$orderby` on top. `$filter` is
+   passed as the *ignore* flag — it was already enforced by the engine and
+   is never applied twice.
 
 The order is load-bearing: tenant first, framework filters second, user
-query third.
+query third — and the user's `$filter` goes through the engine, not around
+it.
+
+## `$filter` support
+
+Since #3004 the user's `$filter` is no longer composed as arbitrary LINQ by
+`ApplyTo` — it is translated into the QueryEngine predicate tree so the
+`QueryDefinition`'s `Filterable()` whitelist and operator inference are
+enforced once, engine-side.
+
+Supported constructs:
+
+| OData construct | QueryEngine translation |
+| --------------- | ----------------------- |
+| `and` / `or` / `not` | `And` / `Or` / `Not` predicate composition |
+| `eq` / `ne` | `Eq` / `Ne` leaf |
+| `X eq null` / `X ne null` | `IsNull` / `IsNotNull` null check |
+| `gt` / `ge` / `lt` / `le` | `Gt` / `Gte` / `Lt` / `Lte` (mirrored when the literal is on the left) |
+| `contains` / `startswith` / `endswith` | `Contains` / `StartsWith` / `EndsWith` over an entity-local string column |
+| `X in ('a','b')` | `In` leaf (comma-joined values) |
+| Typed literals | `DateTimeOffset` (ISO-8601 round-trip), `Edm.Date` (`yyyy-MM-dd`), `Guid`, `bool`, numerics (invariant), enum member names |
+
+Explicitly rejected — `400 Bad Request` with an actionable detail and the
+`granit.odata.query.rejected` metric (`reason=filter_not_translatable`):
+
+- `any(...)` / `all(...)` lambdas and collection `$count` segments
+- arithmetic operators (`add`, `sub`, `mul`, `div`, `mod`) and unary minus
+- the `has` flag-enum operator
+- cross-navigation property access (`Customer/Name`) — filter on the
+  EntitySet's own columns
+- every other canonical function (`tolower`, `toupper`, `trim`, `concat`,
+  `indexof`, `length`, `substring`, `year`, `month`, `day`, `date`, `time`,
+  `now`, `round`, `floor`, `ceiling`, `cast`, `isof`, `geo.*`, …)
+- dynamic (open-type) properties
+- `in` list items that would not round-trip the engine's comma-separated
+  list format (items containing a comma, `null`, empty or
+  whitespace-padded strings)
+
+The 400 contract (RFC 7807 Problem, title `Query option not supported`):
+
+- **`filter_not_translatable`** — the construct is not in the table above;
+  the detail names it and suggests the supported alternative.
+- **`filter_field_rejected`** — the filter is translatable but references
+  columns the `QueryDefinition` does not allow; the detail lists every
+  violation (`[FieldNotFilterable] InternalNote: …`).
+- **`odata_validation_failed`** — the clause failed to parse, referenced a
+  property absent from `$metadata`, or another query option failed the
+  per-route validation settings (e.g. `$orderby` on a non-`Sortable()`
+  column).
+
+> **BREAKING (#3004):** filtering on an EDM-visible but non-`Filterable()`
+> column previously passed through `ApplyTo` silently; it now returns
+> `400` with the field name in the Problem detail. Mark every column BI
+> tools filter on as `Filterable()` in the `QueryDefinition`. Similarly,
+> `$orderby` now requires the column to be `Sortable()`.
 
 ## Strict-config validator (C6 #1395)
 

--- a/tests/Granit.Http.ODataExposure.Tests.Integration/ODataFilterTranslationTests.cs
+++ b/tests/Granit.Http.ODataExposure.Tests.Integration/ODataFilterTranslationTests.cs
@@ -1,0 +1,231 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Http.ODataExposure.Tests.Integration;
+
+/// <summary>
+/// #3004 end-to-end assertions for the <c>$filter</c> → QueryPredicate translation layer:
+/// the filter shapes Power BI emits fold into SQL through the engine's single enforcement
+/// point, untranslatable or non-whitelisted constructs return <c>400</c> with an actionable
+/// Problem detail, and the SQL capture proves the translated filter reaches the database
+/// exactly once (never re-applied by <c>ApplyTo</c>).
+/// </summary>
+public sealed class ODataFilterTranslationTests(PostgresFixture postgres)
+    : IClassFixture<PostgresFixture>, IAsyncLifetime
+{
+    private readonly PostgresFixture _postgres = postgres;
+    private static readonly Guid TenantA = Guid.Parse("11111111-1111-1111-1111-111111111111");
+
+    private ODataTestApp _app = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        _app = await ODataTestApp.CreateAsync(_postgres.ConnectionString);
+        await SeedAsync();
+    }
+
+    public async ValueTask DisposeAsync() => await _app.DisposeAsync();
+
+    // ── Happy shapes (what Power BI query folding emits) ─────────────────
+
+    [Theory]
+    [InlineData("Status eq 'Paid' and Amount gt 100", new[] { "A-002" })]
+    [InlineData("Status eq 'Draft' or Amount gt 400", new[] { "A-004", "A-005" })]
+    [InlineData("Status eq 'Paid' or Status eq 'Sent' or Amount gt 400", new[] { "A-001", "A-002", "A-003", "A-005" })]
+    [InlineData("Status in ('Paid','Sent')", new[] { "A-001", "A-002", "A-003", "A-005" })]
+    [InlineData("contains(Number, '003')", new[] { "A-003" })]
+    [InlineData("startswith(Number, 'A-')", new[] { "A-001", "A-002", "A-003", "A-004", "A-005" })]
+    [InlineData("endswith(Number, '1')", new[] { "A-001" })]
+    [InlineData("not contains(Number, '003')", new[] { "A-001", "A-002", "A-004", "A-005" })]
+    [InlineData("PaidAt ne null", new[] { "A-001", "A-002", "A-005" })]
+    [InlineData("PaidAt eq null", new[] { "A-003", "A-004" })]
+    [InlineData(
+        "PaidAt ge 2026-01-01T00:00:00Z and PaidAt lt 2026-02-01T00:00:00Z",
+        new[] { "A-001", "A-005" })]
+    public async Task Filter_SupportedShape_ReturnsExpectedRows(string filter, string[] expectedNumbers)
+    {
+        HttpResponseMessage response = await GetAsync($"Invoices?$filter={Uri.EscapeDataString(filter)}");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        IReadOnlyList<JsonElement> rows = await ReadValueAsync(response);
+        rows.Select(r => r.GetProperty("Number").GetString())
+            .Order()
+            .ShouldBe(expectedNumbers.Order(), $"filter: {filter}");
+    }
+
+    // ── Rejections → 400 Problem ─────────────────────────────────────────
+
+    [Theory]
+    // BREAKING (#3004): EDM-visible but non-Filterable() column — used to pass through
+    // ApplyTo silently, now rejected by the engine's strict predicate validation with the
+    // field name in the detail.
+    [InlineData("InternalNote eq 'x'", "InternalNote")]
+    [InlineData("InternalNote eq 'x'", "FieldNotFilterable")]
+    // unsupported canonical functions
+    [InlineData("tolower(Status) eq 'paid'", "tolower")]
+    [InlineData("year(PaidAt) eq 2026", "year")]
+    // arithmetic
+    [InlineData("Amount add 5 gt 10", "Arithmetic")]
+    // in-list item containing the engine's separator
+    [InlineData("Status in ('a,b')", "comma")]
+    public async Task Filter_RejectedShape_Returns400WithActionableDetail(string filter, string expectedFragment)
+    {
+        HttpResponseMessage response = await GetAsync($"Invoices?$filter={Uri.EscapeDataString(filter)}");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+        string body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        body.ShouldContain(expectedFragment, customMessage: body);
+        body.ShouldContain("Query option not supported");
+    }
+
+    [Fact]
+    public async Task Filter_NavigationAccess_Returns400()
+    {
+        // The test EDM exposes no Customer navigation, so the parser rejects the path —
+        // surfaced as a 400 Problem instead of an unhandled ODataException (pre-#3004).
+        HttpResponseMessage response = await GetAsync(
+            $"Invoices?$filter={Uri.EscapeDataString("Customer/Name eq 'ACME'")}");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+        string body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        body.ShouldContain("Customer", customMessage: body);
+    }
+
+    [Fact]
+    public async Task OrderBy_NonSortableColumn_Returns400()
+    {
+        // Status is Filterable but NOT Sortable in the QueryDefinition — the per-route
+        // AllowedOrderByProperties whitelist (derived from SortableFields) rejects it.
+        HttpResponseMessage response = await GetAsync("Invoices?$orderby=Status");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+        string body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        body.ShouldContain("Status", customMessage: body);
+    }
+
+    [Fact]
+    public async Task OrderBy_SortableColumn_ReturnsOrderedRows()
+    {
+        HttpResponseMessage response = await GetAsync("Invoices?$orderby=Amount desc");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        IReadOnlyList<JsonElement> rows = await ReadValueAsync(response);
+        rows.Count.ShouldBe(5);
+        rows[0].GetProperty("Number").GetString().ShouldBe("A-005");
+    }
+
+    // ── Single-application proof (SQL capture) ───────────────────────────
+
+    [Fact]
+    public async Task Filter_TranslatedPredicate_ReachesSqlExactlyOnce()
+    {
+        // With the pre-#3004 flow, ApplyTo would compose the $filter a second time on top of
+        // the engine's predicate. The ignore flag on ApplyTo guarantees each filtered column
+        // appears exactly once in the WHERE clause.
+        _app.SqlCapture.Clear();
+        HttpResponseMessage response = await GetAsync(
+            $"Invoices?$filter={Uri.EscapeDataString("Status eq 'Paid' and Amount gt 100")}");
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        string? selectCommand = _app.SqlCapture.Commands
+            .FirstOrDefault(c => c.Contains(@"FROM ""Invoices""", StringComparison.Ordinal));
+        selectCommand.ShouldNotBeNull("expected a SELECT against \"Invoices\" in the captured SQL");
+
+        int whereIndex = selectCommand.IndexOf("WHERE", StringComparison.Ordinal);
+        whereIndex.ShouldBeGreaterThan(0, "expected a WHERE clause in the captured SQL");
+        string whereClause = selectCommand[whereIndex..];
+
+        CountOccurrences(whereClause, @"""Status""").ShouldBe(1,
+            $"user $filter column must appear exactly once in the WHERE clause — actual SQL:\n{selectCommand}");
+        CountOccurrences(whereClause, @"""Amount""").ShouldBe(1,
+            $"user $filter column must appear exactly once in the WHERE clause — actual SQL:\n{selectCommand}");
+    }
+
+    private static int CountOccurrences(string haystack, string needle)
+    {
+        int count = 0;
+        for (int index = haystack.IndexOf(needle, StringComparison.Ordinal);
+             index >= 0;
+             index = haystack.IndexOf(needle, index + needle.Length, StringComparison.Ordinal))
+        {
+            count++;
+        }
+
+        return count;
+    }
+
+    private async Task<HttpResponseMessage> GetAsync(string relativePath)
+    {
+        using HttpRequestMessage request = new(HttpMethod.Get, $"/api/granit/odata/{relativePath}");
+        request.Headers.Add("X-Test-Tenant", TenantA.ToString());
+        return await _app.Client.SendAsync(request, TestContext.Current.CancellationToken);
+    }
+
+    private static async Task<IReadOnlyList<JsonElement>> ReadValueAsync(HttpResponseMessage response)
+    {
+        JsonDocument doc = await response.Content.ReadFromJsonAsync<JsonDocument>(TestContext.Current.CancellationToken)
+            ?? throw new InvalidOperationException("OData response was empty.");
+        return [.. doc.RootElement.GetProperty("value").EnumerateArray()];
+    }
+
+    private async Task SeedAsync()
+    {
+        using IServiceScope scope = _app.CreateScope();
+        TestDbContext db = scope.ServiceProvider.GetRequiredService<TestDbContext>();
+
+        await db.Invoices.IgnoreQueryFilters().ExecuteDeleteAsync(TestContext.Current.CancellationToken);
+
+        db.Invoices.AddRange(
+            new Invoice
+            {
+                Id = Guid.NewGuid(),
+                TenantId = TenantA,
+                Number = "A-001",
+                Amount = 100m,
+                Status = "Paid",
+                PaidAt = new DateTimeOffset(2026, 1, 15, 0, 0, 0, TimeSpan.Zero),
+            },
+            new Invoice
+            {
+                Id = Guid.NewGuid(),
+                TenantId = TenantA,
+                Number = "A-002",
+                Amount = 250m,
+                Status = "Paid",
+                PaidAt = new DateTimeOffset(2026, 2, 10, 0, 0, 0, TimeSpan.Zero),
+            },
+            new Invoice
+            {
+                Id = Guid.NewGuid(),
+                TenantId = TenantA,
+                Number = "A-003",
+                Amount = 250m,
+                Status = "Sent",
+            },
+            new Invoice
+            {
+                Id = Guid.NewGuid(),
+                TenantId = TenantA,
+                Number = "A-004",
+                Amount = 400m,
+                Status = "Draft",
+                InternalNote = "escalated",
+            },
+            new Invoice
+            {
+                Id = Guid.NewGuid(),
+                TenantId = TenantA,
+                Number = "A-005",
+                Amount = 500m,
+                Status = "Sent",
+                PaidAt = new DateTimeOffset(2026, 1, 20, 0, 0, 0, TimeSpan.Zero),
+            });
+
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+    }
+}

--- a/tests/Granit.Http.ODataExposure.Tests.Integration/TestEntities.cs
+++ b/tests/Granit.Http.ODataExposure.Tests.Integration/TestEntities.cs
@@ -22,6 +22,9 @@ internal sealed class Invoice : IMultiTenant, ISoftDeletable
     public Guid? TenantId { get; set; }
     public string Number { get; init; } = string.Empty;
     public decimal Amount { get; init; }
+    public string Status { get; init; } = "Draft";
+    public DateTimeOffset? PaidAt { get; init; }
+    public string? InternalNote { get; init; }
     public bool IsDeleted { get; set; }
     public DateTimeOffset? DeletedAt { get; set; }
     public string? DeletedBy { get; set; }
@@ -46,6 +49,8 @@ internal sealed class TestDbContext(
         {
             e.HasKey(i => i.Id);
             e.Property(i => i.Number).HasMaxLength(64).IsRequired();
+            e.Property(i => i.Status).HasMaxLength(32).IsRequired();
+            e.Property(i => i.InternalNote).HasMaxLength(256);
         });
 }
 
@@ -55,9 +60,14 @@ internal sealed class InvoiceQueryDefinition : QueryDefinition<Invoice>
 
     protected override void Configure(QueryDefinitionBuilder<Invoice> builder) =>
         builder
-            .Column(i => i.Number, c => c.Filterable())
-            .Column(i => i.Amount, c => c.Filterable())
-            .Column(i => i.TenantId, c => c.Filterable())  // intentionally exposed: hostile $filter targets this column
+            // Sortable() drives the #3004 $orderby whitelist (AllowedOrderByProperties) —
+            // TenantIsolationTests order by TenantId, so the isolation columns are sortable.
+            .Column(i => i.Number, c => c.Filterable().Sortable())
+            .Column(i => i.Amount, c => c.Filterable().Sortable())
+            .Column(i => i.TenantId, c => c.Filterable().Sortable())  // intentionally exposed: hostile $filter targets this column
+            .Column(i => i.Status, c => c.Filterable())               // filterable but NOT sortable — $orderby=Status must 400
+            .Column(i => i.PaidAt, c => c.Filterable())
+            .Column(i => i.InternalNote)                              // declared but NOT filterable — #3004 strict rejection target
             .DefaultPageSize(50);
 }
 
@@ -83,7 +93,13 @@ internal sealed class InvoiceExportDefinition : ExportDefinition<Invoice>
         builder
             .Field(i => i.Number)
             .Field(i => i.Amount)
-            .Field(i => i.TenantId);
+            .Field(i => i.TenantId)
+            .Field(i => i.Status)
+            .Field(i => i.PaidAt)
+            // EDM-visible but not Filterable() in the QueryDefinition — pins the #3004
+            // breaking change: $filter=InternalNote ... used to pass through ApplyTo
+            // silently, it now 400s from the engine's strict predicate validation.
+            .Field(i => i.InternalNote);
 }
 
 internal sealed class InvoiceEntityDefinition : EntityDefinition<Invoice>

--- a/tests/Granit.Http.ODataExposure.Tests/ODataFilterTranslatorTests.cs
+++ b/tests/Granit.Http.ODataExposure.Tests/ODataFilterTranslatorTests.cs
@@ -1,0 +1,265 @@
+using Granit.Http.ODataExposure.Internal;
+using Granit.QueryEngine.Filtering;
+using Microsoft.OData.Edm;
+using Microsoft.OData.ModelBuilder;
+using Microsoft.OData.UriParser;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Http.ODataExposure.Tests;
+
+/// <summary>
+/// Pins the #3004 <c>$filter</c> → <see cref="QueryPredicate"/> translation matrix: every
+/// supported OData node shape maps to the engine's leaf/composite predicates with the exact
+/// literal stringification the engine's value parser round-trips, and every unsupported shape
+/// is rejected with a distinct, actionable detail (never silently dropped — a vanished leaf
+/// inside OR/NOT would change result semantics).
+/// </summary>
+public sealed class ODataFilterTranslatorTests
+{
+    private static readonly IEdmModel Model = BuildModel();
+
+    private static IEdmModel BuildModel()
+    {
+        ODataConventionModelBuilder builder = new();
+        builder.EntitySet<TranslatorInvoice>("Invoices");
+        return builder.GetEdmModel();
+    }
+
+    private static ODataFilterTranslationResult Translate(string filter)
+    {
+        IEdmEntityType invoiceType = Model.SchemaElements
+            .OfType<IEdmEntityType>()
+            .Single(t => t.Name == nameof(TranslatorInvoice));
+        IEdmEntitySet entitySet = Model.EntityContainer.FindEntitySet("Invoices").ShouldNotBeNull();
+
+        ODataQueryOptionParser parser = new(
+            Model,
+            invoiceType,
+            entitySet,
+            new Dictionary<string, string> { ["$filter"] = filter });
+
+        return ODataFilterTranslator.Translate(parser.ParseFilter());
+    }
+
+    private static FilterCriteria ShouldBeLeaf(ODataFilterTranslationResult result)
+    {
+        result.RejectionDetail.ShouldBeNull(result.RejectionDetail);
+        result.RejectedNodeKind.ShouldBeNull();
+        return result.Predicate.ShouldBeOfType<FilterPredicate>().Criteria;
+    }
+
+    private static void ShouldBeRejected(ODataFilterTranslationResult result, string expectedDetailFragment)
+    {
+        result.Predicate.ShouldBeNull();
+        result.RejectedNodeKind.ShouldNotBeNullOrWhiteSpace();
+        result.RejectionDetail.ShouldNotBeNull();
+        result.RejectionDetail.ShouldContain(expectedDetailFragment, customMessage: result.RejectionDetail);
+    }
+
+    // ── Supported leaves ──────────────────────────────────────────────────
+
+    [Theory]
+    // eq / ne on string
+    [InlineData("Number eq 'A-001'", "Number", FilterOperator.Eq, "A-001")]
+    [InlineData("Number ne 'A-001'", "Number", FilterOperator.Ne, "A-001")]
+    // relational operators on numerics (ConvertNode around the promoted literal is unwrapped)
+    [InlineData("Amount gt 100", "Amount", FilterOperator.Gt, "100")]
+    [InlineData("Amount ge 100.5", "Amount", FilterOperator.Gte, "100.5")]
+    [InlineData("Amount lt 100", "Amount", FilterOperator.Lt, "100")]
+    [InlineData("Amount le 100", "Amount", FilterOperator.Lte, "100")]
+    [InlineData("Priority eq 3", "Priority", FilterOperator.Eq, "3")]
+    // literal-on-the-left comparisons are mirrored
+    [InlineData("100 lt Amount", "Amount", FilterOperator.Gt, "100")]
+    [InlineData("100 ge Amount", "Amount", FilterOperator.Lte, "100")]
+    // booleans
+    [InlineData("Active eq true", "Active", FilterOperator.Eq, "true")]
+    [InlineData("Active ne false", "Active", FilterOperator.Ne, "false")]
+    // Guid — invariant "D" format
+    [InlineData("Id eq 3F2504E0-4F89-11D3-9A0C-0305E82C3301", "Id", FilterOperator.Eq, "3f2504e0-4f89-11d3-9a0c-0305e82c3301")]
+    // DateTimeOffset — round-trip "O" format, exactly what the engine's DateTimeOffset.Parse reads
+    [InlineData("PaidAt ge 2026-01-01T00:00:00Z", "PaidAt", FilterOperator.Gte, "2026-01-01T00:00:00.0000000+00:00")]
+    // Edm.Date — yyyy-MM-dd
+    [InlineData("IssuedOn eq 2026-05-01", "IssuedOn", FilterOperator.Eq, "2026-05-01")]
+    // enum — member name (ODataEnumValue)
+    [InlineData("Status eq 'Paid'", "Status", FilterOperator.Eq, "Paid")]
+    // string functions
+    [InlineData("contains(Number, 'A-')", "Number", FilterOperator.Contains, "A-")]
+    [InlineData("startswith(Number, 'A')", "Number", FilterOperator.StartsWith, "A")]
+    [InlineData("endswith(Number, '1')", "Number", FilterOperator.EndsWith, "1")]
+    // in — comma-joined items
+    [InlineData("Status in ('Paid','Sent')", "Status", FilterOperator.In, "Paid,Sent")]
+    [InlineData("Priority in (1,2,3)", "Priority", FilterOperator.In, "1,2,3")]
+    [InlineData("Number in ('a','b')", "Number", FilterOperator.In, "a,b")]
+    public void Translate_SupportedLeaf_ProducesExpectedCriterion(
+        string filter, string expectedField, FilterOperator expectedOperator, string expectedValue)
+    {
+        FilterCriteria criteria = ShouldBeLeaf(Translate(filter));
+
+        criteria.Field.ShouldBe(expectedField);
+        criteria.Operator.ShouldBe(expectedOperator);
+        criteria.Value.ShouldBe(expectedValue);
+    }
+
+    [Theory]
+    [InlineData("PaidAt eq null", FilterOperator.IsNull)]
+    [InlineData("PaidAt ne null", FilterOperator.IsNotNull)]
+    [InlineData("null eq PaidAt", FilterOperator.IsNull)]
+    [InlineData("null ne PaidAt", FilterOperator.IsNotNull)]
+    public void Translate_NullComparison_ProducesNullCheck(string filter, FilterOperator expectedOperator)
+    {
+        FilterCriteria criteria = ShouldBeLeaf(Translate(filter));
+
+        criteria.Field.ShouldBe("PaidAt");
+        criteria.Operator.ShouldBe(expectedOperator);
+        criteria.Value.ShouldBe(string.Empty);
+    }
+
+    // ── Supported composites ──────────────────────────────────────────────
+
+    [Fact]
+    public void Translate_And_ProducesAndPredicate()
+    {
+        ODataFilterTranslationResult result = Translate("Status eq 'Paid' and Amount gt 100");
+
+        result.RejectionDetail.ShouldBeNull(result.RejectionDetail);
+        AndPredicate and = result.Predicate.ShouldBeOfType<AndPredicate>();
+        and.Operands.Count.ShouldBe(2);
+        ((FilterPredicate)and.Operands[0]).Criteria.Field.ShouldBe("Status");
+        ((FilterPredicate)and.Operands[1]).Criteria.Field.ShouldBe("Amount");
+    }
+
+    [Fact]
+    public void Translate_OrChain_ProducesNestedOrPredicates()
+    {
+        // OData's parser is left-associative: (a or b) or c.
+        ODataFilterTranslationResult result = Translate("Status eq 'Paid' or Status eq 'Sent' or Amount gt 400");
+
+        result.RejectionDetail.ShouldBeNull(result.RejectionDetail);
+        OrPredicate outer = result.Predicate.ShouldBeOfType<OrPredicate>();
+        outer.Operands.Count.ShouldBe(2);
+        OrPredicate inner = outer.Operands[0].ShouldBeOfType<OrPredicate>();
+        ((FilterPredicate)inner.Operands[0]).Criteria.Value.ShouldBe("Paid");
+        ((FilterPredicate)inner.Operands[1]).Criteria.Value.ShouldBe("Sent");
+        ((FilterPredicate)outer.Operands[1]).Criteria.Field.ShouldBe("Amount");
+    }
+
+    [Fact]
+    public void Translate_NotContains_ProducesNotPredicate()
+    {
+        ODataFilterTranslationResult result = Translate("not contains(Number, 'A')");
+
+        result.RejectionDetail.ShouldBeNull(result.RejectionDetail);
+        NotPredicate not = result.Predicate.ShouldBeOfType<NotPredicate>();
+        FilterCriteria criteria = not.Operand.ShouldBeOfType<FilterPredicate>().Criteria;
+        criteria.Operator.ShouldBe(FilterOperator.Contains);
+        criteria.Value.ShouldBe("A");
+    }
+
+    // ── Explicit rejections ───────────────────────────────────────────────
+
+    [Theory]
+    // lambdas
+    [InlineData("Lines/any(l: l/LineAmount gt 5)", "any(")]
+    [InlineData("Lines/all(l: l/LineAmount gt 5)", "all(")]
+    // collection count segment
+    [InlineData("Lines/$count gt 2", "$count")]
+    // arithmetic operators
+    [InlineData("Amount add 5 gt 10", "Arithmetic")]
+    [InlineData("Amount sub 5 gt 10", "Arithmetic")]
+    [InlineData("Amount mul 2 gt 10", "Arithmetic")]
+    [InlineData("Amount div 2 gt 10", "Arithmetic")]
+    [InlineData("Amount mod 2 eq 0", "Arithmetic")]
+    // unary minus
+    [InlineData("-Amount lt 10", "unary minus")]
+    // flag-enum has
+    [InlineData("Status has Granit.Http.ODataExposure.Tests.TranslatorInvoiceStatus'Paid'", "'has'")]
+    // cross-navigation property access
+    [InlineData("Customer/Name eq 'ACME'", "Cross-navigation")]
+    // every other canonical function, each named in the detail
+    [InlineData("tolower(Number) eq 'a'", "'tolower'")]
+    [InlineData("toupper(Number) eq 'A'", "'toupper'")]
+    [InlineData("trim(Number) eq 'a'", "'trim'")]
+    [InlineData("concat(Number, 'x') eq 'ax'", "'concat'")]
+    [InlineData("indexof(Number, 'x') eq 1", "'indexof'")]
+    [InlineData("length(Number) gt 3", "'length'")]
+    [InlineData("substring(Number, 1) eq 'x'", "'substring'")]
+    [InlineData("year(PaidAt) eq 2026", "'year'")]
+    [InlineData("month(PaidAt) eq 7", "'month'")]
+    [InlineData("day(PaidAt) eq 14", "'day'")]
+    [InlineData("date(PaidAt) eq 2026-07-14", "'date'")]
+    [InlineData("time(PaidAt) eq 12:00:00", "'time'")]
+    [InlineData("PaidAt lt now()", "'now'")]
+    [InlineData("round(Amount) eq 100", "'round'")]
+    [InlineData("floor(Amount) eq 100", "'floor'")]
+    [InlineData("ceiling(Amount) eq 100", "'ceiling'")]
+    // in — items the engine's comma-splitting In parser would not round-trip
+    [InlineData("Number in ('a,b')", "comma")]
+    [InlineData("PaidAt in (2026-01-01T00:00:00Z, null)", "null literal cannot appear")]
+    [InlineData("Number in (' padded ')", "whitespace")]
+    // bare boolean property
+    [InlineData("Active", "eq true")]
+    [InlineData("not Active", "eq true")]
+    // no property operand at all
+    [InlineData("2 eq 1", "entity-local property")]
+    public void Translate_UnsupportedConstruct_IsRejectedWithActionableDetail(
+        string filter, string expectedDetailFragment) =>
+        ShouldBeRejected(Translate(filter), expectedDetailFragment);
+
+    [Fact]
+    public void Translate_DynamicProperty_IsRejected()
+    {
+        // TranslatorInvoice is an open type (DynamicProperties dictionary), so an undeclared
+        // name parses to a SingleValueOpenPropertyAccessNode instead of failing EDM lookup.
+        ODataFilterTranslationResult result = Translate("UndeclaredProperty eq 'x'");
+
+        ShouldBeRejected(result, "Dynamic property");
+        result.RejectionDetail.ShouldNotBeNull();
+        result.RejectionDetail.ShouldContain("UndeclaredProperty");
+    }
+
+    [Fact]
+    public void Translate_RejectionShortCircuits_InsideComposite()
+    {
+        // A rejection anywhere in the tree fails the whole translation — a silently dropped
+        // OR branch would widen the result set.
+        ODataFilterTranslationResult result = Translate("Status eq 'Paid' or tolower(Number) eq 'a'");
+
+        ShouldBeRejected(result, "'tolower'");
+    }
+}
+
+/// <summary>Filter-translation test entity — one property per supported literal kind, one navigation, one collection, open-type dictionary for dynamic-property rejection.</summary>
+public sealed class TranslatorInvoice
+{
+    public Guid Id { get; set; }
+    public string Number { get; set; } = string.Empty;
+    public decimal Amount { get; set; }
+    public int Priority { get; set; }
+    public bool Active { get; set; }
+    public TranslatorInvoiceStatus Status { get; set; }
+    public DateTimeOffset? PaidAt { get; set; }
+    public DateOnly? IssuedOn { get; set; }
+    public TranslatorCustomer? Customer { get; set; }
+    public List<TranslatorLine> Lines { get; set; } = [];
+    public IDictionary<string, object?> DynamicProperties { get; set; } = new Dictionary<string, object?>();
+}
+
+public enum TranslatorInvoiceStatus
+{
+    Draft,
+    Sent,
+    Paid,
+}
+
+public sealed class TranslatorCustomer
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+}
+
+public sealed class TranslatorLine
+{
+    public Guid Id { get; set; }
+    public decimal LineAmount { get; set; }
+}


### PR DESCRIPTION
## Summary

Twelfth PR of the [Http* redesign epic](https://github.com/granit-fx/granit-dotnet/issues/2986) — consumes the #3028 QueryPredicate API; `$expand`/`$metadata` hardening follows in #3005.

OData `$filter` is no longer composed by `ApplyTo` on top of the engine's output — it is translated into the strictly-validated `QueryPredicate` tree and enforced **once, in QueryEngine**:

- **`ODataFilterTranslator`** (pure function over the ODL `FilterClause`): and/or/not, eq/ne (null constants → IsNull/IsNotNull), relational ops (literal-on-left mirrored), contains/startswith/endswith, `in` — with literal stringification pinned against `FilterExpressionBuilder.ConvertValue` per type. Everything else is rejected with a distinct, actionable 400 detail: lambdas, arithmetic, cross-navigation access, 16+ canonical functions, dynamic properties (metric reason `filter_not_translatable`).
- **Handler flow**: translate → `BuildFilteredQuery(base, request, predicate)` (`QueryPredicateValidationException` → 400 enumerating every violation, metric `filter_field_rejected`) → `options.Validate` → `ApplyTo(filtered, settings, AllowedQueryOptions.Filter)` — the ignore-flag overload (verified on OData 9.4.1) guarantees the filter is never applied twice; the integration suite pins it at the SQL level via `SqlCaptureSink`.
- **Per-route `ODataValidationSettings`** (cached once per route): explicit allowed-options set (+`SkipToken` so the framework's own `@odata.nextLink` continuations keep working), `AllowedOrderByProperties` derived from the QueryDefinition's sortable columns, `MaxNodeCount=100`, `MaxAnyAllExpressionDepth=1`. MaxTop keeps its existing silent-clamp contract.

⚠️ **Breaking (intended)**: `$filter` on an EDM-visible but non-`Filterable()` column — previously honored silently — now returns 400 with the field name; same for `$orderby` on non-sortable columns and previously-ignored options (`$search`, `$apply`). Every column BI users filter on must be declared `Filterable()` in the QueryDefinition.

## Verification

- Unit 107/107 (22 supported-leaf theory rows, 35 rejections, null-check and composite matrices over a real `ODataQueryOptionParser` EDM).
- Integration extended (11 Power-BI folding shapes, rejection matrix, SQL-capture exactly-once, `TenantIsolationTests` assertions unchanged) — compiled green; **not executed here (no Docker)**, runs in the CI integration shard.
- Architecture shard 279/279; format + markdownlint clean; no lock drift.

Closes #3004 · Feature #2991 · Epic #2986

🤖 Generated with [Claude Code](https://claude.com/claude-code)