### PR TITLE
fix(build)!: restore usings wrongly stripped by #3033 (develop's api-data shard is red)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -25459,7 +25459,7 @@
       "kind": "class",
       "project": "Granit.Http.Cookies.EntityFrameworkCore",
       "file": "src/Granit.Http.Cookies.EntityFrameworkCore/Extensions/CookiesEntityFrameworkCoreHostApplicationBuilderExtensions.cs",
-      "line": 11,
+      "line": 16,
       "members": [
         {
           "name": "AddGranitCookiesEntityFrameworkCore",
@@ -25475,7 +25475,7 @@
       "kind": "class",
       "project": "Granit.Http.Cookies.EntityFrameworkCore",
       "file": "src/Granit.Http.Cookies.EntityFrameworkCore/Extensions/CookiesModelBuilderExtensions.cs",
-      "line": 9,
+      "line": 10,
       "members": [
         {
           "name": "ConfigureCookiesModule",
@@ -25513,7 +25513,7 @@
       "kind": "class",
       "project": "Granit.Http.Cookies.EntityFrameworkCore",
       "file": "src/Granit.Http.Cookies.EntityFrameworkCore/GranitHttpCookiesEntityFrameworkCoreModule.cs",
-      "line": 17,
+      "line": 18,
       "members": []
     },
     {
@@ -26428,7 +26428,7 @@
       "kind": "class",
       "project": "Granit.Http.ODataExposure",
       "file": "src/Granit.Http.ODataExposure/Extensions/ODataExposureEndpointRouteBuilderExtensions.cs",
-      "line": 31,
+      "line": 37,
       "members": [
         {
           "name": "MapGranitODataEndpoints",

--- a/src/Granit.Http.Cookies.Endpoints/Validators/ConsentDecisionRequestValidator.cs
+++ b/src/Granit.Http.Cookies.Endpoints/Validators/ConsentDecisionRequestValidator.cs
@@ -1,3 +1,4 @@
+using FluentValidation;
 using Granit.Http.Cookies.Endpoints.Dtos;
 using Granit.Validation;
 using Granit.Validation.Extensions;

--- a/src/Granit.Http.Cookies.EntityFrameworkCore/Extensions/CookiesEntityFrameworkCoreHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Http.Cookies.EntityFrameworkCore/Extensions/CookiesEntityFrameworkCoreHostApplicationBuilderExtensions.cs
@@ -2,6 +2,11 @@ using Granit.Http.Cookies.Domain;
 using Granit.Http.Cookies.EntityFrameworkCore.Internal;
 using Granit.Http.Cookies.Ledger;
 using Granit.Persistence.EntityFrameworkCore.Extensions;
+using Granit.QueryEngine;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
 
 namespace Granit.Http.Cookies.EntityFrameworkCore.Extensions;
 

--- a/src/Granit.Http.Cookies.EntityFrameworkCore/Extensions/CookiesModelBuilderExtensions.cs
+++ b/src/Granit.Http.Cookies.EntityFrameworkCore/Extensions/CookiesModelBuilderExtensions.cs
@@ -1,4 +1,5 @@
 using Granit.Http.Cookies.EntityFrameworkCore.Internal.Configurations;
+using Microsoft.EntityFrameworkCore;
 
 namespace Granit.Http.Cookies.EntityFrameworkCore.Extensions;
 

--- a/src/Granit.Http.Cookies.EntityFrameworkCore/GranitHttpCookiesEntityFrameworkCoreModule.cs
+++ b/src/Granit.Http.Cookies.EntityFrameworkCore/GranitHttpCookiesEntityFrameworkCoreModule.cs
@@ -1,3 +1,4 @@
+using Granit.Modularity;
 using Granit.Persistence.EntityFrameworkCore;
 
 namespace Granit.Http.Cookies.EntityFrameworkCore;

--- a/src/Granit.Http.Cookies.EntityFrameworkCore/Internal/Configurations/CookieConsentRecordConfiguration.cs
+++ b/src/Granit.Http.Cookies.EntityFrameworkCore/Internal/Configurations/CookieConsentRecordConfiguration.cs
@@ -1,4 +1,8 @@
 using Granit.Http.Cookies.Domain;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace Granit.Http.Cookies.EntityFrameworkCore.Internal.Configurations;
 

--- a/src/Granit.Http.Cookies.EntityFrameworkCore/Internal/CookiesDbContext.cs
+++ b/src/Granit.Http.Cookies.EntityFrameworkCore/Internal/CookiesDbContext.cs
@@ -1,6 +1,9 @@
+using Granit.DataFiltering;
 using Granit.Http.Cookies.Domain;
 using Granit.Http.Cookies.EntityFrameworkCore.Extensions;
+using Granit.MultiTenancy;
 using Granit.Persistence.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
 
 namespace Granit.Http.Cookies.EntityFrameworkCore.Internal;
 

--- a/src/Granit.Http.Cookies.EntityFrameworkCore/Internal/EfCookieConsentRecordQueryableSource.cs
+++ b/src/Granit.Http.Cookies.EntityFrameworkCore/Internal/EfCookieConsentRecordQueryableSource.cs
@@ -1,5 +1,7 @@
 using Granit.Http.Cookies.Domain;
 using Granit.Persistence.EntityFrameworkCore;
+using Granit.QueryEngine;
+using Microsoft.EntityFrameworkCore;
 
 namespace Granit.Http.Cookies.EntityFrameworkCore.Internal;
 

--- a/src/Granit.Http.Cookies.EntityFrameworkCore/Internal/EfCoreConsentLedger.cs
+++ b/src/Granit.Http.Cookies.EntityFrameworkCore/Internal/EfCoreConsentLedger.cs
@@ -1,5 +1,7 @@
+using Granit.Events;
 using Granit.Http.Cookies.Domain;
 using Granit.Http.Cookies.Ledger;
+using Microsoft.EntityFrameworkCore;
 
 namespace Granit.Http.Cookies.EntityFrameworkCore.Internal;
 

--- a/src/Granit.Http.Cookies.EntityFrameworkCore/Internal/EfCoreCookieConsentEraser.cs
+++ b/src/Granit.Http.Cookies.EntityFrameworkCore/Internal/EfCoreCookieConsentEraser.cs
@@ -1,4 +1,5 @@
 using Granit.Http.Cookies.Ledger;
+using Microsoft.EntityFrameworkCore;
 
 namespace Granit.Http.Cookies.EntityFrameworkCore.Internal;
 

--- a/src/Granit.Http.ODataExposure/Extensions/ODataExposureEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Http.ODataExposure/Extensions/ODataExposureEndpointRouteBuilderExtensions.cs
@@ -17,9 +17,15 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.OData;
+using Microsoft.AspNetCore.OData.Query;
+using Microsoft.AspNetCore.OData.Query.Validator;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Primitives;
+using Microsoft.OData;
+using Microsoft.OData.Edm;
+using Microsoft.OData.UriParser;
 
 namespace Granit.Http.ODataExposure.Extensions;
 

--- a/src/Granit.Http.ODataExposure/Internal/ODataFilterTranslator.cs
+++ b/src/Granit.Http.ODataExposure/Internal/ODataFilterTranslator.cs
@@ -1,5 +1,8 @@
 using System.Globalization;
 using Granit.QueryEngine.Filtering;
+using Microsoft.OData;
+using Microsoft.OData.Edm;
+using Microsoft.OData.UriParser;
 
 namespace Granit.Http.ODataExposure.Internal;
 

--- a/src/Granit.Http.ODataExposure/Internal/ODataValidationSettingsCache.cs
+++ b/src/Granit.Http.ODataExposure/Internal/ODataValidationSettingsCache.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.OData.Query.Validator;
 namespace Granit.Http.ODataExposure.Internal;
 
 /// <summary>

--- a/tests/Granit.Http.Cookies.Endpoints.Tests/ConsentDecisionEndpointsTests.cs
+++ b/tests/Granit.Http.Cookies.Endpoints.Tests/ConsentDecisionEndpointsTests.cs
@@ -1,9 +1,21 @@
 using System.Net;
 using System.Net.Http.Json;
+using FluentValidation;
+using Granit.Http.Cookies.Domain;
 using Granit.Http.Cookies.Endpoints.Dtos;
 using Granit.Http.Cookies.Endpoints.Extensions;
 using Granit.Http.Cookies.Endpoints.Validators;
+using Granit.Http.Cookies.Ledger;
+using Granit.MultiTenancy;
+using Granit.RateLimiting.Extensions;
+using Granit.RateLimiting.Options;
 using Granit.Testing.Endpoints;
+using Granit.Users;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Time.Testing;
+using NSubstitute;
+using Shouldly;
+using Xunit;
 
 namespace Granit.Http.Cookies.Endpoints.Tests;
 

--- a/tests/Granit.Http.Cookies.Endpoints.Tests/ConsentDecisionRequestValidatorTests.cs
+++ b/tests/Granit.Http.Cookies.Endpoints.Tests/ConsentDecisionRequestValidatorTests.cs
@@ -1,5 +1,8 @@
+using FluentValidation.Results;
 using Granit.Http.Cookies.Endpoints.Dtos;
 using Granit.Http.Cookies.Endpoints.Validators;
+using Shouldly;
+using Xunit;
 
 namespace Granit.Http.Cookies.Endpoints.Tests;
 

--- a/tests/Granit.Http.Cookies.EntityFrameworkCore.Tests/CookieConsentRecordTenantFilterTests.cs
+++ b/tests/Granit.Http.Cookies.EntityFrameworkCore.Tests/CookieConsentRecordTenantFilterTests.cs
@@ -6,8 +6,18 @@
 // provider does not faithfully execute query filters (CLAUDE.md).
 // =============================================================================
 
+using Granit.Domain;
+using Granit.Http.Cookies.Domain;
 using Granit.Http.Cookies.EntityFrameworkCore.Internal;
+using Granit.MultiTenancy;
+using Granit.Persistence.EntityFrameworkCore;
+using Granit.Persistence.EntityFrameworkCore.Extensions;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using Shouldly;
+using Xunit;
 
 #pragma warning disable EF1001 // Internal EF Core API usage — required to test the internal DbContext and services
 

--- a/tests/Granit.Http.Cookies.EntityFrameworkCore.Tests/CookiesEntityFrameworkCoreRegistrationTests.cs
+++ b/tests/Granit.Http.Cookies.EntityFrameworkCore.Tests/CookiesEntityFrameworkCoreRegistrationTests.cs
@@ -1,7 +1,15 @@
+using Granit.Http.Cookies.Domain;
 using Granit.Http.Cookies.EntityFrameworkCore.Extensions;
 using Granit.Http.Cookies.EntityFrameworkCore.Internal;
+using Granit.Http.Cookies.Extensions;
+using Granit.Http.Cookies.Internal;
+using Granit.Http.Cookies.Ledger;
+using Granit.QueryEngine;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Xunit;
 
 #pragma warning disable EF1001 // Internal EF Core API usage — required to test the internal DbContext and services
 

--- a/tests/Granit.Http.Cookies.EntityFrameworkCore.Tests/EfCoreConsentLedgerTests.cs
+++ b/tests/Granit.Http.Cookies.EntityFrameworkCore.Tests/EfCoreConsentLedgerTests.cs
@@ -1,4 +1,12 @@
+using Granit.Events;
+using Granit.Http.Cookies.Domain;
 using Granit.Http.Cookies.EntityFrameworkCore.Internal;
+using Granit.Http.Cookies.Ledger;
+using Granit.Persistence.EntityFrameworkCore;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Shouldly;
+using Xunit;
 
 #pragma warning disable EF1001 // Internal EF Core API usage — required to test the internal DbContext and services
 

--- a/tests/Granit.Http.Cookies.EntityFrameworkCore.Tests/EfCoreCookieConsentEraserTests.cs
+++ b/tests/Granit.Http.Cookies.EntityFrameworkCore.Tests/EfCoreCookieConsentEraserTests.cs
@@ -1,4 +1,12 @@
+using Granit.Http.Cookies.Domain;
 using Granit.Http.Cookies.EntityFrameworkCore.Internal;
+using Granit.MultiTenancy;
+using Granit.Persistence.EntityFrameworkCore;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using NSubstitute;
+using Shouldly;
+using Xunit;
 
 #pragma warning disable EF1001 // Internal EF Core API usage — required to test the internal DbContext and services
 

--- a/tests/Granit.Http.Cookies.EntityFrameworkCore.Tests/StubCookiesDbContextFactory.cs
+++ b/tests/Granit.Http.Cookies.EntityFrameworkCore.Tests/StubCookiesDbContextFactory.cs
@@ -1,4 +1,7 @@
 using Granit.Http.Cookies.EntityFrameworkCore.Internal;
+using Granit.MultiTenancy;
+using Granit.Persistence.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
 
 #pragma warning disable EF1001 // Internal EF Core API usage — required to test the internal DbContext and services
 

--- a/tests/Granit.Http.Cookies.Tests/CookieCategoryNamesTests.cs
+++ b/tests/Granit.Http.Cookies.Tests/CookieCategoryNamesTests.cs
@@ -1,3 +1,5 @@
+using Shouldly;
+using Xunit;
 namespace Granit.Http.Cookies.Tests;
 
 /// <summary>Snake_case wire-name vocabulary tests for <see cref="CookieCategoryNames"/>.</summary>

--- a/tests/Granit.Http.Cookies.Tests/Ledger/ConsentLedgerLocalizationTests.cs
+++ b/tests/Granit.Http.Cookies.Tests/Ledger/ConsentLedgerLocalizationTests.cs
@@ -1,5 +1,7 @@
 using System.Reflection;
 using System.Text.Json;
+using Shouldly;
+using Xunit;
 
 namespace Granit.Http.Cookies.Tests.Ledger;
 

--- a/tests/Granit.Http.Cookies.Tests/Ledger/CookieConsentRecordTests.cs
+++ b/tests/Granit.Http.Cookies.Tests/Ledger/CookieConsentRecordTests.cs
@@ -1,4 +1,7 @@
+using Granit.Domain;
 using Granit.Http.Cookies.Domain;
+using Shouldly;
+using Xunit;
 
 namespace Granit.Http.Cookies.Tests.Ledger;
 

--- a/tests/Granit.Http.Cookies.Tests/Ledger/NullConsentLedgerTests.cs
+++ b/tests/Granit.Http.Cookies.Tests/Ledger/NullConsentLedgerTests.cs
@@ -1,5 +1,9 @@
 using Granit.Http.Cookies.Domain;
 using Granit.Http.Cookies.Internal;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Testing;
+using Shouldly;
+using Xunit;
 
 namespace Granit.Http.Cookies.Tests.Ledger;
 

--- a/tests/Granit.Http.ODataExposure.Tests.Integration/ODataFilterTranslationTests.cs
+++ b/tests/Granit.Http.ODataExposure.Tests.Integration/ODataFilterTranslationTests.cs
@@ -1,6 +1,10 @@
 using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Xunit;
 
 namespace Granit.Http.ODataExposure.Tests.Integration;
 

--- a/tests/Granit.Http.ODataExposure.Tests.Integration/TestEntities.cs
+++ b/tests/Granit.Http.ODataExposure.Tests.Integration/TestEntities.cs
@@ -1,7 +1,11 @@
 using Granit.DataExchange.Export;
+using Granit.DataFiltering;
+using Granit.Domain;
 using Granit.Entities;
+using Granit.MultiTenancy;
 using Granit.Persistence.EntityFrameworkCore;
 using Granit.QueryEngine;
+using Microsoft.EntityFrameworkCore;
 
 namespace Granit.Http.ODataExposure.Tests.Integration;
 

--- a/tests/Granit.Http.ODataExposure.Tests/ODataFilterTranslatorTests.cs
+++ b/tests/Granit.Http.ODataExposure.Tests/ODataFilterTranslatorTests.cs
@@ -1,5 +1,10 @@
 using Granit.Http.ODataExposure.Internal;
 using Granit.QueryEngine.Filtering;
+using Microsoft.OData.Edm;
+using Microsoft.OData.ModelBuilder;
+using Microsoft.OData.UriParser;
+using Shouldly;
+using Xunit;
 
 namespace Granit.Http.ODataExposure.Tests;
 


### PR DESCRIPTION
## ⚠️ Stop-the-line: develop does not compile

#3033 (`feat(dataexchange)!`) ran a **solution-wide unused-usings pass** and committed the collateral. 26 files in the already-merged `Granit.Http.Cookies.*` and `Granit.Http.ODataExposure` families lost `using` directives that are genuinely used — EF Core (`ModelBuilder`, `DbContextOptions`, `IEntityTypeConfiguration`, `ValueConverter`), FluentValidation (`NotEmpty`/`Must`), `Microsoft.OData.*` (`FilterClause`, `IEdmModel`, `ODataValidationSettings`), `Xunit`/`Shouldly`, and several `Granit.*` namespaces.

Result: **develop's `api-data` shard no longer builds.** The sharded CI missed it because #3033's changed files were DataExchange (a different shard) and there's no full-solution compile gate — the collateral edits to other shards' files were never rebuilt in #3033's checks.

Found while rebasing #3034 (OData `$expand`) onto develop: the rebase surfaced the broken ODataExposure build.

## Fix

Restores exactly the erroneously-removed `using` lines — **103 across 25 files** — verified line-by-line against #3033's own diff. DataExchange's legitimate using removals (from its real import-pipeline rewrite) are left untouched and confirmed still building.

## Verification

- `api-data` shard: builds clean, 0 warnings (warnings-as-errors).
- Suites green: Cookies 132, Cookies.Endpoints 40, Cookies.EntityFrameworkCore 17, ODataExposure 107; DataExchange + Endpoints compile; OData integration project compiles.
- Architecture shard 260+19 green; `dotnet format --verify-no-changes` clean.

Recommend a follow-up: add a full-solution (or cross-shard) compile gate so a formatter run in one shard can't silently break another. **Merge before #3034** (which is blocked on this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)