### PR TITLE
fix(dataexchange): remove duplicate streaming SaveAsync in ImportEndToEndTests (develop red)

### DIFF
--- a/tests/Granit.DataExchange.EntityFrameworkCore.Tests/ImportEndToEndTests.cs
+++ b/tests/Granit.DataExchange.EntityFrameworkCore.Tests/ImportEndToEndTests.cs
@@ -347,7 +347,5 @@ public sealed class ImportEndToEndTests : IDisposable
             _files.Remove(blobReference.Value);
             return Task.CompletedTask;
         }
-
-        public Task<BlobReference> SaveAsync(string fileName, string contentType, Func<Stream, CancellationToken, Task> writeAsync, CancellationToken cancellationToken = default) => throw new NotImplementedException();
     }
 }


### PR DESCRIPTION
## Urgent — develop rouge (CS0111)

#3042 et #3043 ont chacun ajouté la surcharge `SaveAsync` streaming au provider de test local de `ImportEndToEndTests` (pour corriger le break de #3039). Les deux ont mergé → **deux surcharges de même signature** (un stub qui `throw` à côté de la vraie implémentation bufferisée). Git a traité les deux ajouts comme indépendants (pas de conflit textuel), donc develop est passé rouge sur `EntityFrameworkCore.Tests`.

## Fix

Supprime le stub redondant, garde l'implémentation fonctionnelle. Un fichier, test-only, `Build succeeded` confirmé localement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)