### PR TITLE
refactor(openiddict)!: make the EF package data-only, full stack in the bundle (Vague 5)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -2219,7 +2219,7 @@
         "Granit.Encryption",
         "Granit.Identity.Local",
         "Granit.MultiTenancy",
-        "Granit.OpenIddict.Server",
+        "Granit.OpenIddict",
         "Granit.Persistence.EntityFrameworkCore"
       ],
       "framework": "net10.0"
@@ -43256,12 +43256,12 @@
       "kind": "class",
       "project": "Granit.OpenIddict.EntityFrameworkCore",
       "file": "src/Granit.OpenIddict.EntityFrameworkCore/Extensions/OpenIddictEntityFrameworkCoreHostApplicationBuilderExtensions.cs",
-      "line": 28,
+      "line": 27,
       "members": [
         {
-          "name": "AddGranitOpenIddict",
+          "name": "AddGranitOpenIddictEntityFrameworkCore",
           "kind": "method",
-          "signature": "AddGranitOpenIddict(this IHostApplicationBuilder builder, Action<DbContextOptionsBuilder> configure)",
+          "signature": "AddGranitOpenIddictEntityFrameworkCore(this IHostApplicationBuilder builder, Action<DbContextOptionsBuilder> configure)",
           "returnType": "IHostApplicationBuilder"
         }
       ]
@@ -43304,7 +43304,7 @@
       "kind": "class",
       "project": "Granit.OpenIddict.EntityFrameworkCore",
       "file": "src/Granit.OpenIddict.EntityFrameworkCore/GranitOpenIddictEntityFrameworkCoreModule.cs",
-      "line": 33,
+      "line": 32,
       "members": [
         {
           "name": "ConfigureServices",

--- a/src/Granit.OpenIddict.EntityFrameworkCore/Extensions/OpenIddictEntityFrameworkCoreHostApplicationBuilderExtensions.cs
+++ b/src/Granit.OpenIddict.EntityFrameworkCore/Extensions/OpenIddictEntityFrameworkCoreHostApplicationBuilderExtensions.cs
@@ -8,7 +8,6 @@ using Granit.OpenIddict.EntityFrameworkCore.Internal;
 using Granit.OpenIddict.Extensions;
 using Granit.OpenIddict.Models;
 using Granit.OpenIddict.Options;
-using Granit.OpenIddict.Server.Extensions;
 using Granit.Persistence.EntityFrameworkCore.Extensions;
 using Granit.Persistence.EntityFrameworkCore.SharedConnection;
 using Granit.QueryEngine;
@@ -28,13 +27,21 @@ namespace Granit.OpenIddict.EntityFrameworkCore.Extensions;
 public static class OpenIddictEntityFrameworkCoreHostApplicationBuilderExtensions
 {
     /// <summary>
-    /// Registers the complete Granit OpenIddict stack: ASP.NET Core Identity, OpenIddict
-    /// (core + server + validation), and EF Core persistence.
+    /// Registers the persistence + identity layer for OpenIddict: the isolated
+    /// <see cref="OpenIddictDbContext"/>, ASP.NET Core Identity backed by it, OpenIddict Core with
+    /// EF Core stores, the group store and DbContext accessor, the session/device provider, and
+    /// the query engine / export sources for applications and scopes.
     /// </summary>
+    /// <remarks>
+    /// Does NOT wire the OpenIddict server pipeline — that is added on top by
+    /// <c>Granit.Bundle.OpenIddict</c> (<c>AddGranitOpenIddict</c>), so this package carries no
+    /// dependency on <c>Granit.OpenIddict.Server</c>. A migration host or admin tool that needs
+    /// only the schema, stores, and identity can reference this package without the server.
+    /// </remarks>
     /// <param name="builder">The host application builder.</param>
     /// <param name="configure">EF Core provider configuration (e.g. <c>options.UseNpgsql(cs)</c>).</param>
     /// <returns>The builder for chaining.</returns>
-    public static IHostApplicationBuilder AddGranitOpenIddict(
+    public static IHostApplicationBuilder AddGranitOpenIddictEntityFrameworkCore(
         this IHostApplicationBuilder builder,
         Action<DbContextOptionsBuilder> configure)
     {
@@ -54,7 +61,7 @@ public static class OpenIddictEntityFrameworkCoreHostApplicationBuilderExtension
         builder.Services.Configure<GranitLockoutOptions>(
             builder.Configuration.GetSection(GranitLockoutOptions.SectionName));
 
-        // 3. Register ASP.NET Core Identity
+        // 3. Register ASP.NET Core Identity backed by the OpenIddict DbContext.
         builder.Services
             .AddIdentity<LocalIdentity, GranitRole>(options =>
             {
@@ -68,7 +75,7 @@ public static class OpenIddictEntityFrameworkCoreHostApplicationBuilderExtension
             .AddEntityFrameworkStores<OpenIddictDbContext>()
             .AddDefaultTokenProviders();
 
-        // 3. Register OpenIddict Core — EF Core stores
+        // 4. Register OpenIddict Core — EF Core stores
         builder.Services.AddOpenIddict()
             .AddCore(options =>
             {
@@ -88,21 +95,18 @@ public static class OpenIddictEntityFrameworkCoreHostApplicationBuilderExtension
                 }
             });
 
-        // 4. Register OpenIddict Server + Validation (delegated to Granit.OpenIddict.Server)
-        builder.AddGranitOpenIddictServer();
-
-        // 5. Register group store — required by AspNetIdentityProvider
+        // 5. Group store — required by AspNetIdentityProvider.
         builder.Services.TryAddScoped<ILocalIdentityGroupStore, OpenIddictGroupStore>();
 
         // 6. Accessor exposing the scoped OpenIddictDbContext as IIdentityDbContextAccessor —
-        //    consumed by IGranitRoleOrchestrator to share the Identity transaction
-        //    with the host authorization DbContext when both target the same database.
+        //    consumed by IGranitRoleOrchestrator to share the Identity transaction with the host
+        //    authorization DbContext when both target the same database.
         builder.Services.TryAddScoped<IIdentityDbContextAccessor,
             OpenIddictIdentityDbContextAccessor>();
 
-        // 7. Session/device provider for the canonical /sessions + /devices API. Registered here, with
-        //    the authority wiring, so a host cannot enable OpenIddict auth and still silently serve the
-        //    no-op session defaults (the failure mode when GranitOpenIddictModule is absent from the graph).
+        // 7. Session/device provider for the canonical /sessions + /devices API. Registered here so a
+        //    host cannot enable OpenIddict persistence and still silently serve the no-op session
+        //    defaults (the failure mode when GranitOpenIddictModule is absent from the graph).
         builder.Services.AddOpenIddictUserSessionProvider();
 
         // 8. Query engine sources for the identity entities owned by the consolidated

--- a/src/Granit.OpenIddict.EntityFrameworkCore/Granit.OpenIddict.EntityFrameworkCore.csproj
+++ b/src/Granit.OpenIddict.EntityFrameworkCore/Granit.OpenIddict.EntityFrameworkCore.csproj
@@ -30,7 +30,7 @@
     <ProjectReference Include="..\Granit.Encryption\Granit.Encryption.csproj" />
     <ProjectReference Include="..\Granit.Identity.Local\Granit.Identity.Local.csproj" />
     <ProjectReference Include="..\Granit.MultiTenancy\Granit.MultiTenancy.csproj" />
-    <ProjectReference Include="..\Granit.OpenIddict.Server\Granit.OpenIddict.Server.csproj" />
+    <ProjectReference Include="..\Granit.OpenIddict\Granit.OpenIddict.csproj" />
     <ProjectReference Include="..\Granit.Persistence.EntityFrameworkCore\Granit.Persistence.EntityFrameworkCore.csproj" />
   </ItemGroup>
 

--- a/src/Granit.OpenIddict.EntityFrameworkCore/GranitOpenIddictEntityFrameworkCoreModule.cs
+++ b/src/Granit.OpenIddict.EntityFrameworkCore/GranitOpenIddictEntityFrameworkCoreModule.cs
@@ -6,7 +6,6 @@ using Granit.Modularity;
 using Granit.MultiTenancy;
 using Granit.OpenIddict.EntityFrameworkCore.Internal;
 using Granit.OpenIddict.EntityFrameworkCore.Seeding;
-using Granit.OpenIddict.Server;
 using Granit.OpenIddict.Services;
 using Granit.Persistence.EntityFrameworkCore;
 using Granit.Persistence.EntityFrameworkCore.DataSeeding;
@@ -28,7 +27,7 @@ namespace Granit.OpenIddict.EntityFrameworkCore;
     typeof(GranitEncryptionModule),
     typeof(GranitIdentityLocalModule),
     typeof(GranitMultiTenancyModule),
-    typeof(GranitOpenIddictServerModule),
+    typeof(GranitOpenIddictModule),
     typeof(GranitPersistenceEntityFrameworkCoreModule))]
 public sealed class GranitOpenIddictEntityFrameworkCoreModule : GranitModule
 {

--- a/src/Granit.OpenIddict.EntityFrameworkCore/packages.lock.json
+++ b/src/Granit.OpenIddict.EntityFrameworkCore/packages.lock.json
@@ -365,25 +365,10 @@
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
-      "granit.authentication": {
-        "type": "Project",
-        "dependencies": {
-          "Granit": "[0.1.0-dev, )"
-        }
-      },
       "granit.authentication.external": {
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )"
-        }
-      },
-      "granit.authentication.openiddict": {
-        "type": "Project",
-        "dependencies": {
-          "Granit": "[0.1.0-dev, )",
-          "Granit.Authentication": "[0.1.0-dev, )",
-          "OpenIddict.Validation.AspNetCore": "[7.*, )",
-          "OpenIddict.Validation.SystemNetHttp": "[7.*, )"
         }
       },
       "granit.authorization": {
@@ -564,18 +549,6 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
-      "granit.openiddict.server": {
-        "type": "Project",
-        "dependencies": {
-          "Granit.Authentication": "[0.1.0-dev, )",
-          "Granit.Authentication.OpenIddict": "[0.1.0-dev, )",
-          "Granit.Identity.Abstractions": "[0.1.0-dev, )",
-          "Granit.OpenIddict": "[0.1.0-dev, )",
-          "OpenIddict": "[7.*, )",
-          "OpenIddict.Server.AspNetCore": "[7.*, )",
-          "OpenIddict.Validation.AspNetCore": "[7.*, )"
-        }
-      },
       "granit.persistence": {
         "type": "Project",
         "dependencies": {
@@ -693,24 +666,6 @@
         "requested": "[2.7.5, )",
         "resolved": "2.7.5",
         "contentHash": "0FA67RSnRM4tcBKqiqVu/HPdZ9+QOKbmeRjxRUGTCjPU4C0bmUhd97Dso7Yild5P7nOV6GxJ2xrK0Kv/O9xp0w=="
-      },
-      "OpenIddict.Server.AspNetCore": {
-        "type": "CentralTransitive",
-        "requested": "[7.*, )",
-        "resolved": "7.5.0",
-        "contentHash": "dPgoG/y7oJcngY+xILxrp+lgGjrOMIrlt/mQcGKMj/g+QlNW8Xod5ibAMbFIQUUWXGVKd+lZKPMa7wPfioLpTw==",
-        "dependencies": {
-          "OpenIddict.Server": "7.5.0"
-        }
-      },
-      "OpenIddict.Validation.AspNetCore": {
-        "type": "CentralTransitive",
-        "requested": "[7.*, )",
-        "resolved": "7.5.0",
-        "contentHash": "yTHifKNJLe0uH4fotBQcii8XpHYQOwmACXK2aEeAYadxYlysiO67glfxdETzeAfpJ/QM4cG7V2bjXUCZLCHEbg==",
-        "dependencies": {
-          "OpenIddict.Validation": "7.5.0"
-        }
       },
       "OpenIddict.Validation.SystemNetHttp": {
         "type": "CentralTransitive",

--- a/src/bundles/Granit.Bundle.OpenIddict/OpenIddictHostApplicationBuilderExtensions.cs
+++ b/src/bundles/Granit.Bundle.OpenIddict/OpenIddictHostApplicationBuilderExtensions.cs
@@ -1,0 +1,42 @@
+using Granit.OpenIddict.EntityFrameworkCore.Extensions;
+using Granit.OpenIddict.Server.Extensions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Hosting;
+
+namespace Granit.Bundle.OpenIddict;
+
+/// <summary>
+/// Full-stack imperative wiring for the Granit OpenIddict authority.
+/// </summary>
+public static class OpenIddictHostApplicationBuilderExtensions
+{
+    /// <summary>
+    /// Registers the complete Granit OpenIddict authority: EF Core persistence + ASP.NET Core
+    /// Identity (via <c>Granit.OpenIddict.EntityFrameworkCore</c>) and the OpenIddict server +
+    /// validation pipeline (via <c>Granit.OpenIddict.Server</c>).
+    /// </summary>
+    /// <remarks>
+    /// This bundle composes the two halves so a host gets the whole authority in one call. Hosts
+    /// that want only the data layer (e.g. a migration job) can call
+    /// <c>AddGranitOpenIddictEntityFrameworkCore</c> directly, and DPoP sender-constraining is
+    /// opt-in via the <c>Granit.OpenIddict.Server.DPoP</c> package.
+    /// </remarks>
+    /// <param name="builder">The host application builder.</param>
+    /// <param name="configure">EF Core provider configuration (e.g. <c>options.UseNpgsql(cs)</c>).</param>
+    /// <returns>The builder for chaining.</returns>
+    public static IHostApplicationBuilder AddGranitOpenIddict(
+        this IHostApplicationBuilder builder,
+        Action<DbContextOptionsBuilder> configure)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(configure);
+
+        // Persistence + identity (no server dependency).
+        builder.AddGranitOpenIddictEntityFrameworkCore(configure);
+
+        // OpenIddict server + validation pipeline.
+        builder.AddGranitOpenIddictServer();
+
+        return builder;
+    }
+}

--- a/src/bundles/Granit.Bundle.OpenIddict/packages.lock.json
+++ b/src/bundles/Granit.Bundle.OpenIddict/packages.lock.json
@@ -869,7 +869,7 @@
           "Granit.Encryption": "[0.1.0-dev, )",
           "Granit.Identity.Local": "[0.1.0-dev, )",
           "Granit.MultiTenancy": "[0.1.0-dev, )",
-          "Granit.OpenIddict.Server": "[0.1.0-dev, )",
+          "Granit.OpenIddict": "[0.1.0-dev, )",
           "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
           "Microsoft.AspNetCore.Identity.EntityFrameworkCore": "[10.*, )",
           "Microsoft.EntityFrameworkCore": "[10.*, )",

--- a/tests/Granit.ArchitectureTests/packages.lock.json
+++ b/tests/Granit.ArchitectureTests/packages.lock.json
@@ -3600,7 +3600,7 @@
           "Granit.Encryption": "[0.1.0-dev, )",
           "Granit.Identity.Local": "[0.1.0-dev, )",
           "Granit.MultiTenancy": "[0.1.0-dev, )",
-          "Granit.OpenIddict.Server": "[0.1.0-dev, )",
+          "Granit.OpenIddict": "[0.1.0-dev, )",
           "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
           "Microsoft.AspNetCore.Identity.EntityFrameworkCore": "[10.*, )",
           "Microsoft.EntityFrameworkCore": "[10.*, )",

--- a/tests/Granit.OpenIddict.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.OpenIddict.Endpoints.Tests/packages.lock.json
@@ -820,7 +820,7 @@
           "Granit.Encryption": "[0.1.0-dev, )",
           "Granit.Identity.Local": "[0.1.0-dev, )",
           "Granit.MultiTenancy": "[0.1.0-dev, )",
-          "Granit.OpenIddict.Server": "[0.1.0-dev, )",
+          "Granit.OpenIddict": "[0.1.0-dev, )",
           "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
           "Microsoft.AspNetCore.Identity.EntityFrameworkCore": "[10.*, )",
           "Microsoft.EntityFrameworkCore": "[10.*, )",

--- a/tests/Granit.OpenIddict.EntityFrameworkCore.Tests/OpenIddictEfCoreQueryableSourceRegistrationTests.cs
+++ b/tests/Granit.OpenIddict.EntityFrameworkCore.Tests/OpenIddictEfCoreQueryableSourceRegistrationTests.cs
@@ -28,7 +28,7 @@ public sealed class OpenIddictEfCoreQueryableSourceRegistrationTests
             new HostApplicationBuilderSettings { EnvironmentName = Environments.Development });
         // The provider callback is only invoked at context creation, not registration — an
         // empty configure is enough to assert the DI descriptors without an EF provider package.
-        builder.AddGranitOpenIddict(_ => { });
+        builder.AddGranitOpenIddictEntityFrameworkCore(_ => { });
         return builder.Services;
     }
 

--- a/tests/Granit.OpenIddict.EntityFrameworkCore.Tests/packages.lock.json
+++ b/tests/Granit.OpenIddict.EntityFrameworkCore.Tests/packages.lock.json
@@ -526,25 +526,10 @@
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
-      "granit.authentication": {
-        "type": "Project",
-        "dependencies": {
-          "Granit": "[0.1.0-dev, )"
-        }
-      },
       "granit.authentication.external": {
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )"
-        }
-      },
-      "granit.authentication.openiddict": {
-        "type": "Project",
-        "dependencies": {
-          "Granit": "[0.1.0-dev, )",
-          "Granit.Authentication": "[0.1.0-dev, )",
-          "OpenIddict.Validation.AspNetCore": "[7.*, )",
-          "OpenIddict.Validation.SystemNetHttp": "[7.*, )"
         }
       },
       "granit.authorization": {
@@ -732,25 +717,13 @@
           "Granit.Encryption": "[0.1.0-dev, )",
           "Granit.Identity.Local": "[0.1.0-dev, )",
           "Granit.MultiTenancy": "[0.1.0-dev, )",
-          "Granit.OpenIddict.Server": "[0.1.0-dev, )",
+          "Granit.OpenIddict": "[0.1.0-dev, )",
           "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
           "Microsoft.AspNetCore.Identity.EntityFrameworkCore": "[10.*, )",
           "Microsoft.EntityFrameworkCore": "[10.*, )",
           "Microsoft.EntityFrameworkCore.Relational": "[10.*, )",
           "OpenIddict": "[7.*, )",
           "OpenIddict.EntityFrameworkCore": "[7.*, )"
-        }
-      },
-      "granit.openiddict.server": {
-        "type": "Project",
-        "dependencies": {
-          "Granit.Authentication": "[0.1.0-dev, )",
-          "Granit.Authentication.OpenIddict": "[0.1.0-dev, )",
-          "Granit.Identity.Abstractions": "[0.1.0-dev, )",
-          "Granit.OpenIddict": "[0.1.0-dev, )",
-          "OpenIddict": "[7.*, )",
-          "OpenIddict.Server.AspNetCore": "[7.*, )",
-          "OpenIddict.Validation.AspNetCore": "[7.*, )"
         }
       },
       "granit.persistence": {
@@ -926,24 +899,6 @@
           "Microsoft.EntityFrameworkCore.Relational": "10.0.7",
           "OpenIddict.Core": "7.5.0",
           "OpenIddict.EntityFrameworkCore.Models": "7.5.0"
-        }
-      },
-      "OpenIddict.Server.AspNetCore": {
-        "type": "CentralTransitive",
-        "requested": "[7.*, )",
-        "resolved": "7.5.0",
-        "contentHash": "dPgoG/y7oJcngY+xILxrp+lgGjrOMIrlt/mQcGKMj/g+QlNW8Xod5ibAMbFIQUUWXGVKd+lZKPMa7wPfioLpTw==",
-        "dependencies": {
-          "OpenIddict.Server": "7.5.0"
-        }
-      },
-      "OpenIddict.Validation.AspNetCore": {
-        "type": "CentralTransitive",
-        "requested": "[7.*, )",
-        "resolved": "7.5.0",
-        "contentHash": "yTHifKNJLe0uH4fotBQcii8XpHYQOwmACXK2aEeAYadxYlysiO67glfxdETzeAfpJ/QM4cG7V2bjXUCZLCHEbg==",
-        "dependencies": {
-          "OpenIddict.Validation": "7.5.0"
         }
       },
       "OpenIddict.Validation.SystemNetHttp": {

--- a/tests/Granit.OpenIddict.Tests.Integration/Fixtures/OpenIddictTestApplication.cs
+++ b/tests/Granit.OpenIddict.Tests.Integration/Fixtures/OpenIddictTestApplication.cs
@@ -15,6 +15,7 @@ using Granit.OpenIddict.Diagnostics;
 using Granit.OpenIddict.Endpoints.Extensions;
 using Granit.OpenIddict.EntityFrameworkCore.Extensions;
 using Granit.OpenIddict.EntityFrameworkCore.Internal;
+using Granit.OpenIddict.Server.Extensions;
 using Granit.OpenIddict.Tests.Integration.Helpers;
 using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Builder;
@@ -75,9 +76,10 @@ public sealed class OpenIddictTestApplication : IAsyncLifetime
         // worth provisioning for an in-memory integration suite.
         builder.Configuration["OpenIddict:AllowEphemeralKeys"] = "true";
 
-        // 1. Register OpenIddict EF Core + Server + Identity
-        builder.AddGranitOpenIddict(
+        // 1. Register OpenIddict EF Core + Identity, then the server pipeline.
+        builder.AddGranitOpenIddictEntityFrameworkCore(
             options => options.UseNpgsql(_postgres.ConnectionString));
+        builder.AddGranitOpenIddictServer();
 
         // Disable HTTPS requirement — TestServer runs over HTTP in-memory
         builder.Services.AddOpenIddict()

--- a/tests/Granit.OpenIddict.Tests.Integration/packages.lock.json
+++ b/tests/Granit.OpenIddict.Tests.Integration/packages.lock.json
@@ -954,7 +954,7 @@
           "Granit.Encryption": "[0.1.0-dev, )",
           "Granit.Identity.Local": "[0.1.0-dev, )",
           "Granit.MultiTenancy": "[0.1.0-dev, )",
-          "Granit.OpenIddict.Server": "[0.1.0-dev, )",
+          "Granit.OpenIddict": "[0.1.0-dev, )",
           "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
           "Microsoft.AspNetCore.Identity.EntityFrameworkCore": "[10.*, )",
           "Microsoft.EntityFrameworkCore": "[10.*, )",


### PR DESCRIPTION
## Context

Vague 5 of the OpenIddict refonte — removes the inverted `EntityFrameworkCore → Server` dependency. `Granit.OpenIddict.EntityFrameworkCore` referenced `Granit.OpenIddict.Server` purely so its `AddGranitOpenIddict` could delegate to `AddGranitOpenIddictServer()`; a data-layer package pulling in the server pipeline (+ DPoP + validation) is backwards and blocks a data-only host (e.g. a migration job).

Follow-up to #3041 and #3046 (merged).

## Changes

- **The EF package becomes data-only.** Its entry point is now `AddGranitOpenIddictEntityFrameworkCore(builder, configure)`: DbContext, ASP.NET Core Identity (backed by the internal `OpenIddictDbContext`), OpenIddict Core EF stores, group store, DbContext accessor, session provider, and query/export sources — **everything except the server**. Its `ProjectReference` and `[DependsOn]` switch from `Granit.OpenIddict.Server` to the base `Granit.OpenIddict` module.
- **The full-stack `AddGranitOpenIddict(IHostApplicationBuilder, configure)` moves to `Granit.Bundle.OpenIddict`**, composing `AddGranitOpenIddictEntityFrameworkCore` + `AddGranitOpenIddictServer`. The `GranitBuilder` module path still loads the server module transitively via the Endpoints module.
- Integration + registration tests call the two halves directly (they already reference both packages).

## Validation

- Build (EF package now compiles with no `Granit.OpenIddict.Server` reference), locked-mode restore, **architecture shard 262/262** green.
- `Granit.OpenIddict.EntityFrameworkCore.Tests` 35/35.
- The Postgres integration suite (`Granit.OpenIddict.Tests.Integration`) builds against the two explicit calls; it runs in **CI** (Testcontainers).

## Breaking changes

- `AddGranitOpenIddict` moves from `Granit.OpenIddict.EntityFrameworkCore.Extensions` to `Granit.Bundle.OpenIddict`. Data-only hosts call `AddGranitOpenIddictEntityFrameworkCore`; full-stack hosts reference the bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)