### PR TITLE
fix(openiddict): FAPI 2.0 / DPoP correctness (Phase 2B)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -43533,7 +43533,7 @@
       "kind": "class",
       "project": "Granit.OpenIddict",
       "file": "src/Granit.OpenIddict/Options/GranitOpenIddictOptions.cs",
-      "line": 165,
+      "line": 166,
       "members": [
         {
           "name": "WithFapi2Profile",

--- a/src/Granit.Authentication.DPoP/Middleware/DPoPValidationMiddleware.cs
+++ b/src/Granit.Authentication.DPoP/Middleware/DPoPValidationMiddleware.cs
@@ -65,7 +65,9 @@ internal sealed partial class DPoPValidationMiddleware(
         }
 
         // Build the request URI for htu validation
-        string requestUri = $"{context.Request.Scheme}://{context.Request.Host}{context.Request.Path}";
+        // Include PathBase so htu matches behind a path-prefixed ingress (RFC 9449 §4.3): the
+        // client builds htu from the externally-visible URL, which carries the prefix.
+        string requestUri = $"{context.Request.Scheme}://{context.Request.Host}{context.Request.PathBase}{context.Request.Path}";
         string httpMethod = context.Request.Method;
 
         // Access token the proof is presented with — bound via the ath claim (RFC 9449 §4.3).

--- a/src/Granit.OpenIddict.Server.DPoP/Handlers/DPoPTokenBindingHandler.cs
+++ b/src/Granit.OpenIddict.Server.DPoP/Handlers/DPoPTokenBindingHandler.cs
@@ -81,14 +81,16 @@ public sealed partial class DPoPTokenBindingHandler(
             {
                 LogDPoPRequiredFapi2(logger);
                 context.Reject(
-                    error: OpenIddictConstants.Errors.InvalidRequest,
+                    error: InvalidDPoPProof,
                     description: "DPoP proof header is required in FAPI 2.0 profile.");
             }
 
             return;
         }
 
-        string requestUri = $"{request.Scheme}://{request.Host}{request.Path}";
+        // Include PathBase so htu matches behind a path-prefixed ingress (RFC 9449 §4.3): the
+        // client builds htu from the externally-visible URL, which carries the prefix.
+        string requestUri = $"{request.Scheme}://{request.Host}{request.PathBase}{request.Path}";
         DPoPValidationResult result = await validator
             .ValidateAsync(proofJwt, request.Method, requestUri, context.CancellationToken)
             .ConfigureAwait(false);
@@ -97,7 +99,7 @@ public sealed partial class DPoPTokenBindingHandler(
         {
             LogProofRejected(logger, result.Error!);
             context.Reject(
-                error: OpenIddictConstants.Errors.InvalidRequest,
+                error: InvalidDPoPProof,
                 description: $"DPoP proof validation failed: {result.Error}");
             return;
         }
@@ -108,11 +110,24 @@ public sealed partial class DPoPTokenBindingHandler(
             return;
         }
 
+        // Replace, don't append: on refresh_token grants the principal rebuilt from the refresh
+        // token can already carry a cnf claim — appending would emit duplicate Confirmation claims
+        // on the new access token (RFC 9449 §5).
+        ClaimsIdentity identity = principal.Identities.First();
+        foreach (Claim existing in identity.FindAll(OpenIddictConstants.Claims.Confirmation).ToList())
+        {
+            identity.RemoveClaim(existing);
+        }
+
         string cnfJson = JsonSerializer.Serialize(new { jkt = result.JwkThumbprint });
         Claim cnf = new(OpenIddictConstants.Claims.Confirmation, cnfJson, "JSON");
         cnf.SetDestinations(OpenIddictConstants.Destinations.AccessToken);
-        principal.Identities.First().AddClaim(cnf);
+        identity.AddClaim(cnf);
     }
+
+    // RFC 9449 §5 error code for token-endpoint DPoP proof failures. Not exposed as an
+    // OpenIddict constant in this version — pin the RFC literal.
+    private const string InvalidDPoPProof = "invalid_dpop_proof";
 
     [LoggerMessage(
         Level = LogLevel.Warning,

--- a/src/Granit.OpenIddict.Server/Extensions/OpenIddictServerHostApplicationBuilderExtensions.cs
+++ b/src/Granit.OpenIddict.Server/Extensions/OpenIddictServerHostApplicationBuilderExtensions.cs
@@ -102,11 +102,10 @@ public static class OpenIddictServerHostApplicationBuilderExtensions
                 options.RequirePushedAuthorizationRequests();
             }
 
-            // JAR enforcement (RFC 9101): reject unsigned authorization requests.
-            // Mandatory for FAPI 2.0 (set automatically via WithFapi2Profile).
-            // OpenIddict 7.x does not expose a dedicated builder method; enforced via a
-            // custom ValidateAuthorizationRequest event handler that rejects requests
-            // missing a signed 'request' JWT parameter.
+            // JAR enforcement (RFC 9101): reject unsigned authorization requests. This is a
+            // FAPI 1 Advanced requirement and an OPT-IN here (RequireJar) — NOT part of FAPI 2.0,
+            // which mandates PAR (RequirePar) instead. OpenIddict 7.x exposes no dedicated builder
+            // method, so it is enforced via a custom ValidateAuthorizationRequest event handler.
             if (granitOptions.RequireJar)
             {
                 options.AddEventHandler(
@@ -114,8 +113,11 @@ public static class OpenIddictServerHostApplicationBuilderExtensions
                         .CreateBuilder<ValidateAuthorizationRequestContext>()
                         .UseInlineHandler((ValidateAuthorizationRequestContext ctx) =>
                         {
-                            // The 'request' parameter carries the JAR object (RFC 9101 §4).
-                            if (string.IsNullOrEmpty((string?)ctx.Request["request"]))
+                            // The request object arrives inline via 'request' (RFC 9101 §4) or by
+                            // reference via 'request_uri' — including a PAR-pushed request. Accept
+                            // either so RequireJar does not break a PAR flow.
+                            if (string.IsNullOrEmpty((string?)ctx.Request["request"])
+                                && string.IsNullOrEmpty((string?)ctx.Request["request_uri"]))
                             {
                                 ctx.Reject(
                                     error: OpenIddictConstants.Errors.InvalidRequest,

--- a/src/Granit.OpenIddict/Options/GranitOpenIddictOptions.cs
+++ b/src/Granit.OpenIddict/Options/GranitOpenIddictOptions.cs
@@ -98,7 +98,8 @@ public sealed class GranitOpenIddictOptions
     /// requests using a registered key pair.
     /// </para>
     /// <para>
-    /// Required for FAPI 2.0 Security Profile compliance.
+    /// A FAPI 1 Advanced requirement — NOT part of FAPI 2.0, which mandates PAR
+    /// (<see cref="RequirePar"/>) instead. Opt in explicitly; <c>WithFapi2Profile</c> does not set it.
     /// Default: <see langword="false"/> (JAR available but not enforced).
     /// </para>
     /// </remarks>
@@ -175,7 +176,6 @@ public static class GranitOpenIddictOptionsExtensions
     {
         options.EnableFapi2Profile = true;
         options.RequirePar = true;
-        options.RequireJar = true;
         options.UseReferenceTokens = true;
         if (options.SenderConstraining == SenderConstrainingMode.None)
         {

--- a/tests/Granit.OpenIddict.Server.DPoP.Tests/Handlers/DPoPTokenBindingHandlerTests.cs
+++ b/tests/Granit.OpenIddict.Server.DPoP.Tests/Handlers/DPoPTokenBindingHandlerTests.cs
@@ -34,7 +34,7 @@ public sealed class DPoPTokenBindingHandlerTests
     }
 
     [Fact]
-    public async Task NoDPoPHeader_WithFapi2_RejectsAsInvalidRequest()
+    public async Task NoDPoPHeader_WithFapi2_RejectsAsInvalidDPoPProof()
     {
         IDPoPProofValidator validator = Substitute.For<IDPoPProofValidator>();
         DPoPTokenBindingHandler handler = Build(validator, fapi2: true);
@@ -43,7 +43,7 @@ public sealed class DPoPTokenBindingHandlerTests
         await handler.HandleAsync(context);
 
         context.IsRejected.ShouldBeTrue();
-        context.Error.ShouldBe(OpenIddictConstants.Errors.InvalidRequest);
+        context.Error.ShouldBe("invalid_dpop_proof");
     }
 
     [Fact]
@@ -67,7 +67,7 @@ public sealed class DPoPTokenBindingHandlerTests
     }
 
     [Fact]
-    public async Task InvalidProof_RejectsAsInvalidRequest()
+    public async Task InvalidProof_RejectsAsInvalidDPoPProof()
     {
         IDPoPProofValidator validator = Substitute.For<IDPoPProofValidator>();
         validator.ValidateAsync(
@@ -80,8 +80,48 @@ public sealed class DPoPTokenBindingHandlerTests
         await handler.HandleAsync(context);
 
         context.IsRejected.ShouldBeTrue();
-        context.Error.ShouldBe(OpenIddictConstants.Errors.InvalidRequest);
+        context.Error.ShouldBe("invalid_dpop_proof");
         context.Principal!.FindFirst(OpenIddictConstants.Claims.Confirmation).ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task ValidProof_WithExistingCnf_ReplacesNotAppends()
+    {
+        IDPoPProofValidator validator = Substitute.For<IDPoPProofValidator>();
+        validator.ValidateAsync(
+                Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(DPoPValidationResult_Success(Thumbprint));
+
+        DPoPTokenBindingHandler handler = Build(validator, fapi2: true);
+        ProcessSignInContext context = BuildContext(dpopHeader: "fake.proof.jwt");
+        // Simulate a refresh_token grant: the rebuilt principal already carries a stale cnf.
+        context.Principal!.Identities.First().AddClaim(
+            new Claim(OpenIddictConstants.Claims.Confirmation, """{"jkt":"stale-thumbprint"}""", "JSON"));
+
+        await handler.HandleAsync(context);
+
+        var cnfClaims = context.Principal!.FindAll(OpenIddictConstants.Claims.Confirmation).ToList();
+        cnfClaims.Count.ShouldBe(1);
+        using var doc = JsonDocument.Parse(cnfClaims[0].Value);
+        doc.RootElement.GetProperty("jkt").GetString().ShouldBe(Thumbprint);
+    }
+
+    [Fact]
+    public async Task ValidProof_BuildsHtu_IncludingPathBase()
+    {
+        IDPoPProofValidator validator = Substitute.For<IDPoPProofValidator>();
+        validator.ValidateAsync(
+                Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(DPoPValidationResult_Success(Thumbprint));
+
+        DPoPTokenBindingHandler handler = Build(validator, fapi2: true);
+        ProcessSignInContext context = BuildContext(dpopHeader: "fake.proof.jwt", pathBase: "/auth");
+
+        await handler.HandleAsync(context);
+
+        await validator.Received(1).ValidateAsync(
+            "fake.proof.jwt", "POST", "https://auth.example.com/auth/connect/token",
+            Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -112,12 +152,14 @@ public sealed class DPoPTokenBindingHandlerTests
 
     private static ProcessSignInContext BuildContext(
         string? dpopHeader,
-        OpenIddictServerEndpointType endpointType = OpenIddictServerEndpointType.Token)
+        OpenIddictServerEndpointType endpointType = OpenIddictServerEndpointType.Token,
+        string pathBase = "")
     {
         DefaultHttpContext httpContext = new();
         httpContext.Request.Method = "POST";
         httpContext.Request.Scheme = "https";
         httpContext.Request.Host = new HostString("auth.example.com");
+        httpContext.Request.PathBase = pathBase;
         httpContext.Request.Path = "/connect/token";
         if (dpopHeader is not null)
         {

--- a/tests/Granit.OpenIddict.Tests/Options/GranitOpenIddictOptionsTests.cs
+++ b/tests/Granit.OpenIddict.Tests/Options/GranitOpenIddictOptionsTests.cs
@@ -9,4 +9,23 @@ public sealed class GranitOpenIddictOptionsTests
     [Fact]
     public void SectionName_IsOpenIddict() =>
         GranitOpenIddictOptions.SectionName.ShouldBe("OpenIddict");
+
+    [Fact]
+    public void WithFapi2Profile_RequiresPar_And_DPoP()
+    {
+        GranitOpenIddictOptions options = new GranitOpenIddictOptions().WithFapi2Profile();
+
+        options.EnableFapi2Profile.ShouldBeTrue();
+        options.RequirePar.ShouldBeTrue();
+        options.UseReferenceTokens.ShouldBeTrue();
+        options.SenderConstraining.ShouldBe(SenderConstrainingMode.DPoP);
+    }
+
+    [Fact]
+    public void WithFapi2Profile_DoesNotRequireJar()
+    {
+        // FAPI 2.0 mandates PAR, not JAR (JAR is FAPI 1 Advanced). Forcing RequireJar broke
+        // the normal PAR-only flow — clients pushing plain params get no `request` object.
+        new GranitOpenIddictOptions().WithFapi2Profile().RequireJar.ShouldBeFalse();
+    }
 }


### PR DESCRIPTION
## Context

Phase 2B of the OpenIddict refonte — four RFC-conformance defects in the DPoP / FAPI 2.0 path surfaced by the audit. All handler/validator-level (compile + unit verifiable); the Postgres integration suite exercises the flows in CI.

Follow-up to the merged Phase 1 PRs (#3041, #3046, #3047).

## Fixes

- **`invalid_dpop_proof`** (RFC 9449 §5) — the token-binding handler rejected proof failures and a missing FAPI 2.0 proof with `invalid_request`, so clients could not distinguish a malformed request from a bad proof (breaks the nonce-retry loop). Now rejects with `invalid_dpop_proof`.
- **htu PathBase** — the handler and the resource-side `DPoPValidationMiddleware` built `htu` from `Scheme + Host + Path`, dropping `PathBase`, so **every** proof failed `htu` matching behind a path-prefixed ingress. Now includes `PathBase` to match the externally-visible URL the client signs (RFC 9449 §4.3).
- **cnf replace-not-append** — on `refresh_token` grants the rebuilt principal can already carry a `cnf` claim; appending emitted **duplicate** Confirmation claims on the new access token. The handler now removes any existing `cnf` before stamping.
- **JAR is not FAPI 2.0** — `WithFapi2Profile` forced `RequireJar`, so PAR-only clients (the normal FAPI 2.0 flow) that push plain params and send no `request` object were rejected. FAPI 2.0 mandates **PAR**, not JAR (JAR is FAPI 1 Advanced). `WithFapi2Profile` no longer sets `RequireJar`, and when a host opts into `RequireJar` explicitly the handler now also accepts a PAR `request_uri`.

## Validation

- Build, **architecture shard 262/262** green.
- `Granit.OpenIddict.Server.DPoP.Tests` 10/10 (new cnf-replace + PathBase-htu cases, updated error-code assertions), `Granit.Authentication.DPoP.Tests` 76/76, `GranitOpenIddictOptionsTests` (new `WithFapi2Profile` PAR/DPoP-yes, JAR-no coverage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)