### PR TITLE
fix(openiddict): null-is-global multi-tenant query filter (Phase 2E keystone)

### DIFF
--- a/src/Granit.OpenIddict.EntityFrameworkCore/Internal/OpenIddictDbContext.cs
+++ b/src/Granit.OpenIddict.EntityFrameworkCore/Internal/OpenIddictDbContext.cs
@@ -90,8 +90,12 @@ internal sealed class OpenIddictDbContext(
     private void ConfigureMultiTenantFilter<TEntity>(ModelBuilder builder)
         where TEntity : class
     {
+        // null-is-global: a row with TenantId == null belongs to no tenant and is visible
+        // to every tenant (and to anonymous requests). The CurrentTenantId disjunct stays
+        // parameterised (@ef_filter__CurrentTenantId) — see MultiTenantFilterParameterizationReproTests.
         Expression<Func<TEntity, bool>> filter = e =>
             !IsMultiTenantFilterEnabled
+            || EF.Property<Guid?>(e, nameof(IMultiTenant.TenantId)) == null
             || EF.Property<Guid?>(e, nameof(IMultiTenant.TenantId)) == CurrentTenantId;
         builder.Entity<TEntity>()
             .HasQueryFilter(GranitFilterNames.MultiTenant, filter);

--- a/tests/Granit.OpenIddict.EntityFrameworkCore.Tests/Granit.OpenIddict.EntityFrameworkCore.Tests.csproj
+++ b/tests/Granit.OpenIddict.EntityFrameworkCore.Tests/Granit.OpenIddict.EntityFrameworkCore.Tests.csproj
@@ -14,6 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" />
@@ -24,6 +25,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Granit.Http.Cookies\Granit.Http.Cookies.csproj" />
+    <ProjectReference Include="..\..\src\Granit.Testing\Granit.Testing.csproj" />
     <ProjectReference Include="..\..\src\Granit.OpenIddict.EntityFrameworkCore\Granit.OpenIddict.EntityFrameworkCore.csproj" />
   </ItemGroup>
 

--- a/tests/Granit.OpenIddict.EntityFrameworkCore.Tests/OpenIddictMultiTenantFilterTests.cs
+++ b/tests/Granit.OpenIddict.EntityFrameworkCore.Tests/OpenIddictMultiTenantFilterTests.cs
@@ -1,0 +1,157 @@
+using Granit.DataFiltering;
+using Granit.Domain;
+using Granit.OpenIddict.EntityFrameworkCore.Entities;
+using Granit.OpenIddict.EntityFrameworkCore.Internal;
+using Granit.Testing.Fakes;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Shouldly;
+using Xunit;
+
+namespace Granit.OpenIddict.EntityFrameworkCore.Tests;
+
+/// <summary>
+/// The multi-tenant query filter on OpenIddict entities implements <em>null-is-global</em>:
+/// a row with <c>TenantId == null</c> belongs to no tenant and is visible to every tenant
+/// (and to anonymous requests), while a tenant-owned row is invisible to other tenants.
+/// </summary>
+/// <remarks>
+/// Exercised against SQLite so the filter's SQL translation — not merely its expression
+/// tree — is validated. The previous filter (<c>TenantId == CurrentTenantId</c> only, no
+/// null disjunct) hid every global application the moment a tenant scope was active, which
+/// is why consumers disabled the filter ad hoc. See <see cref="OpenIddictDbContext"/>.
+/// </remarks>
+public sealed class OpenIddictMultiTenantFilterTests : IAsyncLifetime
+{
+    private static readonly Guid TenantA = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    private static readonly Guid TenantB = Guid.Parse("22222222-2222-2222-2222-222222222222");
+
+    private readonly FakeCurrentTenant _tenant = new();
+    private readonly MutableDataFilter _dataFilter = new();
+    private SqliteConnection _connection = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        await _connection.OpenAsync(TestContext.Current.CancellationToken);
+        await SeedApplicationsAsync(TestContext.Current.CancellationToken);
+    }
+
+    public async ValueTask DisposeAsync() => await _connection.DisposeAsync();
+
+    [Fact]
+    public async Task GlobalApplication_IsVisible_UnderEveryTenant()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+
+        _tenant.Id = TenantA;
+        await using (OpenIddictDbContext ctx = NewContext())
+        {
+            List<string?> clientIds = await ctx.Set<GranitOpenIddictApplication>()
+                .Select(a => a.ClientId).ToListAsync(ct);
+            clientIds.ShouldBe(["global", "tenant-a"], ignoreOrder: true);
+        }
+
+        _tenant.Id = TenantB;
+        await using (OpenIddictDbContext ctx = NewContext())
+        {
+            List<string?> clientIds = await ctx.Set<GranitOpenIddictApplication>()
+                .Select(a => a.ClientId).ToListAsync(ct);
+            clientIds.ShouldBe(["global", "tenant-b"], ignoreOrder: true);
+        }
+    }
+
+    [Fact]
+    public async Task TenantOwnedApplication_IsInvisible_ToOtherTenant()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+        _tenant.Id = TenantA;
+
+        await using OpenIddictDbContext ctx = NewContext();
+        bool tenantBVisible = await ctx.Set<GranitOpenIddictApplication>()
+            .AnyAsync(a => a.ClientId == "tenant-b", ct);
+
+        tenantBVisible.ShouldBeFalse("tenant B's application must not leak into tenant A's scope");
+    }
+
+    [Fact]
+    public async Task AnonymousRequest_SeesOnlyGlobalApplications()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+        _tenant.Id = null; // no tenant scope
+
+        await using OpenIddictDbContext ctx = NewContext();
+        List<string?> clientIds = await ctx.Set<GranitOpenIddictApplication>()
+            .Select(a => a.ClientId).ToListAsync(ct);
+
+        clientIds.ShouldBe(["global"]);
+    }
+
+    [Fact]
+    public async Task FilterDisabled_SeesAllApplications()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+        _tenant.Id = TenantA;
+        _dataFilter.SetEnabled<IMultiTenant>(false);
+
+        await using OpenIddictDbContext ctx = NewContext();
+        List<string?> clientIds = await ctx.Set<GranitOpenIddictApplication>()
+            .Select(a => a.ClientId).ToListAsync(ct);
+
+        clientIds.ShouldBe(["global", "tenant-a", "tenant-b"], ignoreOrder: true);
+    }
+
+    private OpenIddictDbContext NewContext()
+    {
+        DbContextOptions<OpenIddictDbContext> options =
+            new DbContextOptionsBuilder<OpenIddictDbContext>()
+                .UseSqlite(_connection)
+                .Options;
+        return new OpenIddictDbContext(options, _tenant, _dataFilter);
+    }
+
+    private async Task SeedApplicationsAsync(CancellationToken ct)
+    {
+        // Inserts are not filtered — seed under the disabled filter to keep intent explicit.
+        _dataFilter.SetEnabled<IMultiTenant>(false);
+        await using OpenIddictDbContext ctx = NewContext();
+        await ctx.Database.EnsureCreatedAsync(ct);
+
+        ctx.Set<GranitOpenIddictApplication>().AddRange(
+            new GranitOpenIddictApplication { Id = Guid.NewGuid(), ClientId = "global", TenantId = null },
+            new GranitOpenIddictApplication { Id = Guid.NewGuid(), ClientId = "tenant-a", TenantId = TenantA },
+            new GranitOpenIddictApplication { Id = Guid.NewGuid(), ClientId = "tenant-b", TenantId = TenantB });
+        await ctx.SaveChangesAsync(ct);
+
+        _dataFilter.SetEnabled<IMultiTenant>(true);
+    }
+
+    /// <summary>Minimal mutable <see cref="IDataFilter"/> for toggling the multi-tenant filter in-test.</summary>
+    private sealed class MutableDataFilter : IDataFilter
+    {
+        private readonly Dictionary<Type, bool> _state = [];
+
+        public void SetEnabled<TFilter>(bool enabled) => _state[typeof(TFilter)] = enabled;
+
+        public bool IsEnabled<TFilter>() where TFilter : class =>
+            !_state.TryGetValue(typeof(TFilter), out bool value) || value;
+
+        public IDisposable Disable<TFilter>() where TFilter : class
+        {
+            _state[typeof(TFilter)] = false;
+            return NullScope.Instance;
+        }
+
+        public IDisposable Enable<TFilter>() where TFilter : class
+        {
+            _state[typeof(TFilter)] = true;
+            return NullScope.Instance;
+        }
+
+        private sealed class NullScope : IDisposable
+        {
+            public static readonly NullScope Instance = new();
+            public void Dispose() { }
+        }
+    }
+}

--- a/tests/Granit.OpenIddict.EntityFrameworkCore.Tests/packages.lock.json
+++ b/tests/Granit.OpenIddict.EntityFrameworkCore.Tests/packages.lock.json
@@ -20,6 +20,18 @@
         "resolved": "3.3.4",
         "contentHash": "0k2Jwpc8eq0hjOtX6TxRkHm9clkJ2PAQ3heEHgqIJZcsfdFosC/iyz18nsgTVDDWpID80rC7aiYK7ripx+Qndg=="
       },
+      "Microsoft.EntityFrameworkCore.Sqlite": {
+        "type": "Direct",
+        "requested": "[10.*, )",
+        "resolved": "10.0.10",
+        "contentHash": "kzg9MuQNJvZQxAU+piSkEzc7/1tpW6n1nVSGGMObu2GgxLK8Nf+6fvZundaznTZ+O2KhfPZ8HFNCzMH3PWDUmA==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Sqlite.Core": "10.0.10",
+          "Microsoft.Extensions.DependencyModel": "10.0.10",
+          "SQLitePCLRaw.bundle_e_sqlite3": "2.1.11",
+          "SQLitePCLRaw.core": "2.1.11"
+        }
+      },
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
         "requested": "[18.*, )",
@@ -54,6 +66,22 @@
           "DiffEngine": "11.3.0",
           "EmptyFiles": "4.4.0"
         }
+      },
+      "SQLitePCLRaw.bundle_e_sqlite3": {
+        "type": "Direct",
+        "requested": "[3.0.3, )",
+        "resolved": "3.0.3",
+        "contentHash": "Zt8jmSL5zcDWGk8rmzhWBJ6IRyLWh1yWS04Pg72+GIvo3Ba4E/rG4Y/4l7AWlSEogEbzyKRTCXUAs1v/O7Pkkg==",
+        "dependencies": {
+          "SQLitePCLRaw.config.e_sqlite3": "3.0.3",
+          "SourceGear.sqlite3": "3.50.4.5"
+        }
+      },
+      "SQLitePCLRaw.core": {
+        "type": "Direct",
+        "requested": "[3.0.3, )",
+        "resolved": "3.0.3",
+        "contentHash": "bjm6FY4lZyP+t7GmiuvSM0QXpFihAvyE0Y9O2yibm3g95AAWJPNnHOKVNJGyPTGIKuK7Pr4Wh8Rd8/aOtAclQw=="
       },
       "xunit.runner.visualstudio": {
         "type": "Direct",
@@ -117,6 +145,11 @@
         "resolved": "2.23.0",
         "contentHash": "nWArUZTdU7iqZLycLKWe0TDms48KKGE6pONH2terYNa8REXiqixrMOkf1sk5DHGMaUTqONU2YkS4SAXBhLStgw=="
       },
+      "Microsoft.AspNetCore.TestHost": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "Kks+OpQlP/eWQhnTjkiv0H9kc9Uqa7ieAzNV62yJpZ8Ips/WwpfpwrwZUKzV83CBJaBl5OI7J2XxVVTC8vah/Q=="
+      },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
         "resolved": "6.0.0",
@@ -132,6 +165,14 @@
         "resolved": "18.8.1",
         "contentHash": "Eclse/ZZjr4lmWzZFNN9h/OluhKL+SK/QbUyKUewgX139aGeyMEO/DkMPwuFs2MixvanTnz6891rF8UHDg+W4Q=="
       },
+      "Microsoft.Data.Sqlite.Core": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "TPCs0ldm7AWqcKmp6f/Xr+14sat7hx4rHfRlS4RgCURBH2thEWbAKEyX7cCWr63zVJVOJIJZTg2cBiUXa8ys6g==",
+        "dependencies": {
+          "SQLitePCLRaw.core": "2.1.11"
+        }
+      },
       "Microsoft.EntityFrameworkCore.Abstractions": {
         "type": "Transitive",
         "resolved": "10.0.10",
@@ -141,6 +182,17 @@
         "type": "Transitive",
         "resolved": "10.0.10",
         "contentHash": "2gLDordUCGf3aNOOuqtTbP5mxhiP9nk6TnvGiE3RnqT891O+Zf/qKu1PIREubs1M16A0SImr4vULBfU5BTDs1Q=="
+      },
+      "Microsoft.EntityFrameworkCore.Sqlite.Core": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "YbVWMIouzwTKBiLms8boa7xeRT88wI14R1msv3XExFk9n0/sa8nU7MwDa1CKtfLGMJs7O7QWuS9/xhcQ72AD2A==",
+        "dependencies": {
+          "Microsoft.Data.Sqlite.Core": "10.0.10",
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.10",
+          "Microsoft.Extensions.DependencyModel": "10.0.10",
+          "SQLitePCLRaw.core": "2.1.11"
+        }
       },
       "Microsoft.Extensions.AmbientMetadata.Application": {
         "type": "Transitive",
@@ -156,6 +208,11 @@
         "type": "Transitive",
         "resolved": "10.3.0",
         "contentHash": "g6/S5rhP1XNBqeDa9zKXri/uDKe6gjzSqGsocuySb1OdVm8fz/M9YcWTJsCw5RHF8xIb/B3NgsfBPQF9Emjk3Q=="
+      },
+      "Microsoft.Extensions.DependencyModel": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "rfZA1RjR021RPqSmIPovfz2aOd79TGqJ9BengbjnzIISOVwjLmuSDnhCMmiY/1c6iYvGolQ1iNGzkav0u11XEA=="
       },
       "Microsoft.Extensions.Diagnostics.ExceptionSummarization": {
         "type": "Transitive",
@@ -419,6 +476,27 @@
         "contentHash": "ehTImQ/eUyO07VYW2WvwSmU9rRH200SKJ/3jku9rOkyWE0A2JxNFmAVms8dSn49QLSjmjFRRSgfNyOgr/2PSmA==",
         "dependencies": {
           "Polly.Core": "8.4.2"
+        }
+      },
+      "SourceGear.sqlite3": {
+        "type": "Transitive",
+        "resolved": "3.50.4.5",
+        "contentHash": "UtnipXhJYZKQOQIfpws/msLK7IRhMplE1CZCaZLIQXRnGD474QVpO/J9nMlQQY8NZueGz1aidjoxDRnrC1NT3Q=="
+      },
+      "SQLitePCLRaw.config.e_sqlite3": {
+        "type": "Transitive",
+        "resolved": "3.0.3",
+        "contentHash": "caP/ap0X2fyVmstCXu5ueOmcr2XWAxA2XyKghV7H4bOAFmq3nWcsGl9q44iY1HYG+i8Qr4G9XEqdfti0rV6/ZQ==",
+        "dependencies": {
+          "SQLitePCLRaw.provider.e_sqlite3": "3.0.3"
+        }
+      },
+      "SQLitePCLRaw.provider.e_sqlite3": {
+        "type": "Transitive",
+        "resolved": "3.0.3",
+        "contentHash": "wd+fGvZTrr3BJNe48opSczmC176Okd61ZgoZNQcdvZwkek6to978ccdpcFmNo5GHxCnk29KwT+f+lAZYgfLVZg==",
+        "dependencies": {
+          "SQLitePCLRaw.core": "3.0.3"
         }
       },
       "System.CodeDom": {
@@ -762,6 +840,16 @@
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
+      "granit.testing": {
+        "type": "Project",
+        "dependencies": {
+          "Bogus": "[35.*, )",
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.AspNetCore.Mvc.Testing": "[10.*, )"
+        }
+      },
       "granit.timing": {
         "type": "Project",
         "dependencies": {
@@ -784,6 +872,12 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )"
         }
+      },
+      "Bogus": {
+        "type": "CentralTransitive",
+        "requested": "[35.*, )",
+        "resolved": "35.6.5",
+        "contentHash": "2FGZn+aAVHjmCgClgmGkTDBVZk0zkLvAKGaxEf5JL6b3i9JbHTE4wnuY4vHCuzlCmJdU6VZjgDfHwmYkQF8VAA=="
       },
       "Fido2.AspNet": {
         "type": "CentralTransitive",
@@ -817,6 +911,16 @@
         "contentHash": "/ZV8RMWbWob1ZGsF5f1wVJNNlFLPKCf2ba834PpQiNhirVQ/ksup5SujtuUsvByHEZgv+9dmjC/4Xdi75axmXQ==",
         "dependencies": {
           "Microsoft.EntityFrameworkCore.Relational": "10.0.10"
+        }
+      },
+      "Microsoft.AspNetCore.Mvc.Testing": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.10",
+        "contentHash": "pTWE4RtRbb9sl/U9QjZA5oapEZ01ZEMfRilZvvh55ZW97caTQ2XuAF6sgc+7ojKWBbR2qrcWVo5P80gMPuW/tQ==",
+        "dependencies": {
+          "Microsoft.AspNetCore.TestHost": "10.0.10",
+          "Microsoft.Extensions.DependencyModel": "10.0.10"
         }
       },
       "Microsoft.AspNetCore.OpenApi": {


### PR DESCRIPTION
## Contexte

Refonte `Granit.OpenIddict*` — **Phase 2E (multi-tenancy finie), pierre angulaire : le filtre**.

Le filtre de requête `IMultiTenant` sur `OpenIddictDbContext` était `TenantId == CurrentTenantId` **sans disjonction null**. Une ligne `TenantId == null` (application/scope global — le contrat documenté « null = global ») disparaissait dès qu'un scope tenant était actif. C'est précisément pourquoi les consommateurs **désactivaient le filtre ad hoc** au lieu de s'y fier.

## Changement

Ajout de la disjonction null-is-global :

```csharp
Expression<Func<TEntity, bool>> filter = e =>
    !IsMultiTenantFilterEnabled
    || EF.Property<Guid?>(e, nameof(IMultiTenant.TenantId)) == null
    || EF.Property<Guid?>(e, nameof(IMultiTenant.TenantId)) == CurrentTenantId;
```

- Une ligne `TenantId == null` est visible pour **chaque tenant** et pour les requêtes anonymes.
- Une ligne tenant-owned reste **invisible aux autres tenants**.
- La comparaison `CurrentTenantId` reste **paramétrée** (`@ef_filter__CurrentTenantId`) — pas de constante capturée par closure, conformément au contrat `GranitDbContext` (repro `MultiTenantFilterParameterizationReproTests`).

## Tests

Nouveau `OpenIddictMultiTenantFilterTests` — validé contre **SQLite** (traduction SQL réelle) en instanciant le **vrai** `OpenIddictDbContext` :

- ✅ global visible sous chaque tenant
- ✅ tenant-owned isolé des autres tenants
- ✅ anonyme ne voit que le global
- ✅ filtre désactivé voit tout
- Le test #1 pilote **deux contextes du même type** à travers un switch de tenant → prouve que le cache de modèle ne fige pas la valeur du tenant.

`Granit.OpenIddict.EntityFrameworkCore.Tests` : **39/39** ✓ · `dotnet format --verify-no-changes` clean.

## Suite (PR séparées, Phase 2E)

- Stamping (`TenantId` à la création admin + seeding, réponse admin expose `TenantId`).
- Résolution tenant sur la surface protocole (userinfo, grants 2FA/passkey → fail-closed).
- Retrait des bypasses ad hoc rendus inutiles + garde entity-caching order-proof (`IValidateOptions`).

> ⚠️ Le flow token multi-tenant e2e (Testcontainers/Postgres) validera la chaîne complète en CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)