### PR TITLE
feat(openiddict): stamp owning tenant on OIDC application creation (Phase 2E)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -42995,7 +42995,7 @@
       "kind": "record",
       "project": "Granit.OpenIddict.Endpoints",
       "file": "src/Granit.OpenIddict.Endpoints/Dtos/AdminOidcCreateApplicationRequest.cs",
-      "line": 21,
+      "line": 22,
       "members": []
     },
     {

--- a/src/Granit.OpenIddict.Endpoints/Dtos/AdminOidcCreateApplicationRequest.cs
+++ b/src/Granit.OpenIddict.Endpoints/Dtos/AdminOidcCreateApplicationRequest.cs
@@ -17,6 +17,7 @@ namespace Granit.OpenIddict.Endpoints.Dtos;
 /// <param name="SigningKeyJwk">Public signing key as JWK JSON for <c>private_key_jwt</c> authentication (RFC 7523). Null for shared-secret clients.</param>
 /// <param name="ClientSide">Host/tenant policy enforced at sign-in. Null means no restriction.</param>
 /// <param name="DeviceKind">Device classification for the devices that authenticate through this client (e.g. <c>MobileApp</c>, <c>Tv</c>). Null or omitted means not declared (the session adapters fall back to a redirect-URI/grant heuristic).</param>
+/// <param name="TenantId">Owning tenant. Omit (or <see langword="null"/>) to create a global application, or to inherit the caller's active tenant when the admin API is invoked under a tenant scope. A host administrator (no active tenant) may set this explicitly to provision an application for a specific tenant; a tenant-scoped administrator may only target their own tenant (a mismatch is rejected with 403).</param>
 #pragma warning disable GRSEC003 // ClientSecret is a DTO parameter, not a stored secret
 public sealed record AdminOidcCreateApplicationRequest(
     string ClientId,
@@ -29,5 +30,6 @@ public sealed record AdminOidcCreateApplicationRequest(
     string? ConsentType = null,
     string? SigningKeyJwk = null,
     MultiTenancySides? ClientSide = null,
-    DeviceKind? DeviceKind = null);
+    DeviceKind? DeviceKind = null,
+    Guid? TenantId = null);
 #pragma warning restore GRSEC003

--- a/src/Granit.OpenIddict.Endpoints/Endpoints/AdminOidcEndpoints.cs
+++ b/src/Granit.OpenIddict.Endpoints/Endpoints/AdminOidcEndpoints.cs
@@ -2,6 +2,7 @@ using System.Security.Cryptography;
 using Granit.Domain;
 using Granit.Entities;
 using Granit.Http.Idempotency;
+using Granit.MultiTenancy;
 using Granit.OpenIddict.Endpoints.Dtos;
 using Granit.OpenIddict.Extensions;
 using Granit.OpenIddict.Models;
@@ -47,6 +48,7 @@ internal static class AdminOidcEndpoints
             .WithMetadata(new IdempotentAttribute { Required = false })
             .Produces<AdminOidcApplicationResponse>(StatusCodes.Status201Created)
             .ProducesValidationProblem(StatusCodes.Status422UnprocessableEntity)
+            .ProducesProblem(StatusCodes.Status403Forbidden)
             .RequireAuthorization(OpenIddictPermissions.Applications.Manage);
 
         apps.MapPut("/{clientId}", UpdateApplicationAsync)
@@ -197,11 +199,19 @@ internal static class AdminOidcEndpoints
         return TypedResults.Ok<IReadOnlyList<AdminOidcApplicationResponse>>(results);
     }
 
-    private static async Task<Created<AdminOidcApplicationResponse>> CreateApplicationAsync(
+    private static async Task<Results<Created<AdminOidcApplicationResponse>, ProblemHttpResult>> CreateApplicationAsync(
         AdminOidcCreateApplicationRequest request,
         [FromServices] IOpenIddictApplicationManager applicationManager,
+        [FromServices] ICurrentTenant currentTenant,
         CancellationToken cancellationToken)
     {
+        if (!TryResolveWriteTenant(request.TenantId, currentTenant, out Guid? tenantId))
+        {
+            return TypedResults.Problem(
+                detail: "A tenant-scoped administrator cannot assign an application to a different tenant.",
+                statusCode: StatusCodes.Status403Forbidden);
+        }
+
         var descriptor = new OpenIddictApplicationDescriptor
         {
             ClientId = request.ClientId,
@@ -245,13 +255,48 @@ internal static class AdminOidcEndpoints
 
         object app = await applicationManager.CreateAsync(descriptor, cancellationToken).ConfigureAwait(false);
 
+        // OpenIddict entities implement IMultiTenant but are not audited, so the persistence
+        // interceptor (which stamps only ICreationAuditedObject entities) never assigns their
+        // TenantId — stamp the resolved tenant explicitly. Tokens and authorizations stay global.
+        if (tenantId is not null && app is IMultiTenant granitApp && granitApp.TenantId != tenantId)
+        {
+            granitApp.TenantId = tenantId;
+            await applicationManager.UpdateAsync(app, cancellationToken).ConfigureAwait(false);
+        }
+
         var responseDescriptor = new OpenIddictApplicationDescriptor();
         await applicationManager.PopulateAsync(responseDescriptor, app, cancellationToken).ConfigureAwait(false);
-        Guid? tenantId = app is IMultiTenant granitApp ? granitApp.TenantId : null;
+        Guid? persistedTenantId = app is IMultiTenant persisted ? persisted.TenantId : null;
 
         return TypedResults.Created(
             $"/admin/oidc/applications/{request.ClientId}",
-            ToResponse(responseDescriptor, tenantId));
+            ToResponse(responseDescriptor, persistedTenantId));
+    }
+
+    /// <summary>
+    /// Resolves the owning tenant for a write. An explicit tenant wins in host context
+    /// (no active tenant); otherwise the caller's active tenant is used. A tenant-scoped
+    /// caller that names a <em>different</em> tenant is rejected (cross-tenant provisioning).
+    /// </summary>
+    /// <param name="explicitTenantId">The tenant named on the request, or <see langword="null"/>.</param>
+    /// <param name="currentTenant">The ambient tenant context.</param>
+    /// <param name="resolved">The tenant to stamp (<see langword="null"/> = global) when the call is allowed.</param>
+    /// <returns><see langword="false"/> when the resolution is a forbidden cross-tenant write.</returns>
+    internal static bool TryResolveWriteTenant(
+        Guid? explicitTenantId, ICurrentTenant currentTenant, out Guid? resolved)
+    {
+        Guid? activeTenantId = currentTenant.IsAvailable ? currentTenant.Id : null;
+
+        if (explicitTenantId is not null
+            && activeTenantId is not null
+            && explicitTenantId != activeTenantId)
+        {
+            resolved = null;
+            return false;
+        }
+
+        resolved = explicitTenantId ?? activeTenantId;
+        return true;
     }
 
     private static async Task<Results<NoContent, ProblemHttpResult>> DeleteApplicationAsync(

--- a/tests/Granit.OpenIddict.Endpoints.Tests/AdminOidcTenantResolutionTests.cs
+++ b/tests/Granit.OpenIddict.Endpoints.Tests/AdminOidcTenantResolutionTests.cs
@@ -1,0 +1,71 @@
+using Granit.OpenIddict.Endpoints.Endpoints;
+using Granit.Testing.Fakes;
+using Shouldly;
+using Xunit;
+
+namespace Granit.OpenIddict.Endpoints.Tests;
+
+/// <summary>
+/// The admin write path resolves an OIDC application's owning tenant from the request and the
+/// ambient tenant scope: an explicit tenant is honoured in host context, the active tenant is
+/// inherited otherwise, and a tenant-scoped caller cannot provision for a different tenant.
+/// </summary>
+public sealed class AdminOidcTenantResolutionTests
+{
+    private static readonly Guid TenantA = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    private static readonly Guid TenantB = Guid.Parse("22222222-2222-2222-2222-222222222222");
+
+    [Fact]
+    public void HostContext_NoExplicit_ResolvesGlobal()
+    {
+        bool ok = AdminOidcEndpoints.TryResolveWriteTenant(
+            explicitTenantId: null, HostContext(), out Guid? resolved);
+
+        ok.ShouldBeTrue();
+        resolved.ShouldBeNull();
+    }
+
+    [Fact]
+    public void HostContext_ExplicitTenant_ResolvesThatTenant()
+    {
+        bool ok = AdminOidcEndpoints.TryResolveWriteTenant(
+            explicitTenantId: TenantA, HostContext(), out Guid? resolved);
+
+        ok.ShouldBeTrue();
+        resolved.ShouldBe(TenantA);
+    }
+
+    [Fact]
+    public void TenantScope_NoExplicit_InheritsActiveTenant()
+    {
+        bool ok = AdminOidcEndpoints.TryResolveWriteTenant(
+            explicitTenantId: null, TenantScope(TenantA), out Guid? resolved);
+
+        ok.ShouldBeTrue();
+        resolved.ShouldBe(TenantA);
+    }
+
+    [Fact]
+    public void TenantScope_ExplicitMatchesActive_IsAllowed()
+    {
+        bool ok = AdminOidcEndpoints.TryResolveWriteTenant(
+            explicitTenantId: TenantA, TenantScope(TenantA), out Guid? resolved);
+
+        ok.ShouldBeTrue();
+        resolved.ShouldBe(TenantA);
+    }
+
+    [Fact]
+    public void TenantScope_ExplicitDiffersFromActive_IsForbidden()
+    {
+        bool ok = AdminOidcEndpoints.TryResolveWriteTenant(
+            explicitTenantId: TenantB, TenantScope(TenantA), out Guid? resolved);
+
+        ok.ShouldBeFalse("a tenant-scoped admin must not provision for another tenant");
+        resolved.ShouldBeNull();
+    }
+
+    private static FakeCurrentTenant HostContext() => new();
+
+    private static FakeCurrentTenant TenantScope(Guid tenantId) => new() { Id = tenantId };
+}

--- a/tests/Granit.OpenIddict.Endpoints.Tests/Integration/AdminOidcEndpointsIntegrationTests.cs
+++ b/tests/Granit.OpenIddict.Endpoints.Tests/Integration/AdminOidcEndpointsIntegrationTests.cs
@@ -145,6 +145,51 @@ public sealed class AdminOidcEndpointsIntegrationTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task CreateApplication_ExplicitTenantId_StampsTenantOnEntity()
+    {
+        // CreateAsync leaves TenantId null (OpenIddict entities are not audited, so the
+        // persistence interceptor never stamps them). In host context (NullTenantContext)
+        // the handler must apply the explicitly requested tenant via a follow-up UpdateAsync.
+        var targetTenant = Guid.Parse("33333333-3333-3333-3333-333333333333");
+        GranitOpenIddictApplication createdApp = new() { TenantId = null };
+
+        _server.ApplicationManager.CreateAsync(
+            Arg.Any<OpenIddictApplicationDescriptor>(),
+            Arg.Any<CancellationToken>())
+            .Returns(createdApp);
+#pragma warning disable CA2012 // NSubstitute mock setup intentionally doesn't await ValueTask
+        _server.ApplicationManager
+            .PopulateAsync(Arg.Any<OpenIddictApplicationDescriptor>(), createdApp, Arg.Any<CancellationToken>())
+            .Returns(ci =>
+            {
+                OpenIddictApplicationDescriptor d = ci.ArgAt<OpenIddictApplicationDescriptor>(0);
+                d.ClientId = "tenant-client";
+                d.DisplayName = "Tenant App";
+                d.ApplicationType = "web";
+                return new ValueTask();
+            });
+#pragma warning restore CA2012
+
+        AdminOidcCreateApplicationRequest request =
+            new("tenant-client", "Tenant App", null, "web", TenantId: targetTenant);
+
+        HttpResponseMessage response = await _server.AuthenticatedClient
+            .PostAsJsonAsync("/admin/oidc/applications", request, TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Created);
+
+        // The handler stamped the resolved tenant on the created entity and persisted it.
+        createdApp.TenantId.ShouldBe(targetTenant);
+        await _server.ApplicationManager.Received(1)
+            .UpdateAsync(createdApp, Arg.Any<CancellationToken>());
+
+        AdminOidcApplicationResponse? result = await response.Content
+            .ReadFromJsonAsync<AdminOidcApplicationResponse>(TestContext.Current.CancellationToken);
+        result.ShouldNotBeNull();
+        result.TenantId.ShouldBe(targetTenant);
+    }
+
+    [Fact]
     public async Task CreateApplication_DeclaredDeviceKind_PersistsAndReturnsIt()
     {
         GranitOpenIddictApplication createdApp = new() { TenantId = null };

--- a/tests/Granit.OpenIddict.Endpoints.Tests/Integration/OidcEndpointsTestServer.cs
+++ b/tests/Granit.OpenIddict.Endpoints.Tests/Integration/OidcEndpointsTestServer.cs
@@ -1,4 +1,5 @@
 using FluentValidation;
+using Granit.MultiTenancy;
 using Granit.OpenIddict.Endpoints.Extensions;
 using Granit.OpenIddict.Endpoints.Options;
 using Granit.OpenIddict.Permissions;
@@ -110,6 +111,11 @@ internal sealed class OidcEndpointsTestServer : IAsyncDisposable
         builder.Services.AddSingleton(scopeManager);
         builder.Services.AddSingleton(authorizationManager);
         builder.Services.AddSingleton(tokenManager);
+
+        // Multi-tenancy default: AddGranit<T>() registers NullTenantContext as ICurrentTenant in a
+        // real host. The minimal harness supplies it so tenant-aware admin handlers resolve (host
+        // context = no active tenant → applications created global).
+        builder.Services.AddSingleton<ICurrentTenant>(NullTenantContext.Instance);
 
         // Options
         builder.Services.AddSingleton(Microsoft.Extensions.Options.Options.Create(new OpenIddictEndpointsOptions()));


### PR DESCRIPTION
## Contexte

Refonte `Granit.OpenIddict*` — **Phase 2E (multi-tenancy finie)**, suite du fix de filtre null-is-global (#3049).

**Cause racine découverte** : les entités OpenIddict (`GranitOpenIddictApplication/Scope/Token/Authorization`) implémentent `IMultiTenant`, mais `AuditedEntityInterceptor` ne stampe le `TenantId` que sur les entités `ICreationAuditedObject` — ce que les entités OpenIddict **ne sont pas** (elles étendent les bases OpenIddict, pas la hiérarchie auditée Granit). Résultat : **aucune application créée n'obtenait jamais de `TenantId`** → tous les clients étaient globaux, les clients OIDC per-tenant impossibles à provisionner. Voilà le vrai « TenantId jamais stampé » de l'audit (pas le contexte host).

## Changement

Stamping explicite du tenant propriétaire dans `CreateApplicationAsync`, après `CreateAsync` :

| Requête | Contexte | Résultat |
| --- | --- | --- |
| pas de `TenantId` | tenant actif A | hérite A |
| pas de `TenantId` | host (pas de tenant) | global (`null`) |
| `TenantId = A` | host | A (host admin provisionne pour un tenant) |
| `TenantId = A` | tenant actif A | A |
| `TenantId = B` | tenant actif A | **403** (provisioning cross-tenant refusé) |

**Tokens et authorizations restent globaux** (jamais stampés) — leur isolation découle de l'application (qui porte le `TenantId`) + le subject ; les stamper casserait les flux cross-tenant légitimes (décision du plan de refonte).

La résolution est un helper pur, unit-testé (`TryResolveWriteTenant`). La réponse admin expose déjà `TenantId`. Le test host enregistre désormais le `NullTenantContext` par défaut que `AddGranit<T>()` fournit dans un vrai host.

## Tests

- `TryResolveWriteTenant` — 5 cas (host/tenant × explicite/implicite/cross-tenant).
- Test d'intégration HTTP : chemin d'assignation explicite (entité stampée + `UpdateAsync` persisté + réponse reflète le tenant).
- `Granit.OpenIddict.Endpoints.Tests` : **125/125** ✓ · architecture **262/262** ✓ · `dotnet format --verify-no-changes` clean.

## Suite (PR séparées, Phase 2E)

- Stamping des **scopes** + symétrie `TenantId` dans `AdminOidcScopeResponse`.
- **Seeding** : `TenantId` par app/scope seedé.
- **Résolution tenant sur la surface protocole** (userinfo, grants 2FA/passkey → fail-closed) + retrait des bypasses ad hoc + garde entity-caching order-proof.

> Dépend conceptuellement de #3049 (visibilité null-is-global) mais touche des fichiers disjoints — non empilé, `develop` reste vert indépendamment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)