### PR TITLE
feat(openiddict): seed OIDC applications and scopes with an owning tenant (Phase 2E)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -43571,7 +43571,7 @@
       "kind": "record",
       "project": "Granit.OpenIddict",
       "file": "src/Granit.OpenIddict/Options/GranitOpenIddictSeedingOptions.cs",
-      "line": 39,
+      "line": 40,
       "members": []
     },
     {
@@ -43580,7 +43580,7 @@
       "kind": "record",
       "project": "Granit.OpenIddict",
       "file": "src/Granit.OpenIddict/Options/GranitOpenIddictSeedingOptions.cs",
-      "line": 59,
+      "line": 62,
       "members": []
     },
     {

--- a/src/Granit.OpenIddict.EntityFrameworkCore/Seeding/OpenIddictSeedContributor.cs
+++ b/src/Granit.OpenIddict.EntityFrameworkCore/Seeding/OpenIddictSeedContributor.cs
@@ -1,3 +1,4 @@
+using Granit.Domain;
 using Granit.Identity;
 using Granit.OpenIddict.Extensions;
 using Granit.OpenIddict.Options;
@@ -68,6 +69,7 @@ internal sealed partial class OpenIddictSeedContributor(
         object? existing = await applicationManager.FindByClientIdAsync(descriptor.ClientId, cancellationToken)
             .ConfigureAwait(false);
 
+        object entity;
         if (existing is null)
         {
             var appDescriptor = new OpenIddictApplicationDescriptor
@@ -78,28 +80,51 @@ internal sealed partial class OpenIddictSeedContributor(
 
             PopulateDescriptor(appDescriptor, descriptor);
 
-            await applicationManager.CreateAsync(appDescriptor, cancellationToken).ConfigureAwait(false);
+            entity = await applicationManager.CreateAsync(appDescriptor, cancellationToken).ConfigureAwait(false);
             Log.ApplicationCreated(logger, descriptor.ClientId);
         }
         else
         {
+            entity = existing;
             var appDescriptor = new OpenIddictApplicationDescriptor();
             await applicationManager.PopulateAsync(appDescriptor, existing, cancellationToken)
                 .ConfigureAwait(false);
 
-            // Skip update when values are already up to date — prevents ConcurrencyException
-            // when migrator and API both execute seeders concurrently at startup.
-            if (!ApplicationNeedsUpdate(appDescriptor, descriptor))
+            // Skip the descriptor update when values are already up to date — prevents
+            // ConcurrencyException when migrator and API both run seeders concurrently at
+            // startup. Tenant reconciliation below still runs (it is a separate write).
+            if (ApplicationNeedsUpdate(appDescriptor, descriptor))
+            {
+                PopulateDescriptor(appDescriptor, descriptor);
+
+                await applicationManager.UpdateAsync(existing, appDescriptor, cancellationToken)
+                    .ConfigureAwait(false);
+                Log.ApplicationUpdated(logger, descriptor.ClientId);
+            }
+            else
             {
                 Log.ApplicationUnchanged(logger, descriptor.ClientId);
-                return;
             }
+        }
 
-            PopulateDescriptor(appDescriptor, descriptor);
+        await StampTenantAsync(entity, descriptor.TenantId, descriptor.ClientId, cancellationToken)
+            .ConfigureAwait(false);
+    }
 
-            await applicationManager.UpdateAsync(existing, appDescriptor, cancellationToken)
-                .ConfigureAwait(false);
-            Log.ApplicationUpdated(logger, descriptor.ClientId);
+    /// <summary>
+    /// Reconciles the owning tenant on a seeded application. The tenant is not an OpenIddict
+    /// descriptor field, and OpenIddict entities are not audited, so the persistence interceptor
+    /// never assigns their <c>TenantId</c> — stamp it directly. <see langword="null"/> = global.
+    /// No-op (no write) when the entity already carries the desired tenant.
+    /// </summary>
+    private async Task StampTenantAsync(
+        object entity, Guid? tenantId, string clientId, CancellationToken cancellationToken)
+    {
+        if (entity is IMultiTenant multiTenant && multiTenant.TenantId != tenantId)
+        {
+            multiTenant.TenantId = tenantId;
+            await applicationManager.UpdateAsync(entity, cancellationToken).ConfigureAwait(false);
+            Log.ApplicationTenantStamped(logger, clientId, tenantId);
         }
     }
 
@@ -235,6 +260,7 @@ internal sealed partial class OpenIddictSeedContributor(
         object? existing = await scopeManager.FindByNameAsync(descriptor.Name, cancellationToken)
             .ConfigureAwait(false);
 
+        object entity;
         if (existing is null)
         {
             var scopeDescriptor = new OpenIddictScopeDescriptor
@@ -249,37 +275,49 @@ internal sealed partial class OpenIddictSeedContributor(
                 scopeDescriptor.Resources.Add(resource);
             }
 
-            await scopeManager.CreateAsync(scopeDescriptor, cancellationToken).ConfigureAwait(false);
+            entity = await scopeManager.CreateAsync(scopeDescriptor, cancellationToken).ConfigureAwait(false);
             Log.ScopeCreated(logger, descriptor.Name);
         }
         else
         {
+            entity = existing;
             var scopeDescriptor = new OpenIddictScopeDescriptor();
             await scopeManager.PopulateAsync(scopeDescriptor, existing, cancellationToken)
                 .ConfigureAwait(false);
 
-            // Skip update when values are already up to date — prevents ConcurrencyException
-            // when migrator and API both execute seeders concurrently at startup.
+            // Skip the descriptor update when values are already up to date — prevents
+            // ConcurrencyException when migrator and API both run seeders concurrently at
+            // startup. Tenant reconciliation below still runs (it is a separate write).
             if (scopeDescriptor.DisplayName == descriptor.DisplayName
                 && scopeDescriptor.Description == descriptor.Description
                 && scopeDescriptor.Resources.SetEquals(descriptor.Resources))
             {
                 Log.ScopeUnchanged(logger, descriptor.Name);
-                return;
             }
-
-            scopeDescriptor.DisplayName = descriptor.DisplayName;
-            scopeDescriptor.Description = descriptor.Description;
-
-            scopeDescriptor.Resources.Clear();
-            foreach (string resource in descriptor.Resources)
+            else
             {
-                scopeDescriptor.Resources.Add(resource);
-            }
+                scopeDescriptor.DisplayName = descriptor.DisplayName;
+                scopeDescriptor.Description = descriptor.Description;
 
-            await scopeManager.UpdateAsync(existing, scopeDescriptor, cancellationToken)
-                .ConfigureAwait(false);
-            Log.ScopeUpdated(logger, descriptor.Name);
+                scopeDescriptor.Resources.Clear();
+                foreach (string resource in descriptor.Resources)
+                {
+                    scopeDescriptor.Resources.Add(resource);
+                }
+
+                await scopeManager.UpdateAsync(existing, scopeDescriptor, cancellationToken)
+                    .ConfigureAwait(false);
+                Log.ScopeUpdated(logger, descriptor.Name);
+            }
+        }
+
+        // Reconcile the owning tenant (not an OpenIddict descriptor field; entities are not
+        // audited). null = global — the standard OIDC scopes always resolve here.
+        if (entity is IMultiTenant multiTenant && multiTenant.TenantId != descriptor.TenantId)
+        {
+            multiTenant.TenantId = descriptor.TenantId;
+            await scopeManager.UpdateAsync(entity, cancellationToken).ConfigureAwait(false);
+            Log.ScopeTenantStamped(logger, descriptor.Name, descriptor.TenantId);
         }
     }
 
@@ -321,6 +359,9 @@ internal sealed partial class OpenIddictSeedContributor(
         [LoggerMessage(Level = LogLevel.Debug, Message = "OIDC application '{ClientId}' is already up to date — skipping update.")]
         public static partial void ApplicationUnchanged(ILogger logger, string clientId);
 
+        [LoggerMessage(Level = LogLevel.Debug, Message = "Stamped OIDC application '{ClientId}' with tenant '{TenantId}'.")]
+        public static partial void ApplicationTenantStamped(ILogger logger, string clientId, Guid? tenantId);
+
         [LoggerMessage(Level = LogLevel.Debug, Message = "Created OIDC scope '{ScopeName}'.")]
         public static partial void ScopeCreated(ILogger logger, string scopeName);
 
@@ -329,5 +370,8 @@ internal sealed partial class OpenIddictSeedContributor(
 
         [LoggerMessage(Level = LogLevel.Debug, Message = "OIDC scope '{ScopeName}' is already up to date — skipping update.")]
         public static partial void ScopeUnchanged(ILogger logger, string scopeName);
+
+        [LoggerMessage(Level = LogLevel.Debug, Message = "Stamped OIDC scope '{ScopeName}' with tenant '{TenantId}'.")]
+        public static partial void ScopeTenantStamped(ILogger logger, string scopeName, Guid? tenantId);
     }
 }

--- a/src/Granit.OpenIddict/Options/GranitOpenIddictSeedingOptions.cs
+++ b/src/Granit.OpenIddict/Options/GranitOpenIddictSeedingOptions.cs
@@ -36,6 +36,7 @@ public sealed class GranitOpenIddictSeedingOptions
 /// <param name="ApplicationType">The application type (<c>"web"</c> or <c>"native"</c>). Default: <c>"web"</c>.</param>
 /// <param name="ClientSide">Optional host/tenant policy enforced at sign-in. <see cref="MultiTenancySides.Host"/> = only users with <c>TenantId = null</c> may obtain tokens for this client; <see cref="MultiTenancySides.Tenant"/> = only users with a non-null <c>TenantId</c>; <see cref="MultiTenancySides.Both"/> or <see langword="null"/> = no restriction. Stored on the OIDC application's <c>Properties</c> bag and enforced by <c>ClientSideAuthorizationHandler</c>.</param>
 /// <param name="DeviceKind">Optional device classification for the devices that authenticate through this client (e.g. <see cref="DeviceKind.MobileApp"/>, <see cref="DeviceKind.Tv"/>). Stored on the OIDC application's <c>Properties</c> bag and read by the session adapters so <c>/devices</c> shows an accurate classification. <see langword="null"/> or <see cref="DeviceKind.Unknown"/> = not declared (the adapter falls back to a redirect-URI/grant heuristic).</param>
+/// <param name="TenantId">Owning tenant. <see langword="null"/> (default) seeds a global application visible to every tenant; a value seeds a tenant-owned application. Seeding runs in host context, so an explicit tenant is honoured. The seeder reconciles this on every run.</param>
 public sealed record OidcApplicationSeedDescriptor(
     string ClientId,
     string? ClientSecret,
@@ -47,7 +48,8 @@ public sealed record OidcApplicationSeedDescriptor(
     string? ConsentType = null,
     string? ApplicationType = null,
     MultiTenancySides? ClientSide = null,
-    DeviceKind? DeviceKind = null);
+    DeviceKind? DeviceKind = null,
+    Guid? TenantId = null);
 
 /// <summary>
 /// Describes an OIDC scope to seed.
@@ -56,8 +58,10 @@ public sealed record OidcApplicationSeedDescriptor(
 /// <param name="DisplayName">A human-readable display name.</param>
 /// <param name="Resources">Resources associated with this scope.</param>
 /// <param name="Description">An optional human-readable description.</param>
+/// <param name="TenantId">Owning tenant. <see langword="null"/> (default) seeds a global scope visible to every tenant; a value seeds a tenant-owned scope. The standard OIDC scopes are always global.</param>
 public sealed record OidcScopeSeedDescriptor(
     string Name,
     string DisplayName,
     string[] Resources,
-    string? Description = null);
+    string? Description = null,
+    Guid? TenantId = null);

--- a/tests/Granit.OpenIddict.EntityFrameworkCore.Tests/OpenIddictSeedContributorTests.cs
+++ b/tests/Granit.OpenIddict.EntityFrameworkCore.Tests/OpenIddictSeedContributorTests.cs
@@ -1,4 +1,5 @@
 using Granit.Identity;
+using Granit.OpenIddict.EntityFrameworkCore.Entities;
 using Granit.OpenIddict.EntityFrameworkCore.Seeding;
 using Granit.OpenIddict.Extensions;
 using Granit.OpenIddict.Options;
@@ -6,6 +7,7 @@ using Granit.Persistence.EntityFrameworkCore.DataSeeding;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
 using OpenIddict.Abstractions;
+using Shouldly;
 using Xunit;
 
 namespace Granit.OpenIddict.EntityFrameworkCore.Tests;
@@ -370,5 +372,89 @@ public sealed class OpenIddictSeedContributorTests
             Arg.Any<object>(),
             Arg.Any<OpenIddictApplicationDescriptor>(),
             Arg.Any<CancellationToken>());
+    }
+
+    // -------------------------------------------------------------------------
+    // Tenant stamping — TenantId is not an OpenIddict descriptor field
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task SeedApplicationAsync_WithTenantId_StampsTenantOnCreatedEntity()
+    {
+        var tenant = Guid.Parse("44444444-4444-4444-4444-444444444444");
+        GranitOpenIddictApplication created = new() { TenantId = null };
+
+        _appManager.FindByClientIdAsync("tenant-client", Arg.Any<CancellationToken>())
+            .Returns((object?)null);
+        _appManager.CreateAsync(Arg.Any<OpenIddictApplicationDescriptor>(), Arg.Any<CancellationToken>())
+            .Returns(created);
+
+        OidcApplicationSeedDescriptor app = new(
+            ClientId: "tenant-client",
+            ClientSecret: null,
+            DisplayName: "Tenant Client",
+            Permissions: [],
+            RedirectUris: [],
+            PostLogoutRedirectUris: [],
+            TenantId: tenant);
+
+        OpenIddictSeedContributor contributor = CreateContributor(apps: [app]);
+        await contributor.SeedAsync(Ctx, TestContext.Current.CancellationToken);
+
+        created.TenantId.ShouldBe(tenant);
+        await _appManager.Received(1).UpdateAsync(created, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task SeedApplicationAsync_GlobalApplication_DoesNotStampOrUpdate()
+    {
+        GranitOpenIddictApplication created = new() { TenantId = null };
+
+        _appManager.FindByClientIdAsync("global-client", Arg.Any<CancellationToken>())
+            .Returns((object?)null);
+        _appManager.CreateAsync(Arg.Any<OpenIddictApplicationDescriptor>(), Arg.Any<CancellationToken>())
+            .Returns(created);
+
+        OidcApplicationSeedDescriptor app = new(
+            ClientId: "global-client",
+            ClientSecret: null,
+            DisplayName: "Global Client",
+            Permissions: [],
+            RedirectUris: [],
+            PostLogoutRedirectUris: []); // TenantId defaults to null (global)
+
+        OpenIddictSeedContributor contributor = CreateContributor(apps: [app]);
+        await contributor.SeedAsync(Ctx, TestContext.Current.CancellationToken);
+
+        created.TenantId.ShouldBeNull();
+        await _appManager.DidNotReceive().UpdateAsync(created, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task SeedScopeAsync_WithTenantId_StampsTenantOnCreatedEntity()
+    {
+        var tenant = Guid.Parse("55555555-5555-5555-5555-555555555555");
+        GranitOpenIddictScope created = new() { TenantId = null };
+
+        // Every scope (standard + configured) is not found → create path; the configured scope's
+        // CreateAsync returns our tenant-owned entity so we can assert the stamp.
+        _scopeManager.FindByNameAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns((object?)null);
+        _scopeManager.CreateAsync(
+                Arg.Is<OpenIddictScopeDescriptor>(d => d.Name == "tenant-scope"),
+                Arg.Any<CancellationToken>())
+            .Returns(created);
+
+        OidcScopeSeedDescriptor scope = new(
+            Name: "tenant-scope",
+            DisplayName: "Tenant Scope",
+            Resources: [],
+            TenantId: tenant);
+
+        OpenIddictSeedContributor contributor = CreateContributor(scopes: [scope]);
+        await contributor.SeedAsync(Ctx, TestContext.Current.CancellationToken);
+
+        created.TenantId.ShouldBe(tenant);
+        await _scopeManager.Received(1).UpdateAsync(created, Arg.Any<CancellationToken>());
     }
 }


### PR DESCRIPTION
## Contexte

Refonte `Granit.OpenIddict*` — **Phase 2E (multi-tenancy finie)**. Suite de #3049 (filtre null-is-global) et #3050 (stamping admin). Ce PR couvre le **seeding**.

Les descriptors de seed ne portaient aucun tenant, et `TenantId` n'est pas un champ de descriptor OpenIddict → **toute application/scope seedé était global**. Un host multi-tenant ne pouvait pas provisionner déclarativement un client tenant-owned au démarrage.

## Changement

- `OidcApplicationSeedDescriptor` et `OidcScopeSeedDescriptor` gagnent un `Guid? TenantId = null` optionnel (défaut = global).
- Après l'upsert du manager, le seeder **stampe le tenant directement sur l'entité** (les entités OpenIddict ne sont pas auditées → l'intercepteur de persistance ne les stampe jamais, cf. #3050).
- **Réconcilié à chaque run**, et **no-op** (aucune écriture supplémentaire) quand l'entité porte déjà le tenant voulu → le cas global courant (tous les scopes OIDC standard) reste un seul aller-retour.
- Tokens et authorizations restent globaux.

## Tests

- Application tenant-owned créée → stampée + `UpdateAsync` persisté.
- Application globale → **pas** stampée (aucune écriture).
- Scope tenant-owned → stampé.
- `Granit.OpenIddict.EntityFrameworkCore.Tests` : **38/38** ✓ · base `Granit.OpenIddict.Tests` : **261/261** ✓ · `dotnet format` clean.

## Suite (Phase 2E)

- Stamping **admin des scopes** + symétrie `TenantId` dans `AdminOidcScopeResponse` (réutilise `TryResolveWriteTenant` de #3050 — à faire une fois #3050 mergé pour éviter l'empilement).
- Résolution tenant sur la surface protocole (userinfo, grants 2FA/passkey → fail-closed) + retrait des bypasses ad hoc + garde entity-caching order-proof.

> Indépendant de #3049/#3050 (fichiers disjoints : package EFCore seeding + base options) — non empilé.

🤖 Generated with [Claude Code](https://claude.com/claude-code)