### PR TITLE
fix(openiddict): centralize protocol-surface user resolution; fix userinfo/2FA/passkey tenant fail-closed (Phase 2E)

### DIFF
--- a/src/Granit.OpenIddict.Endpoints/Endpoints/ConnectAuthorizationEndpoints.cs
+++ b/src/Granit.OpenIddict.Endpoints/Endpoints/ConnectAuthorizationEndpoints.cs
@@ -1,10 +1,10 @@
 using System.Collections.Immutable;
 using System.Security.Claims;
 using Granit.DataFiltering;
-using Granit.Domain;
 using Granit.Identity.Local.Domain;
 using Granit.MultiTenancy;
 using Granit.OpenIddict.Diagnostics;
+using Granit.OpenIddict.Endpoints.Internal;
 using Granit.OpenIddict.Endpoints.Options;
 using Granit.OpenIddict.Services;
 using Microsoft.AspNetCore;
@@ -113,20 +113,17 @@ internal static partial class ConnectAuthorizationEndpoints
         // hide the user whenever their TenantId does not match the active scope —
         // host admins (TenantId = null) in particular become invisible on every
         // request that has inherited a tenant context from another source.
+        // Resolve the user with the multi-tenant filter disabled (globally-unique id, already
+        // authenticated by cookie) and align the tenant scope to the user for the rest of the flow
+        // (authorization-record lookup, principal build, metrics). See OidcUserTenantResolver.
         UserManager<LocalIdentity> userManager = context.RequestServices
             .GetRequiredService<UserManager<LocalIdentity>>();
         IDataFilter? dataFilter = context.RequestServices.GetService<IDataFilter>();
+        ICurrentTenant? requestTenant = context.RequestServices.GetService<ICurrentTenant>();
 
-        LocalIdentity? user;
-        IDisposable? filterScope = dataFilter?.Disable<IMultiTenant>();
-        try
-        {
-            user = await userManager.GetUserAsync(authenticateResult.Principal).ConfigureAwait(false);
-        }
-        finally
-        {
-            filterScope?.Dispose();
-        }
+        LocalIdentity? user = await OidcUserTenantResolver
+            .FindByPrincipalAsync(userManager, authenticateResult.Principal, dataFilter)
+            .ConfigureAwait(false);
 
         if (user is null)
         {
@@ -139,12 +136,9 @@ internal static partial class ConnectAuthorizationEndpoints
             return Results.Redirect(BuildLoginRedirectUrl(context, request, options));
         }
 
-        // Align the tenant context with the resolved user for the rest of the flow
-        // (authorization-record lookup, principal build, metrics). When the user is
-        // a host admin (TenantId = null) this clears any stale tenant leaked from
-        // a prior request; when the user is a tenant user this switches the scope
-        // to their own tenant regardless of what the resolver pipeline produced.
-        ICurrentTenant? requestTenant = context.RequestServices.GetService<ICurrentTenant>();
+        // Align the tenant scope to the resolved user for the rest of the flow (authorization-record
+        // lookup, principal build, metrics). Opened here (not in the resolver) because ICurrentTenant
+        // is AsyncLocal-backed; a host user (TenantId null) clears any stale leaked scope.
         using IDisposable? tenantScope = requestTenant?.Change(user.TenantId);
 
         // Build the principal with requested scopes.

--- a/src/Granit.OpenIddict.Endpoints/Endpoints/ConnectTokenEndpoints.cs
+++ b/src/Granit.OpenIddict.Endpoints/Endpoints/ConnectTokenEndpoints.cs
@@ -3,10 +3,12 @@ using System.Diagnostics;
 using System.Security.Claims;
 using Granit.Auditing;
 using Granit.Auditing.Domain;
+using Granit.DataFiltering;
 using Granit.Identity.Local.Domain;
 using Granit.Identity.Local.Services;
 using Granit.MultiTenancy;
 using Granit.OpenIddict.Diagnostics;
+using Granit.OpenIddict.Endpoints.Internal;
 using Granit.OpenIddict.Services;
 using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Authentication;
@@ -245,7 +247,14 @@ internal static partial class ConnectTokenEndpoints
                 authenticationSchemes: [OpenIddictServerAspNetCoreDefaults.AuthenticationScheme]);
         }
 
-        LocalIdentity? user = await userManager.FindByNameAsync(username).ConfigureAwait(false);
+        // Resolve with the multi-tenant filter disabled, then align the scope to the user so the
+        // recovery-code redemption and token verification below run under the user's own tenant.
+        IDataFilter? dataFilter = context.RequestServices.GetService<IDataFilter>();
+        ICurrentTenant? currentTenant = context.RequestServices.GetService<ICurrentTenant>();
+
+        LocalIdentity? user = await OidcUserTenantResolver
+            .FindByUserNameAsync(userManager, username, dataFilter)
+            .ConfigureAwait(false);
         if (user is null)
         {
             LogUserNotFound(logger, username);
@@ -256,6 +265,11 @@ internal static partial class ConnectTokenEndpoints
             return Results.Forbid(
                 authenticationSchemes: [OpenIddictServerAspNetCoreDefaults.AuthenticationScheme]);
         }
+
+        // Align the scope to the user so the recovery-code redemption and token verification below
+        // run under the user's own tenant. Opened here (not in the resolver) because ICurrentTenant
+        // is AsyncLocal-backed.
+        using IDisposable? tenantScope = currentTenant?.Change(user.TenantId);
 
         bool valid;
         if (useRecoveryCode)
@@ -360,8 +374,12 @@ internal static partial class ConnectTokenEndpoints
 
         UserManager<LocalIdentity> userManager = context.RequestServices
             .GetRequiredService<UserManager<LocalIdentity>>();
+        IDataFilter? dataFilter = context.RequestServices.GetService<IDataFilter>();
+        ICurrentTenant? currentTenant = context.RequestServices.GetService<ICurrentTenant>();
 
-        LocalIdentity? user = await userManager.FindByIdAsync(assertion.UserId).ConfigureAwait(false);
+        LocalIdentity? user = await OidcUserTenantResolver
+            .FindBySubjectAsync(userManager, assertion.UserId, dataFilter)
+            .ConfigureAwait(false);
         if (user is null)
         {
             LogUserNotFound(logger, assertion.UserId);
@@ -372,6 +390,10 @@ internal static partial class ConnectTokenEndpoints
             return Results.Forbid(
                 authenticationSchemes: [OpenIddictServerAspNetCoreDefaults.AuthenticationScheme]);
         }
+
+        // Align the scope to the user for the principal build. Opened here (not in the resolver)
+        // because ICurrentTenant is AsyncLocal-backed.
+        using IDisposable? tenantScope = currentTenant?.Change(user.TenantId);
 
         ImmutableArray<string> scopes = request.GetScopes();
         IOidcPrincipalFactory principalFactory = context.RequestServices.GetRequiredService<IOidcPrincipalFactory>();

--- a/src/Granit.OpenIddict.Endpoints/Endpoints/ConnectUserInfoEndpoints.cs
+++ b/src/Granit.OpenIddict.Endpoints/Endpoints/ConnectUserInfoEndpoints.cs
@@ -1,6 +1,9 @@
 using System.Collections.Immutable;
 using System.Security.Claims;
+using Granit.DataFiltering;
 using Granit.Identity.Local.Domain;
+using Granit.MultiTenancy;
+using Granit.OpenIddict.Endpoints.Internal;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
@@ -48,15 +51,27 @@ internal static class ConnectUserInfoEndpoints
                 authenticationSchemes: [OpenIddictServerAspNetCoreDefaults.AuthenticationScheme]);
         }
 
+        // Resolve the user with the multi-tenant filter disabled, then align the tenant scope to
+        // the user. userinfo is called by a resource server with no tenant middleware, so a bare
+        // lookup would fail closed for every tenant user (and leak nothing for host users).
         UserManager<LocalIdentity> userManager = context.RequestServices
             .GetRequiredService<UserManager<LocalIdentity>>();
-        LocalIdentity? user = await userManager.FindByIdAsync(subject).ConfigureAwait(false);
+        IDataFilter? dataFilter = context.RequestServices.GetService<IDataFilter>();
+        ICurrentTenant? currentTenant = context.RequestServices.GetService<ICurrentTenant>();
+
+        LocalIdentity? user = await OidcUserTenantResolver
+            .FindBySubjectAsync(userManager, subject, dataFilter)
+            .ConfigureAwait(false);
 
         if (user is null)
         {
             return Results.Forbid(
                 authenticationSchemes: [OpenIddictServerAspNetCoreDefaults.AuthenticationScheme]);
         }
+
+        // Align the tenant scope to the resolved user for the rest of the request. Opened here (not
+        // inside the resolver) because ICurrentTenant is AsyncLocal-backed.
+        using IDisposable? tenantScope = currentTenant?.Change(user.TenantId);
 
         // Build claims based on granted scopes.
         ImmutableArray<string> scopes = principal.GetScopes();

--- a/src/Granit.OpenIddict.Endpoints/Endpoints/ConnectVerifyEndpoints.cs
+++ b/src/Granit.OpenIddict.Endpoints/Endpoints/ConnectVerifyEndpoints.cs
@@ -1,8 +1,9 @@
 using System.Collections.Immutable;
 using System.Security.Claims;
 using Granit.DataFiltering;
-using Granit.Domain;
 using Granit.Identity.Local.Domain;
+using Granit.MultiTenancy;
+using Granit.OpenIddict.Endpoints.Internal;
 using Granit.OpenIddict.Endpoints.Options;
 using Granit.OpenIddict.Services;
 using Microsoft.AspNetCore;
@@ -111,22 +112,17 @@ internal static partial class ConnectVerifyEndpoints
             return Results.Redirect(loginUrl);
         }
 
-        // Resolve the user — bypass the multi-tenant filter: the authenticated user ID is globally
-        // unique and the cookie signature already guarantees authenticity.
+        // Resolve the user with the multi-tenant filter disabled (globally-unique id, already
+        // authenticated by cookie) and align the tenant scope to the user for the principal build
+        // and sign-in that follow. See OidcUserTenantResolver.
         UserManager<LocalIdentity> userManager = context.RequestServices
             .GetRequiredService<UserManager<LocalIdentity>>();
         IDataFilter? dataFilter = context.RequestServices.GetService<IDataFilter>();
+        ICurrentTenant? currentTenant = context.RequestServices.GetService<ICurrentTenant>();
 
-        LocalIdentity? user;
-        IDisposable? filterScope = dataFilter?.Disable<IMultiTenant>();
-        try
-        {
-            user = await userManager.GetUserAsync(identityResult.Principal).ConfigureAwait(false);
-        }
-        finally
-        {
-            filterScope?.Dispose();
-        }
+        LocalIdentity? user = await OidcUserTenantResolver
+            .FindByPrincipalAsync(userManager, identityResult.Principal, dataFilter)
+            .ConfigureAwait(false);
 
         if (user is null)
         {
@@ -135,6 +131,10 @@ internal static partial class ConnectVerifyEndpoints
             string verifyReturnUrl = $"{options.DeviceVerificationPath}?user_code={Uri.EscapeDataString(userCode)}";
             return Results.Redirect($"{options.LoginPath}?returnUrl={Uri.EscapeDataString(verifyReturnUrl)}");
         }
+
+        // Align the tenant scope to the resolved user for the principal build and sign-in that
+        // follow. Opened here (not in the resolver) because ICurrentTenant is AsyncLocal-backed.
+        using IDisposable? tenantScope = currentTenant?.Change(user.TenantId);
 
         // Build a principal from the authenticated user with the device authorization's requested scopes.
         // The principal from oidcResult carries the scopes originally requested by the device.

--- a/src/Granit.OpenIddict.Endpoints/Internal/OidcUserTenantResolver.cs
+++ b/src/Granit.OpenIddict.Endpoints/Internal/OidcUserTenantResolver.cs
@@ -1,0 +1,75 @@
+using System.Security.Claims;
+using Granit.DataFiltering;
+using Granit.Domain;
+using Granit.Identity.Local.Domain;
+using Microsoft.AspNetCore.Identity;
+
+namespace Granit.OpenIddict.Endpoints.Internal;
+
+/// <summary>
+/// Looks up the <see cref="LocalIdentity"/> behind an OIDC protocol request with the multi-tenant
+/// query filter disabled.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The user id (subject) and user name are globally unique and the request is already
+/// authenticated, so the lookup must not depend on whatever tenant scope happens to be active —
+/// otherwise a host user (<c>TenantId == null</c>) or a user whose tenant was not resolved for this
+/// request becomes invisible and the flow fails closed with a spurious 403. This is the single
+/// source of truth for the filter-disabled lookup used by the authorize, device-verification,
+/// userinfo and two-factor/passkey-grant flows.
+/// </para>
+/// <para>
+/// Aligning the ambient tenant scope to the resolved user (<c>currentTenant.Change(user.TenantId)</c>)
+/// is deliberately left to the caller: <c>ICurrentTenant</c> is <c>AsyncLocal</c>-backed, so a scope
+/// opened inside this async method would not flow back to the caller. The caller opens it in its own
+/// execution context and keeps it for the rest of the request.
+/// </para>
+/// </remarks>
+internal static class OidcUserTenantResolver
+{
+    /// <summary>Resolves the user by subject id (userinfo, passkey grant).</summary>
+    public static Task<LocalIdentity?> FindBySubjectAsync(
+        UserManager<LocalIdentity> userManager, string subject, IDataFilter? dataFilter)
+    {
+        ArgumentNullException.ThrowIfNull(userManager);
+        return WithoutTenantFilterAsync(dataFilter, () => userManager.FindByIdAsync(subject));
+    }
+
+    /// <summary>Resolves the user by user name (two-factor grant).</summary>
+    public static Task<LocalIdentity?> FindByUserNameAsync(
+        UserManager<LocalIdentity> userManager, string userName, IDataFilter? dataFilter)
+    {
+        ArgumentNullException.ThrowIfNull(userManager);
+        return WithoutTenantFilterAsync(dataFilter, () => userManager.FindByNameAsync(userName));
+    }
+
+    /// <summary>Resolves the user by authenticated principal (cookie-driven authorize/verify).</summary>
+    public static Task<LocalIdentity?> FindByPrincipalAsync(
+        UserManager<LocalIdentity> userManager, ClaimsPrincipal principal, IDataFilter? dataFilter)
+    {
+        ArgumentNullException.ThrowIfNull(userManager);
+        return WithoutTenantFilterAsync(dataFilter, () => userManager.GetUserAsync(principal));
+    }
+
+    /// <summary>
+    /// Runs <paramref name="lookup"/> with the <see cref="IMultiTenant"/> filter disabled, restoring
+    /// it afterwards. Extracted for unit testing without an ASP.NET Identity
+    /// <see cref="UserManager{TUser}"/>.
+    /// </summary>
+    internal static async Task<LocalIdentity?> WithoutTenantFilterAsync(
+        IDataFilter? dataFilter, Func<Task<LocalIdentity?>> lookup)
+    {
+        ArgumentNullException.ThrowIfNull(lookup);
+
+        IDisposable? filterScope = dataFilter?.Disable<IMultiTenant>();
+        try
+        {
+            return await lookup().ConfigureAwait(false);
+        }
+        finally
+        {
+            filterScope?.Dispose();
+        }
+    }
+}

--- a/tests/Granit.OpenIddict.Endpoints.Tests/Internal/OidcUserTenantResolverTests.cs
+++ b/tests/Granit.OpenIddict.Endpoints.Tests/Internal/OidcUserTenantResolverTests.cs
@@ -1,0 +1,95 @@
+using Granit.DataFiltering;
+using Granit.Domain;
+using Granit.Identity.Local.Domain;
+using Granit.OpenIddict.Endpoints.Internal;
+using Shouldly;
+using Xunit;
+
+namespace Granit.OpenIddict.Endpoints.Tests.Internal;
+
+/// <summary>
+/// <see cref="OidcUserTenantResolver"/> runs the user lookup with the multi-tenant filter disabled
+/// — so a globally-unique subject/user name resolves regardless of the ambient tenant scope — and
+/// restores the filter afterwards. Aligning the tenant scope to the user is the caller's job
+/// (ICurrentTenant is AsyncLocal-backed), so it is not exercised here.
+/// </summary>
+public sealed class OidcUserTenantResolverTests
+{
+    private static readonly Guid TenantA = Guid.Parse("11111111-1111-1111-1111-111111111111");
+
+    [Fact]
+    public async Task WithoutTenantFilterAsync_DisablesFilterDuringLookup_AndRestoresAfter()
+    {
+        RestorableDataFilter filter = new();
+        bool? enabledDuringLookup = null;
+
+        LocalIdentity? user = await OidcUserTenantResolver.WithoutTenantFilterAsync(
+            filter, () =>
+            {
+                enabledDuringLookup = filter.IsEnabled<IMultiTenant>();
+                return Task.FromResult<LocalIdentity?>(new LocalIdentity { TenantId = TenantA });
+            });
+
+        enabledDuringLookup.ShouldBe(false, "the multi-tenant filter must be off during the lookup");
+        filter.IsEnabled<IMultiTenant>().ShouldBeTrue("the filter must be restored after the lookup");
+        user.ShouldNotBeNull();
+        user.TenantId.ShouldBe(TenantA);
+    }
+
+    [Fact]
+    public async Task WithoutTenantFilterAsync_RestoresFilter_EvenWhenLookupThrows()
+    {
+        RestorableDataFilter filter = new();
+
+        await Should.ThrowAsync<InvalidOperationException>(() =>
+            OidcUserTenantResolver.WithoutTenantFilterAsync(
+                filter, () => throw new InvalidOperationException("boom")));
+
+        filter.IsEnabled<IMultiTenant>().ShouldBeTrue("the filter must be restored after a failed lookup");
+    }
+
+    [Fact]
+    public async Task WithoutTenantFilterAsync_UserNotFound_ReturnsNull()
+    {
+        RestorableDataFilter filter = new();
+
+        LocalIdentity? user = await OidcUserTenantResolver.WithoutTenantFilterAsync(
+            filter, () => Task.FromResult<LocalIdentity?>(null));
+
+        user.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task WithoutTenantFilterAsync_NullDataFilter_StillResolves()
+    {
+        LocalIdentity? user = await OidcUserTenantResolver.WithoutTenantFilterAsync(
+            dataFilter: null, () => Task.FromResult<LocalIdentity?>(new LocalIdentity { TenantId = TenantA }));
+
+        user.ShouldNotBeNull();
+    }
+
+    /// <summary>Minimal <see cref="IDataFilter"/> whose <see cref="Disable{T}"/> restores the prior state on dispose.</summary>
+    private sealed class RestorableDataFilter : IDataFilter
+    {
+        private readonly Dictionary<Type, bool> _state = [];
+
+        public bool IsEnabled<TFilter>() where TFilter : class =>
+            !_state.TryGetValue(typeof(TFilter), out bool value) || value;
+
+        public IDisposable Disable<TFilter>() where TFilter : class => SetScoped<TFilter>(false);
+
+        public IDisposable Enable<TFilter>() where TFilter : class => SetScoped<TFilter>(true);
+
+        private RestoreScope SetScoped<TFilter>(bool enabled) where TFilter : class
+        {
+            bool previous = IsEnabled<TFilter>();
+            _state[typeof(TFilter)] = enabled;
+            return new RestoreScope(() => _state[typeof(TFilter)] = previous);
+        }
+
+        private sealed class RestoreScope(Action restore) : IDisposable
+        {
+            public void Dispose() => restore();
+        }
+    }
+}


### PR DESCRIPTION
## Contexte

Refonte `Granit.OpenIddict*` — **Phase 2E (multi-tenancy finie)**. Après le filtre (#3049), le stamping admin (#3050) et le seeding (#3051), ce PR traite la **surface protocole**.

Les endpoints OIDC résolvaient l'utilisateur agissant de **cinq façons différentes** :
- `authorize` / `verify` : filtre multi-tenant désactivé pour le lookup ✅
- `token` (code/refresh) : scope restauré depuis la claim `tenant_id` ✅
- **`userinfo`, grants 2FA & passkey : ni l'un ni l'autre** ⚠️ — `FindByIdAsync`/`FindByNameAsync` nu sous le scope ambiant.

Aucun middleware tenant ne tourne sur ces appels → scope null → le filtre **cache tout utilisateur tenant** : un utilisateur tenant ne pouvait pas récupérer son propre `userinfo`, ni se connecter via les grants 2FA/passkey (403 fantôme). **Fail-closed.**

## Changement

Nouveau `OidcUserTenantResolver` — un **lookup unique filtre-désactivé** (par subject, user name, ou principal). L'id/nom étant globalement unique et la requête déjà authentifiée, le lookup ne doit pas dépendre du scope ambiant.

**Point de correctness subtil** : l'alignement du scope tenant (`currentTenant.Change(user.TenantId)`) reste **dans chaque caller**. `ICurrentTenant` est backé par `AsyncLocal` → un scope ouvert **dans** la méthode async du resolver ne remonterait pas au caller. Le split évite ce piège (découvert en test : les 2 premiers essais échouaient avant de sortir le `Change` du helper).

Migrés vers le resolver : `authorize`, `verify`, `userinfo`, grants **2FA** et **passkey** (userinfo/2FA/passkey gagnent le fix ; verify aligne désormais aussi le scope). Le chemin `token` code/refresh garde sa restauration par claim (valide, sécurité-critique, inchangé).

## Tests

- `WithoutTenantFilterAsync` : filtre désactivé pendant le lookup + restauré (même sur exception) + null-filter OK.
- `Granit.OpenIddict.Endpoints.Tests` : **129/129** ✓ · architecture **262/262** ✓ · `dotnet format` clean.

## Suite (Phase 2E)

- Retrait des bypasses ad-hoc redondants (session provider `Disable<IMultiTenant>`) une fois #3049 mergé.
- Garde entity-caching order-proof (`IValidateOptions`).
- Stamping admin des scopes (réutilise `TryResolveWriteTenant` de #3050).

> Indépendant de #3049/#3050/#3051 (fichiers disjoints) — non empilé.

🤖 Generated with [Claude Code](https://claude.com/claude-code)