### PR TITLE
feat(openiddict): stamp owning tenant on OIDC scope creation; expose scope TenantId (Phase 2E)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -43013,7 +43013,7 @@
       "kind": "record",
       "project": "Granit.OpenIddict.Endpoints",
       "file": "src/Granit.OpenIddict.Endpoints/Dtos/AdminOidcCreateScopeRequest.cs",
-      "line": 10,
+      "line": 11,
       "members": []
     },
     {
@@ -43031,7 +43031,7 @@
       "kind": "record",
       "project": "Granit.OpenIddict.Endpoints",
       "file": "src/Granit.OpenIddict.Endpoints/Dtos/AdminOidcScopeResponse.cs",
-      "line": 10,
+      "line": 11,
       "members": []
     },
     {

--- a/src/Granit.OpenIddict.Endpoints/Dtos/AdminOidcCreateScopeRequest.cs
+++ b/src/Granit.OpenIddict.Endpoints/Dtos/AdminOidcCreateScopeRequest.cs
@@ -7,8 +7,10 @@ namespace Granit.OpenIddict.Endpoints.Dtos;
 /// <param name="DisplayName">A human-readable display name.</param>
 /// <param name="Description">An optional human-readable description.</param>
 /// <param name="Resources">Resource server identifiers associated with this scope.</param>
+/// <param name="TenantId">Owning tenant. Omit (or <see langword="null"/>) for a global scope, or to inherit the caller's active tenant. A host administrator may set this explicitly to provision a scope for a specific tenant; a tenant-scoped administrator may only target their own tenant (a mismatch is rejected with 403).</param>
 public sealed record AdminOidcCreateScopeRequest(
     string Name,
     string? DisplayName = null,
     string? Description = null,
-    string[]? Resources = null);
+    string[]? Resources = null,
+    Guid? TenantId = null);

--- a/src/Granit.OpenIddict.Endpoints/Dtos/AdminOidcScopeResponse.cs
+++ b/src/Granit.OpenIddict.Endpoints/Dtos/AdminOidcScopeResponse.cs
@@ -7,8 +7,10 @@ namespace Granit.OpenIddict.Endpoints.Dtos;
 /// <param name="DisplayName">The display name.</param>
 /// <param name="Description">Human-readable description.</param>
 /// <param name="Resources">Resource server identifiers associated with this scope.</param>
+/// <param name="TenantId">The tenant identifier, or <see langword="null"/> for global scopes.</param>
 public sealed record AdminOidcScopeResponse(
     string? Name,
     string? DisplayName,
     string? Description,
-    string[] Resources);
+    string[] Resources,
+    Guid? TenantId);

--- a/src/Granit.OpenIddict.Endpoints/Endpoints/AdminOidcEndpoints.cs
+++ b/src/Granit.OpenIddict.Endpoints/Endpoints/AdminOidcEndpoints.cs
@@ -101,6 +101,7 @@ internal static class AdminOidcEndpoints
             .WithMetadata(new IdempotentAttribute { Required = false })
             .Produces<AdminOidcScopeResponse>(StatusCodes.Status201Created)
             .ProducesValidationProblem(StatusCodes.Status422UnprocessableEntity)
+            .ProducesProblem(StatusCodes.Status403Forbidden)
             .RequireAuthorization(OpenIddictPermissions.Scopes.Manage);
 
         scopes.MapPut("/{scopeName}", UpdateScopeAsync)
@@ -441,17 +442,26 @@ internal static class AdminOidcEndpoints
         {
             var descriptor = new OpenIddictScopeDescriptor();
             await scopeManager.PopulateAsync(descriptor, scope, cancellationToken).ConfigureAwait(false);
-            results.Add(ToScopeResponse(descriptor));
+            Guid? tenantId = scope is IMultiTenant granitScope ? granitScope.TenantId : null;
+            results.Add(ToScopeResponse(descriptor, tenantId));
         }
 
         return TypedResults.Ok<IReadOnlyList<AdminOidcScopeResponse>>(results);
     }
 
-    private static async Task<Created<AdminOidcScopeResponse>> CreateScopeAsync(
+    private static async Task<Results<Created<AdminOidcScopeResponse>, ProblemHttpResult>> CreateScopeAsync(
         AdminOidcCreateScopeRequest request,
         [FromServices] IOpenIddictScopeManager scopeManager,
+        [FromServices] ICurrentTenant currentTenant,
         CancellationToken cancellationToken)
     {
+        if (!TryResolveWriteTenant(request.TenantId, currentTenant, out Guid? tenantId))
+        {
+            return TypedResults.Problem(
+                detail: "A tenant-scoped administrator cannot assign a scope to a different tenant.",
+                statusCode: StatusCodes.Status403Forbidden);
+        }
+
         var descriptor = new OpenIddictScopeDescriptor
         {
             Name = request.Name,
@@ -466,12 +476,21 @@ internal static class AdminOidcEndpoints
 
         object scope = await scopeManager.CreateAsync(descriptor, cancellationToken).ConfigureAwait(false);
 
+        // OpenIddict entities implement IMultiTenant but are not audited, so the persistence
+        // interceptor never stamps their TenantId — assign the resolved tenant explicitly.
+        if (tenantId is not null && scope is IMultiTenant granitScope && granitScope.TenantId != tenantId)
+        {
+            granitScope.TenantId = tenantId;
+            await scopeManager.UpdateAsync(scope, cancellationToken).ConfigureAwait(false);
+        }
+
         var responseDescriptor = new OpenIddictScopeDescriptor();
         await scopeManager.PopulateAsync(responseDescriptor, scope, cancellationToken).ConfigureAwait(false);
+        Guid? persistedTenantId = scope is IMultiTenant persisted ? persisted.TenantId : null;
 
         return TypedResults.Created(
             $"/admin/oidc/scopes/{responseDescriptor.Name}",
-            ToScopeResponse(responseDescriptor));
+            ToScopeResponse(responseDescriptor, persistedTenantId));
     }
 
     private static async Task<Results<Ok<AdminOidcScopeResponse>, ProblemHttpResult>> UpdateScopeAsync(
@@ -512,8 +531,9 @@ internal static class AdminOidcEndpoints
 
         var responseDescriptor = new OpenIddictScopeDescriptor();
         await scopeManager.PopulateAsync(responseDescriptor, scope, cancellationToken).ConfigureAwait(false);
+        Guid? tenantId = scope is IMultiTenant granitScope ? granitScope.TenantId : null;
 
-        return TypedResults.Ok(ToScopeResponse(responseDescriptor));
+        return TypedResults.Ok(ToScopeResponse(responseDescriptor, tenantId));
     }
 
     private static async Task<Results<NoContent, ProblemHttpResult>> DeleteScopeAsync(
@@ -661,12 +681,14 @@ internal static class AdminOidcEndpoints
 
     // ──── Helpers ────
 
-    private static AdminOidcScopeResponse ToScopeResponse(OpenIddictScopeDescriptor descriptor) =>
+    private static AdminOidcScopeResponse ToScopeResponse(
+        OpenIddictScopeDescriptor descriptor, Guid? tenantId) =>
         new(
             descriptor.Name,
             descriptor.DisplayName,
             descriptor.Description,
-            [.. descriptor.Resources]);
+            [.. descriptor.Resources],
+            tenantId);
 
     private static AdminOidcApplicationResponse ToResponse(
         OpenIddictApplicationDescriptor descriptor, Guid? tenantId) =>

--- a/tests/Granit.OpenIddict.Endpoints.Tests/Integration/AdminOidcEndpointsIntegrationTests.cs
+++ b/tests/Granit.OpenIddict.Endpoints.Tests/Integration/AdminOidcEndpointsIntegrationTests.cs
@@ -512,6 +512,45 @@ public sealed class AdminOidcEndpointsIntegrationTests : IAsyncLifetime
         result.DisplayName.ShouldBe("Custom Scope");
         result.Description.ShouldBe("A custom OIDC scope");
         result.Resources.ShouldBe(["api://my-resource"]);
+        result.TenantId.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task CreateScope_ExplicitTenantId_StampsTenantOnEntity()
+    {
+        var targetTenant = Guid.Parse("66666666-6666-6666-6666-666666666666");
+        GranitOpenIddictScope createdScope = new() { TenantId = null };
+
+        _server.ScopeManager.CreateAsync(
+            Arg.Any<OpenIddictScopeDescriptor>(),
+            Arg.Any<CancellationToken>())
+            .Returns(createdScope);
+#pragma warning disable CA2012
+        _server.ScopeManager
+            .PopulateAsync(Arg.Any<OpenIddictScopeDescriptor>(), createdScope, Arg.Any<CancellationToken>())
+            .Returns(ci =>
+            {
+                OpenIddictScopeDescriptor d = ci.ArgAt<OpenIddictScopeDescriptor>(0);
+                d.Name = "tenant_scope";
+                return new ValueTask();
+            });
+#pragma warning restore CA2012
+
+        AdminOidcCreateScopeRequest request = new(
+            "tenant_scope", "Tenant Scope", Resources: [], TenantId: targetTenant);
+
+        HttpResponseMessage response = await _server.AuthenticatedClient
+            .PostAsJsonAsync("/admin/oidc/scopes", request, TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Created);
+
+        createdScope.TenantId.ShouldBe(targetTenant);
+        await _server.ScopeManager.Received(1).UpdateAsync(createdScope, Arg.Any<CancellationToken>());
+
+        AdminOidcScopeResponse? result = await response.Content
+            .ReadFromJsonAsync<AdminOidcScopeResponse>(TestContext.Current.CancellationToken);
+        result.ShouldNotBeNull();
+        result.TenantId.ShouldBe(targetTenant);
     }
 
     [Fact]


### PR DESCRIPTION
## Contexte

Refonte `Granit.OpenIddict*` — **Phase 2E (multi-tenancy finie)**. Miroir du stamping applications (#3050, mergé) côté **scopes**, maintenant que le resolver partagé `TryResolveWriteTenant` et le filtre null-is-global (#3049, mergé) sont sur develop.

## Changement

- **`AdminOidcScopeResponse`** gagne `TenantId` ; List/Create/Update le lisent depuis l'entité (le descriptor OpenIddict n'a pas de champ tenant) — symétrique avec la réponse application.
- **`AdminOidcCreateScopeRequest`** gagne un `TenantId` optionnel. `CreateScopeAsync` résout le tenant propriétaire (`explicit ?? actif`), rejette un write cross-tenant en **403**, et stampe l'entité scope créée (entités OpenIddict non auditées → l'intercepteur ne stampe jamais).
- Les scopes OIDC standard restent **globaux** (pas de `TenantId` → null).

## Tests

- Test d'intégration HTTP : chemin d'assignation explicite (entité stampée + `UpdateAsync` persisté + réponse reflète le tenant).
- Le 403 cross-tenant est couvert par les tests unitaires de `TryResolveWriteTenant` (#3050).
- `Granit.OpenIddict.Endpoints.Tests` : **126/126** ✓ · architecture **262/262** ✓ · `dotnet format` clean.

## Phase 2E — état

Filtre null-is-global ✅ #3049 (mergé) · stamping apps ✅ #3050 (mergé) · seeding ⏳ #3051 · surface protocole ⏳ #3052 · **stamping scopes** (ce PR). Reste : retrait des bypasses ad-hoc + garde entity-caching order-proof.

> Fichiers disjoints de #3051/#3052 — non empilé.

🤖 Generated with [Claude Code](https://claude.com/claude-code)