### PR TITLE
refactor(openiddict): drop redundant tenant-filter bypass in session revoke; fix stale rationale (Phase 2E)

### DIFF
--- a/src/Granit.OpenIddict/Services/OpenIddictUserSessionProvider.cs
+++ b/src/Granit.OpenIddict/Services/OpenIddictUserSessionProvider.cs
@@ -29,8 +29,11 @@ internal sealed class OpenIddictUserSessionProvider(
     {
         var sessions = new List<UserSessionDescriptor>();
 
-        // GranitOpenIddictToken.TenantId is always null — OpenIddict never sets it.
-        // Disable the IMultiTenant filter so tenant users can see their own tokens.
+        // Kept deliberately: tokens themselves are global (TenantId stays null) and the
+        // null-is-global filter would surface them anyway, but this listing also resolves each
+        // token's application for its device kind, and applications may be tenant-owned. The
+        // /sessions call can run outside the owning tenant's scope, so disable the IMultiTenant
+        // filter for the whole listing to resolve those applications regardless of scope.
         using IDisposable? _ = dataFilter?.Disable<IMultiTenant>();
 
         // One device-kind resolution per distinct client across the whole listing — many of a user's tokens
@@ -192,8 +195,10 @@ internal sealed class OpenIddictUserSessionProvider(
     public async Task<bool> RevokeAsync(
         string userId, string sessionId, CancellationToken cancellationToken = default)
     {
-        using IDisposable? _ = dataFilter?.Disable<IMultiTenant>();
-
+        // No IMultiTenant bypass needed: this path only reads the token (tokens are always
+        // global — TenantId stays null, never stamped), and the null-is-global query filter
+        // makes a global row visible under every tenant scope. Ownership is enforced by the
+        // subject check below.
         object? token = await tokenManager.FindByIdAsync(sessionId, cancellationToken)
             .ConfigureAwait(false);
         if (token is null)


### PR DESCRIPTION
## Contexte

Refonte `Granit.OpenIddict*` — **Phase 2E**, finition. Maintenant que le filtre est null-is-global (#3049, mergé) et que les applications peuvent être tenant-owned (#3050, mergé), les deux bypasses `Disable<IMultiTenant>()` de `OpenIddictUserSessionProvider` demandaient une revue.

## Changement

- **`RevokeAsync`** ne lit que le token (les tokens sont **globaux** — `TenantId` reste null, jamais stampé), et null-is-global rend une ligne globale visible sous n'importe quel scope tenant. Le bypass était **redondant → retiré**. La propriété reste garantie par le check du subject.
- **`ListAsync`** garde son bypass, mais l'ancien commentaire (« TenantId toujours null → pour que les utilisateurs tenant voient leurs tokens ») était **trompeur** : la vraie raison de le garder est que le listing résout l'**application** de chaque token (device kind), et les applications peuvent désormais être tenant-owned — un lecteur suivant le commentaire périmé aurait retiré un bypass qui protège ces lookups d'apps. **Justification corrigée.**

## Tests

- `Granit.OpenIddict.Tests` : **261/261** ✓ (session provider inclus) · `dotnet format` clean.
- Le comportement de requête réel (token global visible sous scope tenant) est couvert par la suite d'intégration Postgres en CI.

## Phase 2E

Fonctionnellement complète : filtre (#3049 ✅) · stamping apps (#3050 ✅) · seeding (#3051) · surface protocole (#3052 ✅ mergé) · stamping scopes (#3053) · bypasses (ce PR). Reste optionnel : garde entity-caching order-proof (défensif, valeur marginale sous ClientId globalement-unique).

🤖 Generated with [Claude Code](https://claude.com/claude-code)