### PR TITLE
feat(openiddict): implement the FAPI 2.0 PS256 signing-algorithm override (Phase 2A)

### DIFF
--- a/src/Granit.OpenIddict/GranitOpenIddictModule.cs
+++ b/src/Granit.OpenIddict/GranitOpenIddictModule.cs
@@ -70,6 +70,10 @@ public sealed class GranitOpenIddictModule : GranitModule
             .AddOptions<GranitKeyRotationOptions>()
             .BindConfiguration(GranitKeyRotationOptions.SectionName);
 
+        // FAPI 2.0 profile → PS256 signing algorithm (unless an explicit non-default was set).
+        context.Services.AddSingleton<IPostConfigureOptions<GranitKeyRotationOptions>,
+            Fapi2SigningAlgorithmPostConfigure>();
+
         context.Services.TryAddScoped<IClaimsDestinationProvider, DefaultClaimsDestinationProvider>();
         context.Services.TryAddScoped<IOidcPrincipalFactory, OidcPrincipalFactory>();
         context.Services.TryAddScoped<ITotpService, DefaultTotpService>();

--- a/src/Granit.OpenIddict/Internal/Fapi2SigningAlgorithmPostConfigure.cs
+++ b/src/Granit.OpenIddict/Internal/Fapi2SigningAlgorithmPostConfigure.cs
@@ -1,0 +1,39 @@
+using Granit.OpenIddict.Options;
+using Microsoft.Extensions.Options;
+
+namespace Granit.OpenIddict.Internal;
+
+/// <summary>
+/// Upgrades the key-rotation signing algorithm to <c>PS256</c> (RSASSA-PSS) when the FAPI 2.0
+/// profile is enabled and the algorithm is still the RS256 default.
+/// </summary>
+/// <remarks>
+/// <para>
+/// FAPI 2.0 §5.2.2 requires PS256 or ES256. <see cref="GranitKeyRotationOptions.SigningAlgorithm"/>
+/// documents this automatic override; this post-configure implements it. An explicit non-default
+/// choice (for example ES256) is respected — only the RS256 default is upgraded.
+/// </para>
+/// <para>
+/// The algorithm is read at key generation (<c>KeyRotationService.GenerateKeyAsync</c>), so a
+/// FAPI 2.0 deployment mints PS256 keys without the operator having to restate the algorithm.
+/// </para>
+/// </remarks>
+internal sealed class Fapi2SigningAlgorithmPostConfigure(
+    IOptions<GranitOpenIddictOptions> openIddictOptions)
+    : IPostConfigureOptions<GranitKeyRotationOptions>
+{
+    internal const string DefaultAlgorithm = "RS256";
+    internal const string Fapi2Algorithm = "PS256";
+
+    /// <inheritdoc/>
+    public void PostConfigure(string? name, GranitKeyRotationOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        if (openIddictOptions.Value.EnableFapi2Profile
+            && string.Equals(options.SigningAlgorithm, DefaultAlgorithm, StringComparison.Ordinal))
+        {
+            options.SigningAlgorithm = Fapi2Algorithm;
+        }
+    }
+}

--- a/tests/Granit.OpenIddict.Tests/Internal/Fapi2SigningAlgorithmPostConfigureTests.cs
+++ b/tests/Granit.OpenIddict.Tests/Internal/Fapi2SigningAlgorithmPostConfigureTests.cs
@@ -1,0 +1,47 @@
+using Granit.OpenIddict.Internal;
+using Granit.OpenIddict.Options;
+using Shouldly;
+using Xunit;
+
+namespace Granit.OpenIddict.Tests.Internal;
+
+/// <summary>
+/// The FAPI 2.0 profile upgrades the key-rotation signing algorithm to PS256 when it is still the
+/// RS256 default, and leaves an explicit non-default choice untouched.
+/// </summary>
+public sealed class Fapi2SigningAlgorithmPostConfigureTests
+{
+    private static Fapi2SigningAlgorithmPostConfigure Create(bool fapi2) =>
+        new(Microsoft.Extensions.Options.Options.Create(
+            new GranitOpenIddictOptions { EnableFapi2Profile = fapi2 }));
+
+    [Fact]
+    public void Fapi2Enabled_DefaultAlgorithm_UpgradesToPs256()
+    {
+        GranitKeyRotationOptions options = new(); // SigningAlgorithm defaults to RS256
+
+        Create(fapi2: true).PostConfigure(name: null, options);
+
+        options.SigningAlgorithm.ShouldBe("PS256");
+    }
+
+    [Fact]
+    public void Fapi2Enabled_ExplicitEs256_IsRespected()
+    {
+        GranitKeyRotationOptions options = new() { SigningAlgorithm = "ES256" };
+
+        Create(fapi2: true).PostConfigure(name: null, options);
+
+        options.SigningAlgorithm.ShouldBe("ES256", "an explicit non-default algorithm must not be overridden");
+    }
+
+    [Fact]
+    public void Fapi2Disabled_DefaultAlgorithm_StaysRs256()
+    {
+        GranitKeyRotationOptions options = new();
+
+        Create(fapi2: false).PostConfigure(name: null, options);
+
+        options.SigningAlgorithm.ShouldBe("RS256");
+    }
+}


### PR DESCRIPTION
## Contexte

Refonte `Granit.OpenIddict*` — **Phase 2A (clés de signature)**, première tranche.

`GranitKeyRotationOptions.SigningAlgorithm` **documentait** que l'activation du profil FAPI 2.0 remplace automatiquement RS256 → PS256 (FAPI 2.0 §5.2.2 exige PS256 ou ES256), mais **aucun code ne le faisait** : un déploiement FAPI 2.0 générait silencieusement des clés RS256, violant le profil demandé.

## Changement

`Fapi2SigningAlgorithmPostConfigure` (`IPostConfigureOptions<GranitKeyRotationOptions>`) : si `EnableFapi2Profile` et l'algorithme est encore le défaut RS256 → PS256. Un choix explicite non-défaut (ex. ES256) est respecté. `KeyRotationService` lit l'algorithme à la génération → les hosts FAPI 2.0 génèrent des clés PS256 sans le restated.

## Tests

- Upgrade sur défaut · respect d'ES256 explicite · no-op profil désactivé.
- `Granit.OpenIddict.Tests` : **264/264** ✓ · `dotnet format` clean.

## Suite Phase 2A (PR séparées)

- **Read-side rotation-aware** : `IHostedService` qui poll `ISigningKeyStore` et invalide `IOptionsMonitorCache<OpenIddictServerOptions>` au changement de set de clés (le finding #1 — aujourd'hui `DatabaseSigningKeyPostConfigure` est one-shot). Docker désormais dispo → tests d'intégration Postgres en local.
- First-boot generate-on-empty · gestion schéma-absent (health not-ready au lieu de CrashLoop) · guard éphémère → `IValidateOptions`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)