### PR TITLE
fix(identity)!: tenant-safe GDPR erasure, honest GoogleCloud capabilities, OData injection defense (Vague 0)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -29641,7 +29641,7 @@
           "name": "EraseAsync",
           "kind": "method",
           "signature": "EraseAsync(string externalUserId, Guid? tenantId, CancellationToken cancellationToken = default)",
-          "returnType": "Task"
+          "returnType": "Task<int>"
         }
       ]
     },

--- a/src/Granit.Identity.Endpoints/Endpoints/MyUserSessionEndpoints.cs
+++ b/src/Granit.Identity.Endpoints/Endpoints/MyUserSessionEndpoints.cs
@@ -28,20 +28,24 @@ internal static class MyUserSessionEndpoints
                 "Returns the authenticated user's active sessions across the configured backend "
                 + "(BFF, OpenIddict or Keycloak), each enriched with its approximate location and persisted "
                 + "risk level. The current session is flagged. Raw IP addresses are never returned.")
-            .Produces<IReadOnlyList<UserSessionResponse>>();
+            .Produces<IReadOnlyList<UserSessionResponse>>()
+            .ProducesProblem(StatusCodes.Status401Unauthorized);
 
         group.MapDelete("/{sessionId}", RevokeAsync)
             .WithName("RevokeMyUserSession")
             .WithSummary("Revokes one of the caller's sessions by ID.")
             .WithDescription("Revokes the specified session of the authenticated user. Returns 404 when no such session exists.")
             .Produces(StatusCodes.Status204NoContent)
+            .ProducesProblem(StatusCodes.Status401Unauthorized)
             .ProducesProblem(StatusCodes.Status404NotFound);
 
         group.MapDelete("/", RevokeOthersAsync)
             .WithName("RevokeMyOtherUserSessions")
             .WithSummary("Revokes all of the caller's sessions except the current one.")
             .WithDescription("Revokes every session of the authenticated user except the one making the request, and returns how many were revoked.")
-            .Produces<UserSessionsRevokedResponse>();
+            .Produces<UserSessionsRevokedResponse>()
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status401Unauthorized);
 
         return group;
     }

--- a/src/Granit.Identity.Federated.EntityFrameworkCore/Internal/EfCoreUserCacheStore.cs
+++ b/src/Granit.Identity.Federated.EntityFrameworkCore/Internal/EfCoreUserCacheStore.cs
@@ -1,5 +1,6 @@
 using Granit.Identity.Federated.Domain;
 using Granit.Identity.Federated.Internal;
+using Granit.Persistence.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 
 namespace Granit.Identity.Federated.EntityFrameworkCore.Internal;
@@ -36,7 +37,11 @@ internal sealed class EfCoreUserCacheStore(
         await using IdentityFederatedDbContext db = await contextFactory
             .CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
 
+        // Host-context lookup, documented "regardless of tenant": the multi-tenant filter
+        // must be bypassed explicitly — with no ambient tenant it would otherwise hide every
+        // tenant-scoped mirror, and the cache-aside caller would re-insert a duplicate row.
         return await db.FederatedIdentities
+            .IgnoreQueryFilters([GranitFilterNames.MultiTenant])
             .AsNoTracking()
             .FirstOrDefaultAsync(e => e.ExternalUserId == externalUserId, cancellationToken)
             .ConfigureAwait(false);
@@ -233,18 +238,30 @@ internal sealed class EfCoreUserCacheStore(
 
     // -- GDPR --
 
-    public async Task DeleteByExternalIdAsync(
+    public async Task<int> DeleteByExternalIdAsync(
         string externalUserId, Guid? tenantId, CancellationToken cancellationToken = default)
     {
         await using IdentityFederatedDbContext db = await contextFactory
             .CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
 
-        List<FederatedIdentity> entries = await db.FederatedIdentities
-            .Where(e => e.TenantId == tenantId && e.ExternalUserId == externalUserId)
+        // Null tenant scope = GDPR Art. 17 sweep across ALL partitions (contract of
+        // IdentityUserDeletedEto): the multi-tenant filter would otherwise translate the
+        // intent into "host rows only" and leave tenant mirrors behind. A scoped delete
+        // keeps the filter active as a guard — the caller must have established a matching
+        // ambient tenant for the row to be visible.
+        IQueryable<FederatedIdentity> query = tenantId is null
+            ? db.FederatedIdentities
+                .IgnoreQueryFilters([GranitFilterNames.MultiTenant])
+                .Where(e => e.ExternalUserId == externalUserId)
+            : db.FederatedIdentities
+                .Where(e => e.TenantId == tenantId && e.ExternalUserId == externalUserId);
+
+        List<FederatedIdentity> entries = await query
             .ToListAsync(cancellationToken).ConfigureAwait(false);
 
         db.FederatedIdentities.RemoveRange(entries);
         await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        return entries.Count;
     }
 
     public async Task DeleteAllByTenantAsync(Guid? tenantId, CancellationToken cancellationToken = default)

--- a/src/Granit.Identity.Federated.EntraId/Internal/EntraIdIdentityProvider.cs
+++ b/src/Granit.Identity.Federated.EntraId/Internal/EntraIdIdentityProvider.cs
@@ -3,6 +3,7 @@ using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Security.Cryptography;
+using System.Text.RegularExpressions;
 using Granit.Diagnostics;
 using Granit.Events;
 using Granit.Identity.Events;
@@ -57,6 +58,15 @@ internal sealed partial class EntraIdIdentityProvider(
         CancellationToken cancellationToken = default)
     {
         using Activity? activity = IdentityEntraIdActivitySource.Source.StartActivity(IdentityEntraIdActivitySource.GetUsers);
+
+        // Same defense as the Cognito provider: reject search input outside the character
+        // set legitimately used in display names and emails before it reaches the OData
+        // $filter (the URL builder additionally escapes quotes per OData ABNF).
+        if (!string.IsNullOrEmpty(search) && !ValidSearchPattern().IsMatch(search))
+        {
+            LogInvalidSearchInput(search.Length);
+            return [];
+        }
 
         try
         {
@@ -1221,6 +1231,19 @@ internal sealed partial class EntraIdIdentityProvider(
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to get users from Entra ID. Returning empty list")]
     private partial void LogGetUsersFailed(Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Rejected Entra ID user search input ({Length} chars) — failed character whitelist")]
+    private partial void LogInvalidSearchInput(int length);
+
+    /// <summary>
+    /// Whitelist for the Graph user-search input. Allows the characters legitimately found
+    /// in display names and emails (Unicode letters/marks/digits, space, apostrophe,
+    /// <c>._@+-</c>); everything else is rejected before it reaches the OData
+    /// <c>$filter</c>. Apostrophes are additionally escaped by the URL builder (OData
+    /// quote doubling). Bounded length to limit DoS surface.
+    /// </summary>
+    [GeneratedRegex(@"^[\p{L}\p{M}\p{N}' ._@+\-]{1,128}$")]
+    private static partial Regex ValidSearchPattern();
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to get user {UserId} from Entra ID. Returning null")]
     private partial void LogGetUserFailed(Exception exception, string userId);

--- a/src/Granit.Identity.Federated.EntraId/Options/EntraIdAdminOptions.cs
+++ b/src/Granit.Identity.Federated.EntraId/Options/EntraIdAdminOptions.cs
@@ -96,7 +96,8 @@ public sealed class EntraIdAdminOptions
 
         if (!string.IsNullOrEmpty(search))
         {
-            queryParams.Add($"$filter=startswith(displayName,'{Uri.EscapeDataString(search)}') or startswith(mail,'{Uri.EscapeDataString(search)}')");
+            string escaped = EscapeODataStringLiteral(search);
+            queryParams.Add($"$filter=startswith(displayName,'{Uri.EscapeDataString(escaped)}') or startswith(mail,'{Uri.EscapeDataString(escaped)}')");
         }
 
         if (skip.HasValue)
@@ -130,7 +131,16 @@ public sealed class EntraIdAdminOptions
     /// Builds the Graph API URL for listing sign-in audit logs of a user.
     /// </summary>
     internal static string GetAuditSignInsEndpoint(string userId, int top = 25) =>
-        $"/v1.0/auditLogs/signIns?$filter=userId eq '{Uri.EscapeDataString(userId)}'&$top={top}&$orderby=createdDateTime desc";
+        $"/v1.0/auditLogs/signIns?$filter=userId eq '{Uri.EscapeDataString(EscapeODataStringLiteral(userId))}'&$top={top}&$orderby=createdDateTime desc";
+
+    /// <summary>
+    /// Escapes a value embedded in a single-quoted OData string literal by doubling the
+    /// quotes (OData ABNF). <c>Uri.EscapeDataString</c> alone is NOT enough: Graph
+    /// URL-decodes <c>%27</c> back to <c>'</c> before parsing <c>$filter</c>, so an
+    /// unescaped quote breaks out of the literal and rewrites the predicate.
+    /// </summary>
+    private static string EscapeODataStringLiteral(string value) =>
+        value.Replace("'", "''", StringComparison.Ordinal);
 
     // ──── App Roles ────
 

--- a/src/Granit.Identity.Federated.GoogleCloud/Diagnostics/IdentityGoogleCloudActivitySource.cs
+++ b/src/Granit.Identity.Federated.GoogleCloud/Diagnostics/IdentityGoogleCloudActivitySource.cs
@@ -25,8 +25,6 @@ internal static class IdentityGoogleCloudActivitySource
 #pragma warning disable GRSEC003 // Operation name constants, not secrets
         public const string RevokeTokens = "firebase.revoke-tokens";
         public const string SetPassword = "firebase.set-password";
-        public const string GeneratePasswordResetLink = "firebase.generate-password-reset-link";
-        public const string VerifyCredentials = "firebase.verify-credentials";
 #pragma warning restore GRSEC003
     }
 

--- a/src/Granit.Identity.Federated.GoogleCloud/Internal/FirebaseAuthTransport.cs
+++ b/src/Granit.Identity.Federated.GoogleCloud/Internal/FirebaseAuthTransport.cs
@@ -98,15 +98,4 @@ internal sealed class FirebaseAuthTransport(FirebaseAuth auth) : IFirebaseAuthTr
     /// <inheritdoc />
     public Task RevokeRefreshTokensAsync(string uid, CancellationToken cancellationToken = default) =>
         auth.RevokeRefreshTokensAsync(uid, cancellationToken);
-
-    /// <inheritdoc />
-    public Task<string> GeneratePasswordResetLinkAsync(string email, CancellationToken cancellationToken = default) =>
-        auth.GeneratePasswordResetLinkAsync(email);
-
-    /// <inheritdoc />
-    public Task<bool> VerifyPasswordAsync(string email, string password, CancellationToken cancellationToken = default) =>
-        // Firebase Admin SDK does not expose a direct password verify API.
-        // This would require the Firebase Auth REST API with the Web API key.
-        // For now, this capability is not supported in the admin SDK.
-        Task.FromResult(false);
 }

--- a/src/Granit.Identity.Federated.GoogleCloud/Internal/GoogleCloudIdentityProvider.cs
+++ b/src/Granit.Identity.Federated.GoogleCloud/Internal/GoogleCloudIdentityProvider.cs
@@ -259,23 +259,14 @@ internal sealed partial class GoogleCloudIdentityProvider(
     public Task<DateTimeOffset?> GetPasswordChangedAtAsync(string userId, CancellationToken cancellationToken = default) =>
         Task.FromResult<DateTimeOffset?>(null);
 
-    public async Task SendPasswordResetEmailAsync(string userId, CancellationToken cancellationToken = default)
-    {
-        using Activity? activity = IdentityGoogleCloudActivitySource.Source.StartActivity(
-            IdentityGoogleCloudActivitySource.Operations.GeneratePasswordResetLink);
-        activity?.SetTag(IdentityGoogleCloudActivitySource.Tags.UserId, userId);
-
-        UserRecord user = await transport.GetUserAsync(userId, cancellationToken).ConfigureAwait(false);
-
-        if (string.IsNullOrEmpty(user.Email))
-        {
-            throw new InvalidOperationException($"User {userId} has no email address.");
-        }
-
-        await transport.GeneratePasswordResetLinkAsync(user.Email, cancellationToken).ConfigureAwait(false);
-
-        await distributedEventBus.PublishAsync(new IdentityPasswordResetEto(userId), cancellationToken).ConfigureAwait(false);
-    }
+    public Task SendPasswordResetEmailAsync(string userId, CancellationToken cancellationToken = default) =>
+        // The Admin SDK can only generate a reset link, never send it — the previous
+        // implementation generated and discarded the link, then published a
+        // IdentityPasswordResetEto for an email that never left. Hosts gate on
+        // SupportsNativePasswordResetEmail (false); a direct call must fail loud.
+        throw new NotSupportedException(
+            "Firebase Auth cannot send password reset emails from the Admin SDK. "
+            + "Generate a link and deliver it through your own notifier instead.");
 
     public async Task SetTemporaryPasswordAsync(string userId, string temporaryPassword, CancellationToken cancellationToken = default)
     {
@@ -289,13 +280,13 @@ internal sealed partial class GoogleCloudIdentityProvider(
 
     // ── Credentials ───────────────────────────────────────────────────
 
-    public async Task<bool> VerifyUserCredentialsAsync(string username, string password, CancellationToken cancellationToken = default)
-    {
-        using Activity? activity = IdentityGoogleCloudActivitySource.Source.StartActivity(
-            IdentityGoogleCloudActivitySource.Operations.VerifyCredentials);
-
-        return await transport.VerifyPasswordAsync(username, password, cancellationToken).ConfigureAwait(false);
-    }
+    public Task<bool> VerifyUserCredentialsAsync(string username, string password, CancellationToken cancellationToken = default) =>
+        // The Admin SDK exposes no password-verify API; the previous implementation
+        // returned false for every credential, indistinguishable from "wrong password".
+        // Hosts gate on SupportsCredentialVerification (false); a direct call must fail loud.
+        throw new NotSupportedException(
+            "Firebase Auth does not support credential verification from the Admin SDK "
+            + "(requires the Firebase Auth REST API with the Web API key).");
 
     // ── Helpers ───────────────────────────────────────────────────────
 

--- a/src/Granit.Identity.Federated.GoogleCloud/Internal/GoogleCloudIdentityProviderCapabilities.cs
+++ b/src/Granit.Identity.Federated.GoogleCloud/Internal/GoogleCloudIdentityProviderCapabilities.cs
@@ -12,7 +12,13 @@ internal sealed class GoogleCloudIdentityProviderCapabilities : IIdentityProvide
     public bool SupportsIndividualSessionTermination => false;
 
     /// <inheritdoc />
-    public bool SupportsNativePasswordResetEmail => true;
+    /// <remarks>
+    /// The Firebase Admin SDK can only <em>generate</em> a password-reset link
+    /// (<c>GeneratePasswordResetLinkAsync</c>) — it never sends the email. Advertising
+    /// <c>true</c> here made the reset flow a silent no-op for the user. Sending requires
+    /// a notifier hook (see the Entra ID provider's <c>IPasswordResetNotifier</c> pattern).
+    /// </remarks>
+    public bool SupportsNativePasswordResetEmail => false;
 
     /// <inheritdoc />
     public bool SupportsGroupHierarchy => false;
@@ -24,7 +30,12 @@ internal sealed class GoogleCloudIdentityProviderCapabilities : IIdentityProvide
     public int MaxCustomAttributes => 100;
 
     /// <inheritdoc />
-    public bool SupportsCredentialVerification => true;
+    /// <remarks>
+    /// The Firebase Admin SDK exposes no password-verify API — verification would require
+    /// the Firebase Auth REST API with the Web API key. Advertising <c>true</c> here made
+    /// hosts offer credential verification that rejected every valid password.
+    /// </remarks>
+    public bool SupportsCredentialVerification => false;
 
     /// <inheritdoc />
     public bool SupportsUserCreation => true;

--- a/src/Granit.Identity.Federated.GoogleCloud/Internal/IFirebaseAuthTransport.cs
+++ b/src/Granit.Identity.Federated.GoogleCloud/Internal/IFirebaseAuthTransport.cs
@@ -41,8 +41,4 @@ internal interface IFirebaseAuthTransport
     Task SetCustomUserClaimsAsync(string uid, IReadOnlyDictionary<string, object> claims, CancellationToken cancellationToken = default);
 
     Task RevokeRefreshTokensAsync(string uid, CancellationToken cancellationToken = default);
-
-    Task<string> GeneratePasswordResetLinkAsync(string email, CancellationToken cancellationToken = default);
-
-    Task<bool> VerifyPasswordAsync(string email, string password, CancellationToken cancellationToken = default);
 }

--- a/src/Granit.Identity.Federated.Notifications/Templates/identity.token_exchange_audit.fr.html
+++ b/src/Granit.Identity.Federated.Notifications/Templates/identity.token_exchange_audit.fr.html
@@ -1,4 +1,4 @@
-<title>Audit d'échange de jeton : un service a usurpé l'utilisateur {{ model.target_user_id }}</title>
+<title>Audit d'échange de jeton : un service a usurpé l'utilisateur {{ model.target_user_id | html.escape }}</title>
 <p>Bonjour,</p>
 <p>Un échange de jeton fédéré (RFC 8693 — usurpation directe) vient d'être effectué sur la plateforme. Un service a obtenu un jeton d'accès utilisateur <strong>sans le consentement interactif de l'utilisateur</strong>. Examinez l'opération dès maintenant et accusez réception ou escaladez.</p>
 <ul>

--- a/src/Granit.Identity.Federated.Notifications/Templates/identity.token_exchange_audit.html
+++ b/src/Granit.Identity.Federated.Notifications/Templates/identity.token_exchange_audit.html
@@ -1,4 +1,4 @@
-<title>Token exchange audit: service impersonated user {{ model.target_user_id }}</title>
+<title>Token exchange audit: service impersonated user {{ model.target_user_id | html.escape }}</title>
 <p>Hello,</p>
 <p>A federated token exchange (RFC 8693 — direct naked impersonation) has just been performed against the platform. A service has obtained a user-scoped access token <strong>without the user's interactive consent</strong>. Review the operation now and acknowledge or escalate.</p>
 <ul>

--- a/src/Granit.Identity.Federated.Notifications/Templates/identity.user_provisioning_removed.fr.html
+++ b/src/Granit.Identity.Federated.Notifications/Templates/identity.user_provisioning_removed.fr.html
@@ -1,4 +1,4 @@
-<title>Reçu RGPD Art. 17 : utilisateur {{ model.user_id }} supprimé de la plateforme</title>
+<title>Reçu RGPD Art. 17 : utilisateur {{ model.user_id | html.escape }} supprimé de la plateforme</title>
 <p>Bonjour,</p>
 <p>Ceci est un <strong>reçu d'effacement RGPD Art. 17</strong>. Le fournisseur d'identité fédéré a confirmé la suppression d'un utilisateur, et l'entrée de cache correspondante a été supprimée définitivement du stockage local de cette application en conséquence.</p>
 <ul>

--- a/src/Granit.Identity.Federated.Notifications/Templates/identity.user_provisioning_removed.html
+++ b/src/Granit.Identity.Federated.Notifications/Templates/identity.user_provisioning_removed.html
@@ -1,4 +1,4 @@
-<title>GDPR Art. 17 receipt: user {{ model.user_id }} removed from the platform</title>
+<title>GDPR Art. 17 receipt: user {{ model.user_id | html.escape }} removed from the platform</title>
 <p>Hello,</p>
 <p>This is a <strong>GDPR Art. 17 erasure receipt</strong>. The federated identity provider has confirmed the deletion of a user, and the corresponding cache entry has been hard-deleted from this application's local store accordingly.</p>
 <ul>

--- a/src/Granit.Identity.Federated.Privacy/DataDeletion/IdentityFederatedPersonalDataDeletionHandler.cs
+++ b/src/Granit.Identity.Federated.Privacy/DataDeletion/IdentityFederatedPersonalDataDeletionHandler.cs
@@ -39,14 +39,22 @@ public class IdentityFederatedPersonalDataDeletionHandler
         ArgumentNullException.ThrowIfNull(cacheEraser);
         ArgumentNullException.ThrowIfNull(currentTenant);
 
-        Guid? tenantId = @event.TenantId ?? currentTenant.Id;
-        await cacheEraser.EraseAsync(@event.UserId.ToString(), tenantId, cancellationToken).ConfigureAwait(false);
+        // Distributed dispatch carries no ambient tenant — establish it from the event so the
+        // multi-tenant query filter exposes the rows the eraser's explicit predicate targets;
+        // without it the erasure silently no-ops on tenant-scoped mirrors while the saga acks.
+        // A null resolved scope (no tenant on the event, none ambient) erases across ALL
+        // partitions: Art. 17 must not leave a mirror behind in any scope.
+        Guid? tenantId = @event.TenantId ?? (currentTenant.IsAvailable ? currentTenant.Id : null);
+        using IDisposable _ = currentTenant.Change(tenantId);
+
+        int affectedRecords = await cacheEraser
+            .EraseAsync(@event.UserId.ToString(), tenantId, cancellationToken).ConfigureAwait(false);
 
         return new PersonalDataDeletedEto(
             @event.RequestId,
             IdentityFederatedPrivacyDataProvider.ProviderName,
             DeletionAction.PhysicalDelete,
-            AffectedRecords: 0,
+            affectedRecords,
             Details: null,
             @event.TenantId);
     }

--- a/src/Granit.Identity.Federated/Handlers/IdentityUserEventHandler.cs
+++ b/src/Granit.Identity.Federated/Handlers/IdentityUserEventHandler.cs
@@ -4,6 +4,7 @@ using Granit.Identity.Federated.Domain;
 using Granit.Identity.Federated.Events;
 using Granit.Identity.Federated.Internal;
 using Granit.Identity.Federated.RateLimiting;
+using Granit.MultiTenancy;
 using Microsoft.Extensions.Logging;
 
 namespace Granit.Identity.Federated.Handlers;
@@ -15,6 +16,7 @@ internal sealed partial class IdentityUserEventHandler(
     IIdentityProvider identityProvider,
     IIdentityProviderCapabilities providerCapabilities,
     IUserCacheStore store,
+    ICurrentTenant currentTenant,
     ILocalEventBus localEventBus,
     IDistributedEventBus distributedEventBus,
     IUserSyncFailureRateLimiter syncFailureRateLimiter,
@@ -33,17 +35,23 @@ internal sealed partial class IdentityUserEventHandler(
 
     /// <summary>
     /// Handles a user deleted event by hard-deleting the cache entry (GDPR Art. 17).
+    /// A null <see cref="IdentityUserDeletedEto.TenantId"/> erases across all tenants.
     /// </summary>
     public async Task HandleAsync(IdentityUserDeletedEto @event, CancellationToken cancellationToken)
     {
-        await store.DeleteByExternalIdAsync(@event.UserId, @event.TenantId, cancellationToken)
+        // Distributed dispatch carries no ambient tenant — establish the event's scope so the
+        // multi-tenant query filter exposes the row the delete predicate targets. The null
+        // (all-tenants) case bypasses the filter inside the store, per the Eto contract.
+        using IDisposable _ = currentTenant.Change(@event.TenantId);
+
+        int deleted = await store.DeleteByExternalIdAsync(@event.UserId, @event.TenantId, cancellationToken)
             .ConfigureAwait(false);
 
         await localEventBus.PublishAsync(
             new FederatedIdentityErasedEvent(@event.UserId, @event.TenantId), cancellationToken)
             .ConfigureAwait(false);
 
-        LogUserCacheDeleted(@event.UserId);
+        LogUserCacheDeleted(@event.UserId, deleted);
     }
 
     // ──── Domain event handlers (provider-triggered) ────
@@ -140,6 +148,6 @@ internal sealed partial class IdentityUserEventHandler(
     [LoggerMessage(Level = LogLevel.Information, Message = "[AUDIT] User cache entry updated via {Source} for user {UserId}")]
     private partial void LogUserCacheUpdated(string userId, string source);
 
-    [LoggerMessage(Level = LogLevel.Information, Message = "[AUDIT] GDPR: user cache entry deleted via webhook for user {UserId}")]
-    private partial void LogUserCacheDeleted(string userId);
+    [LoggerMessage(Level = LogLevel.Information, Message = "[AUDIT] GDPR: {DeletedCount} user cache entries deleted via webhook for user {UserId}")]
+    private partial void LogUserCacheDeleted(string userId, int deletedCount);
 }

--- a/src/Granit.Identity.Federated/IFederatedUserCacheEraser.cs
+++ b/src/Granit.Identity.Federated/IFederatedUserCacheEraser.cs
@@ -9,10 +9,13 @@ namespace Granit.Identity.Federated;
 public interface IFederatedUserCacheEraser
 {
     /// <summary>
-    /// Permanently deletes the cached mirror for the given external user within a tenant
-    /// scope (GDPR Art. 17). A no-op if no entry is cached for that user.
+    /// Permanently deletes the cached mirror for the given external user (GDPR Art. 17) and
+    /// returns the number of rows removed. A <c>null</c> <paramref name="tenantId"/> erases the
+    /// mirror across ALL tenant partitions — the right to erasure must not leave a copy behind
+    /// in any scope; a non-null value deletes within that tenant only. A no-op (returns 0) if
+    /// no entry is cached for that user.
     /// </summary>
-    Task EraseAsync(
+    Task<int> EraseAsync(
         string externalUserId,
         Guid? tenantId,
         CancellationToken cancellationToken = default);

--- a/src/Granit.Identity.Federated/Internal/FederatedUserCacheEraserAdapter.cs
+++ b/src/Granit.Identity.Federated/Internal/FederatedUserCacheEraserAdapter.cs
@@ -9,7 +9,7 @@ namespace Granit.Identity.Federated.Internal;
 internal sealed class FederatedUserCacheEraserAdapter(IUserCacheStore store)
     : IFederatedUserCacheEraser
 {
-    public Task EraseAsync(
+    public Task<int> EraseAsync(
         string externalUserId, Guid? tenantId, CancellationToken cancellationToken = default) =>
         store.DeleteByExternalIdAsync(externalUserId, tenantId, cancellationToken);
 }

--- a/src/Granit.Identity.Federated/Internal/IUserCacheStore.cs
+++ b/src/Granit.Identity.Federated/Internal/IUserCacheStore.cs
@@ -52,8 +52,14 @@ internal interface IUserCacheStore
 
     // -- GDPR --
 
-    /// <summary>Permanently deletes the cache entry for a user (GDPR Art. 17).</summary>
-    Task DeleteByExternalIdAsync(string externalUserId, Guid? tenantId, CancellationToken cancellationToken = default);
+    /// <summary>
+    /// Permanently deletes the cache entry for a user (GDPR Art. 17) and returns the number of
+    /// rows removed. A <c>null</c> <paramref name="tenantId"/> erases the user's mirror across
+    /// ALL tenant partitions (the multi-tenant query filter is explicitly bypassed); a non-null
+    /// scope deletes within that tenant only and requires the caller to have established a
+    /// matching ambient tenant (<c>ICurrentTenant.Change</c>) so the tenant filter exposes the row.
+    /// </summary>
+    Task<int> DeleteByExternalIdAsync(string externalUserId, Guid? tenantId, CancellationToken cancellationToken = default);
 
     /// <summary>Purges all cache entries for a tenant.</summary>
     Task DeleteAllByTenantAsync(Guid? tenantId, CancellationToken cancellationToken = default);

--- a/src/Granit.Identity.Federated/Queries/FederatedIdentityQueryDefinition.cs
+++ b/src/Granit.Identity.Federated/Queries/FederatedIdentityQueryDefinition.cs
@@ -15,17 +15,22 @@ public sealed class FederatedIdentityQueryDefinition : QueryDefinition<Federated
     /// <inheritdoc/>
     protected override void Configure(QueryDefinitionBuilder<FederatedIdentity> builder)
     {
+        // Username, Email, FirstName, LastName are all [Encrypted] (random-IV AES): the
+        // ciphertext is non-deterministic, so LIKE/equality filters silently match nothing
+        // and sorts order by ciphertext. They stay projectable (shown in the grid, gated by
+        // *.Read) but are NOT filterable/sortable/searchable. Exact-match email lookup is
+        // served by the store via EmailHash, which is never surfaced as a grid column.
+        // (audit ARCHITECTURE #1)
         builder
             // Identity
             .Column(u => u.TenantId, c => c.Label("Tenant").LabelKey("Identity.Federated.Columns.Tenant").Filterable().Sortable())
             .Column(u => u.ExternalUserId, c => c.Label("External User ID").LabelKey("Identity.Federated.Columns.ExternalUserId").Filterable().Sortable())
-            .Column(u => u.Username, c => c.Label("Username").LabelKey("Identity.Federated.Columns.Username").Filterable().Sortable())
+            .Column(u => u.Username, c => c.Label("Username").LabelKey("Identity.Federated.Columns.Username"))
             // Contact (RGPD: PII — admin grid only, gated by *.Read permission)
-            .Column(u => u.Email, c => c.Label("Email").LabelKey("Identity.Federated.Columns.Email").Filterable().Sortable())
-            .Column(u => u.EmailHash, c => c.Label("Email Hash").LabelKey("Identity.Federated.Columns.EmailHash").Filterable())
+            .Column(u => u.Email, c => c.Label("Email").LabelKey("Identity.Federated.Columns.Email"))
             // Profile
-            .Column(u => u.FirstName, c => c.Label("First Name").LabelKey("Identity.Federated.Columns.FirstName").Filterable().Sortable())
-            .Column(u => u.LastName, c => c.Label("Last Name").LabelKey("Identity.Federated.Columns.LastName").Filterable().Sortable())
+            .Column(u => u.FirstName, c => c.Label("First Name").LabelKey("Identity.Federated.Columns.FirstName"))
+            .Column(u => u.LastName, c => c.Label("Last Name").LabelKey("Identity.Federated.Columns.LastName"))
             // State
             .Column(u => u.Enabled, c => c.Label("Enabled").LabelKey("Identity.Federated.Columns.Enabled").Filterable().Sortable())
             .Column(u => u.LastSyncedAt, c => c.Label("Last Synced At").LabelKey("Identity.Federated.Columns.LastSyncedAt").Sortable())
@@ -33,7 +38,7 @@ public sealed class FederatedIdentityQueryDefinition : QueryDefinition<Federated
             .Column(u => u.CreatedAt, c => c.Label("Created At").LabelKey("Identity.Federated.Columns.CreatedAt").Sortable())
             .Column(u => u.ModifiedAt, c => c.Label("Modified At").LabelKey("Identity.Federated.Columns.ModifiedAt").Sortable())
             .AllowGroupBy(u => u.Enabled)
-            .GlobalSearch(u => u.ExternalUserId, u => u.Username, u => u.Email, u => u.FirstName, u => u.LastName)
+            .GlobalSearch(u => u.ExternalUserId)
             .DateFilter(u => u.LastSyncedAt)
             .DefaultSort("-lastSyncedAt")
             .DefaultPageSize(25);

--- a/src/Granit.Identity.Local.Endpoints/Endpoints/AccountLoginEndpoints.cs
+++ b/src/Granit.Identity.Local.Endpoints/Endpoints/AccountLoginEndpoints.cs
@@ -3,6 +3,7 @@ using System.Security.Cryptography;
 using Granit.Auditing;
 using Granit.Auditing.Domain;
 using Granit.DataFiltering;
+using Granit.Diagnostics;
 using Granit.Domain;
 using Granit.Events;
 using Granit.Identity.Endpoints;
@@ -153,7 +154,7 @@ internal static partial class AccountLoginEndpoints
             // when the user does not exist (covers the bulk of the timing gap).
             PerformDummyPasswordHash(httpContext);
 
-            LogLoginFailed(logger, request.Login, "user_not_found");
+            LogLoginFailed(logger, LogRedaction.Username(request.Login), "user_not_found");
             metrics?.RecordAuthenticationFailure(null, InvalidLoginReason);
             await TryWriteAuthAuditAsync(httpContext, logger,
                 method: LocalLoginMethod, userId: null, userName: null,
@@ -252,7 +253,7 @@ internal static partial class AccountLoginEndpoints
         }
 
         // Generic failure (wrong password)
-        LogLoginFailed(logger, request.Login, "invalid_password");
+        LogLoginFailed(logger, LogRedaction.Username(request.Login), "invalid_password");
         metrics?.RecordAuthenticationFailure(null, InvalidLoginReason);
         await TryWriteAuthAuditAsync(httpContext, logger,
             method: LocalLoginMethod, userId: user.Id.ToString(), userName: user.UserName,

--- a/src/Granit.Identity/Queries/UserQueryDefinition.cs
+++ b/src/Granit.Identity/Queries/UserQueryDefinition.cs
@@ -24,10 +24,15 @@ public sealed class UserQueryDefinition : QueryDefinition<User>
     protected override void Configure(QueryDefinitionBuilder<User> builder) =>
         builder
             .Column(u => u.DisplayName, c => c.Label("Name").LabelKey("Identity.Columns.DisplayName").Filterable().Sortable())
-            .Column(u => u.Email, c => c.Label("Email").LabelKey("Identity.Columns.Email").Filterable().Sortable())
+            // Email and PhoneNumber are [Encrypted] (random-IV AES): the ciphertext is
+            // non-deterministic, so LIKE/equality filters silently match nothing and sort
+            // orders by ciphertext. They stay projectable (shown in the grid) but are NOT
+            // filterable/sortable/searchable. Exact-match equality is routed through the
+            // *Hash lookup columns elsewhere, not the admin grid. (audit ARCHITECTURE #1)
+            .Column(u => u.Email, c => c.Label("Email").LabelKey("Identity.Columns.Email"))
             .Column(u => u.FirstName, c => c.Label("First Name").LabelKey("Identity.Columns.FirstName").Filterable().Sortable())
             .Column(u => u.LastName, c => c.Label("Last Name").LabelKey("Identity.Columns.LastName").Filterable().Sortable())
-            .Column(u => u.PhoneNumber, c => c.Label("Phone").LabelKey("Identity.Columns.PhoneNumber").Filterable())
+            .Column(u => u.PhoneNumber, c => c.Label("Phone").LabelKey("Identity.Columns.PhoneNumber"))
             .Column(u => u.IsEnabled, c => c.Label("Enabled").LabelKey("Identity.Columns.IsEnabled").Filterable().Sortable())
             .Column(u => u.PreferredLocale, c => c.Label("Locale").LabelKey("Identity.Columns.PreferredLocale").Filterable())
             .Column(u => u.Timezone, c => c.Label("Timezone").LabelKey("Identity.Columns.Timezone").Filterable())
@@ -35,7 +40,7 @@ public sealed class UserQueryDefinition : QueryDefinition<User>
             .Column(u => u.CreatedAt, c => c.Label("Created At").LabelKey("Identity.Columns.CreatedAt").Sortable())
             .Column(u => u.ModifiedAt, c => c.Label("Modified At").LabelKey("Identity.Columns.ModifiedAt").Sortable())
             .AllowGroupBy(u => u.IsEnabled)
-            .GlobalSearch(u => u.DisplayName!, u => u.Email!, u => u.FirstName!, u => u.LastName!)
+            .GlobalSearch(u => u.DisplayName!, u => u.FirstName!, u => u.LastName!)
             .DefaultSort("-CreatedAt")
             .DefaultPageSize(25);
 }

--- a/tests/Granit.Identity.Federated.EntityFrameworkCore.Tests/EfCoreUserCacheStoreDiagnosticsTests.cs
+++ b/tests/Granit.Identity.Federated.EntityFrameworkCore.Tests/EfCoreUserCacheStoreDiagnosticsTests.cs
@@ -1,0 +1,79 @@
+using Granit.Identity.Federated.Domain;
+using Granit.Identity.Federated.EntityFrameworkCore.Internal;
+using Granit.Identity.Federated.Internal;
+using Microsoft.EntityFrameworkCore;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Identity.Federated.EntityFrameworkCore.Tests;
+
+/// <summary>
+/// Staleness-diagnostics tests kept on the EF Core In-Memory provider: SQLite cannot
+/// translate comparisons or Min/Max aggregates on <see cref="DateTimeOffset"/> columns
+/// (<c>LastSyncedAt</c>), which PostgreSQL — the production provider — handles natively.
+/// Only pure host-scope diagnostics live here; everything with tenant-filter semantics is
+/// covered by the SQLite-backed <see cref="EfCoreUserCacheStoreTests"/>.
+/// </summary>
+public sealed class EfCoreUserCacheStoreDiagnosticsTests : IDisposable
+{
+    private readonly TestDataFilter _filter = new();
+
+    public void Dispose() => _filter.Dispose();
+
+    private EfCoreUserCacheStore CreateStore()
+    {
+        DbContextOptions<IdentityFederatedDbContext> options = new DbContextOptionsBuilder<IdentityFederatedDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        TestIdentityFederatedDbContextFactory factory = new(options, _filter.Filter);
+
+        IUserLookupHasher hasher = Substitute.For<IUserLookupHasher>();
+        hasher.ComputeEmailHash(Arg.Any<string?>()).Returns((string?)null);
+        return new EfCoreUserCacheStore(factory, hasher);
+    }
+
+    private static FederatedIdentity CreateEntry(string externalUserId, DateTimeOffset lastSyncedAt) => new()
+    {
+        Id = Guid.NewGuid(),
+        ExternalUserId = externalUserId,
+        Username = "jdoe",
+        Email = null,
+        Enabled = true,
+        LastSyncedAt = lastSyncedAt,
+        TenantId = null
+    };
+
+    [Fact]
+    public async Task GetStaleCountAsync_CountsStaleEntries()
+    {
+        EfCoreUserCacheStore store = CreateStore();
+
+        await store.UpsertAsync(CreateEntry("user-fresh", DateTimeOffset.UtcNow), TestContext.Current.CancellationToken);
+        await store.UpsertAsync(CreateEntry("user-stale", DateTimeOffset.UtcNow.AddDays(-2)), TestContext.Current.CancellationToken);
+
+        DateTimeOffset threshold = DateTimeOffset.UtcNow.AddDays(-1);
+        int staleCount = await store.GetStaleCountAsync(null, threshold, TestContext.Current.CancellationToken);
+
+        staleCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task GetSyncRangeAsync_ReturnsOldestAndNewest()
+    {
+        EfCoreUserCacheStore store = CreateStore();
+
+        await store.UpsertAsync(
+            CreateEntry("user-old", new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero)),
+            TestContext.Current.CancellationToken);
+        await store.UpsertAsync(
+            CreateEntry("user-recent", new DateTimeOffset(2024, 6, 1, 0, 0, 0, TimeSpan.Zero)),
+            TestContext.Current.CancellationToken);
+
+        (DateTimeOffset? oldest, DateTimeOffset? newest) = await store.GetSyncRangeAsync(
+            null, TestContext.Current.CancellationToken);
+
+        oldest.ShouldBe(new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero));
+        newest.ShouldBe(new DateTimeOffset(2024, 6, 1, 0, 0, 0, TimeSpan.Zero));
+    }
+}

--- a/tests/Granit.Identity.Federated.EntityFrameworkCore.Tests/EfCoreUserCacheStoreTests.cs
+++ b/tests/Granit.Identity.Federated.EntityFrameworkCore.Tests/EfCoreUserCacheStoreTests.cs
@@ -1,6 +1,8 @@
 using Granit.Identity.Federated.Domain;
 using Granit.Identity.Federated.EntityFrameworkCore.Internal;
 using Granit.Identity.Federated.Internal;
+using Granit.Testing.Fakes;
+using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using NSubstitute;
 using Shouldly;
@@ -8,12 +10,22 @@ using Xunit;
 
 namespace Granit.Identity.Federated.EntityFrameworkCore.Tests;
 
+/// <summary>
+/// SQLite-backed store tests with the <c>IMultiTenant</c> query filter ACTIVE, mirroring
+/// production. The EF Core In-Memory provider silently ignores query filters, which is
+/// exactly how the tenant-scoped GDPR-erasure no-op stayed invisible to CI — tests that
+/// touch tenant-scoped rows must establish an ambient tenant via
+/// <see cref="FakeCurrentTenant.Change"/>, the same contract production callers follow.
+/// </summary>
 public sealed class EfCoreUserCacheStoreTests : IDisposable
 {
     private static readonly IUserLookupHasher Hasher = CreateHasher();
-    private readonly TestDataFilter _filter = new();
+    private readonly SqliteConnection _connection = new("DataSource=:memory:");
+    private readonly FakeCurrentTenant _tenant = new();
 
-    public void Dispose() => _filter.Dispose();
+    public EfCoreUserCacheStoreTests() => _connection.Open();
+
+    public void Dispose() => _connection.Dispose();
 
     private static IUserLookupHasher CreateHasher()
     {
@@ -31,9 +43,15 @@ public sealed class EfCoreUserCacheStoreTests : IDisposable
     private EfCoreUserCacheStore CreateStore()
     {
         DbContextOptions<IdentityFederatedDbContext> options = new DbContextOptionsBuilder<IdentityFederatedDbContext>()
-            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .UseSqlite(_connection)
             .Options;
-        TestIdentityFederatedDbContextFactory factory = new(options, _filter.Filter);
+        TestIdentityFederatedDbContextFactory factory = new(options, dataFilter: null, _tenant);
+
+        using (IdentityFederatedDbContext db = factory.CreateDbContext())
+        {
+            db.Database.EnsureCreated();
+        }
+
         return new EfCoreUserCacheStore(factory, Hasher);
     }
 
@@ -55,6 +73,12 @@ public sealed class EfCoreUserCacheStoreTests : IDisposable
             LastSyncedAt = DateTimeOffset.UtcNow,
             TenantId = tenantId
         };
+
+    private async Task UpsertScopedAsync(EfCoreUserCacheStore store, FederatedIdentity entry)
+    {
+        using IDisposable _ = _tenant.Change(entry.TenantId);
+        await store.UpsertAsync(entry, TestContext.Current.CancellationToken);
+    }
 
     [Fact]
     public async Task FindByExternalIdAsync_ReturnsNull_WhenNotFound()
@@ -118,8 +142,11 @@ public sealed class EfCoreUserCacheStoreTests : IDisposable
         EfCoreUserCacheStore store = CreateStore();
         var tenantId = Guid.NewGuid();
 
-        await store.UpsertAsync(CreateEntry("user-1", tenantId: tenantId), TestContext.Current.CancellationToken);
+        await UpsertScopedAsync(store, CreateEntry("user-1", tenantId: tenantId));
 
+        // Host context (no ambient tenant): the documented contract is "regardless of
+        // tenant" — the store must bypass the multi-tenant filter or the cache-aside
+        // caller re-inserts a duplicate host-scope row for an already-mirrored user.
         FederatedIdentity? result = await store.FindFirstByExternalIdAsync(
             "user-1", TestContext.Current.CancellationToken);
 
@@ -134,20 +161,43 @@ public sealed class EfCoreUserCacheStoreTests : IDisposable
         var tenant1 = Guid.NewGuid();
         var tenant2 = Guid.NewGuid();
 
-        await store.UpsertAsync(CreateEntry("user-1", tenantId: tenant1, username: "tenant1-jdoe"),
-            TestContext.Current.CancellationToken);
-        await store.UpsertAsync(CreateEntry("user-1", tenantId: tenant2, username: "tenant2-jdoe"),
-            TestContext.Current.CancellationToken);
+        await UpsertScopedAsync(store, CreateEntry("user-1", tenantId: tenant1, username: "tenant1-jdoe"));
+        await UpsertScopedAsync(store, CreateEntry("user-1", tenantId: tenant2, username: "tenant2-jdoe"));
 
-        FederatedIdentity? fromTenant1 = await store.FindByExternalIdAsync(
-            "user-1", tenant1, TestContext.Current.CancellationToken);
-        FederatedIdentity? fromTenant2 = await store.FindByExternalIdAsync(
-            "user-1", tenant2, TestContext.Current.CancellationToken);
+        using (_tenant.Change(tenant1))
+        {
+            FederatedIdentity? fromTenant1 = await store.FindByExternalIdAsync(
+                "user-1", tenant1, TestContext.Current.CancellationToken);
+            fromTenant1.ShouldNotBeNull();
+            fromTenant1.Username.ShouldBe("tenant1-jdoe");
+        }
 
-        fromTenant1.ShouldNotBeNull();
-        fromTenant1.Username.ShouldBe("tenant1-jdoe");
-        fromTenant2.ShouldNotBeNull();
-        fromTenant2.Username.ShouldBe("tenant2-jdoe");
+        using (_tenant.Change(tenant2))
+        {
+            FederatedIdentity? fromTenant2 = await store.FindByExternalIdAsync(
+                "user-1", tenant2, TestContext.Current.CancellationToken);
+            fromTenant2.ShouldNotBeNull();
+            fromTenant2.Username.ShouldBe("tenant2-jdoe");
+        }
+    }
+
+    [Fact]
+    public async Task MultiTenantFilter_HidesOtherTenantsRows()
+    {
+        EfCoreUserCacheStore store = CreateStore();
+        var tenant1 = Guid.NewGuid();
+        var tenant2 = Guid.NewGuid();
+
+        await UpsertScopedAsync(store, CreateEntry("user-1", tenantId: tenant1));
+
+        // Reading tenant1's row under tenant2's ambient scope must fail closed — this is
+        // the row-level isolation the In-Memory provider never exercised.
+        using (_tenant.Change(tenant2))
+        {
+            FederatedIdentity? crossTenant = await store.FindByExternalIdAsync(
+                "user-1", tenant1, TestContext.Current.CancellationToken);
+            crossTenant.ShouldBeNull();
+        }
     }
 
     [Fact]
@@ -187,45 +237,6 @@ public sealed class EfCoreUserCacheStoreTests : IDisposable
     }
 
     [Fact]
-    public async Task GetStaleCountAsync_CountsStaleEntries()
-    {
-        EfCoreUserCacheStore store = CreateStore();
-
-        FederatedIdentity fresh = CreateEntry("user-fresh");
-        fresh.LastSyncedAt = DateTimeOffset.UtcNow;
-        await store.UpsertAsync(fresh, TestContext.Current.CancellationToken);
-
-        FederatedIdentity stale = CreateEntry("user-stale");
-        stale.LastSyncedAt = DateTimeOffset.UtcNow.AddDays(-2);
-        await store.UpsertAsync(stale, TestContext.Current.CancellationToken);
-
-        DateTimeOffset threshold = DateTimeOffset.UtcNow.AddDays(-1);
-        int staleCount = await store.GetStaleCountAsync(null, threshold, TestContext.Current.CancellationToken);
-
-        staleCount.ShouldBe(1);
-    }
-
-    [Fact]
-    public async Task GetSyncRangeAsync_ReturnsOldestAndNewest()
-    {
-        EfCoreUserCacheStore store = CreateStore();
-
-        FederatedIdentity old = CreateEntry("user-old");
-        old.LastSyncedAt = new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero);
-        await store.UpsertAsync(old, TestContext.Current.CancellationToken);
-
-        FederatedIdentity recent = CreateEntry("user-recent");
-        recent.LastSyncedAt = new DateTimeOffset(2024, 6, 1, 0, 0, 0, TimeSpan.Zero);
-        await store.UpsertAsync(recent, TestContext.Current.CancellationToken);
-
-        (DateTimeOffset? oldest, DateTimeOffset? newest) = await store.GetSyncRangeAsync(
-            null, TestContext.Current.CancellationToken);
-
-        oldest.ShouldBe(new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero));
-        newest.ShouldBe(new DateTimeOffset(2024, 6, 1, 0, 0, 0, TimeSpan.Zero));
-    }
-
-    [Fact]
     public async Task GetSyncRangeAsync_ReturnsNulls_WhenEmpty()
     {
         EfCoreUserCacheStore store = CreateStore();
@@ -251,21 +262,108 @@ public sealed class EfCoreUserCacheStoreTests : IDisposable
     }
 
     [Fact]
+    public async Task DeleteByExternalIdAsync_NullTenant_SweepsAllTenantPartitions()
+    {
+        // GDPR Art. 17 regression (audit BREAKING #2): a null tenant scope is documented on
+        // IdentityUserDeletedEto as "deletes across all tenants" but used to translate to
+        // "TenantId IS NULL" — host rows only — leaving every tenant mirror in place while
+        // the erasure acked. Red on the old implementation, green with the explicit sweep.
+        EfCoreUserCacheStore store = CreateStore();
+        var tenant1 = Guid.NewGuid();
+        var tenant2 = Guid.NewGuid();
+
+        await UpsertScopedAsync(store, CreateEntry("user-1", tenantId: tenant1));
+        await UpsertScopedAsync(store, CreateEntry("user-1", tenantId: tenant2));
+        await store.UpsertAsync(CreateEntry("user-1"), TestContext.Current.CancellationToken);
+        await UpsertScopedAsync(store, CreateEntry("user-2", tenantId: tenant1, username: "survivor"));
+
+        await store.DeleteByExternalIdAsync("user-1", null, TestContext.Current.CancellationToken);
+
+        using (_tenant.Change(tenant1))
+        {
+            (await store.FindByExternalIdAsync("user-1", tenant1, TestContext.Current.CancellationToken))
+                .ShouldBeNull();
+            (await store.FindByExternalIdAsync("user-2", tenant1, TestContext.Current.CancellationToken))
+                .ShouldNotBeNull();
+        }
+
+        using (_tenant.Change(tenant2))
+        {
+            (await store.FindByExternalIdAsync("user-1", tenant2, TestContext.Current.CancellationToken))
+                .ShouldBeNull();
+        }
+
+        (await store.FindByExternalIdAsync("user-1", null, TestContext.Current.CancellationToken))
+            .ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task DeleteByExternalIdAsync_TenantScoped_DeletesOnlyThatTenant_AndReturnsCount()
+    {
+        EfCoreUserCacheStore store = CreateStore();
+        var tenant1 = Guid.NewGuid();
+        var tenant2 = Guid.NewGuid();
+
+        await UpsertScopedAsync(store, CreateEntry("user-1", tenantId: tenant1));
+        await UpsertScopedAsync(store, CreateEntry("user-1", tenantId: tenant2));
+
+        int deleted;
+        using (_tenant.Change(tenant1))
+        {
+            deleted = await store.DeleteByExternalIdAsync(
+                "user-1", tenant1, TestContext.Current.CancellationToken);
+        }
+
+        deleted.ShouldBe(1);
+        using (_tenant.Change(tenant2))
+        {
+            (await store.FindByExternalIdAsync("user-1", tenant2, TestContext.Current.CancellationToken))
+                .ShouldNotBeNull();
+        }
+    }
+
+    [Fact]
+    public async Task DeleteByExternalIdAsync_TenantScoped_WithoutAmbientScope_FailsClosed()
+    {
+        // Pins the residual sharp edge until the tenant-explicit store seam lands: a
+        // tenant-scoped delete issued without a matching ambient tenant must not touch the
+        // row (the filter hides it — fail closed, 0 affected). Callers are responsible for
+        // establishing scope via ICurrentTenant.Change, as the Wolverine handlers now do.
+        EfCoreUserCacheStore store = CreateStore();
+        var tenant1 = Guid.NewGuid();
+
+        await UpsertScopedAsync(store, CreateEntry("user-1", tenantId: tenant1));
+
+        int deleted = await store.DeleteByExternalIdAsync(
+            "user-1", tenant1, TestContext.Current.CancellationToken);
+
+        deleted.ShouldBe(0);
+        using (_tenant.Change(tenant1))
+        {
+            (await store.FindByExternalIdAsync("user-1", tenant1, TestContext.Current.CancellationToken))
+                .ShouldNotBeNull();
+        }
+    }
+
+    [Fact]
     public async Task DeleteAllByTenantAsync_RemovesAllTenantEntries()
     {
         EfCoreUserCacheStore store = CreateStore();
         var tenantId = Guid.NewGuid();
 
-        await store.UpsertAsync(CreateEntry("user-1", tenantId: tenantId), TestContext.Current.CancellationToken);
-        await store.UpsertAsync(CreateEntry("user-2", tenantId: tenantId), TestContext.Current.CancellationToken);
+        await UpsertScopedAsync(store, CreateEntry("user-1", tenantId: tenantId));
+        await UpsertScopedAsync(store, CreateEntry("user-2", tenantId: tenantId));
         await store.UpsertAsync(CreateEntry("user-3"), TestContext.Current.CancellationToken); // no tenant
 
-        await store.DeleteAllByTenantAsync(tenantId, TestContext.Current.CancellationToken);
+        using (_tenant.Change(tenantId))
+        {
+            await store.DeleteAllByTenantAsync(tenantId, TestContext.Current.CancellationToken);
 
-        int tenantCount = await store.GetCountAsync(tenantId, TestContext.Current.CancellationToken);
+            int tenantCount = await store.GetCountAsync(tenantId, TestContext.Current.CancellationToken);
+            tenantCount.ShouldBe(0);
+        }
+
         int globalCount = await store.GetCountAsync(null, TestContext.Current.CancellationToken);
-
-        tenantCount.ShouldBe(0);
         globalCount.ShouldBe(1);
     }
 

--- a/tests/Granit.Identity.Federated.EntityFrameworkCore.Tests/Granit.Identity.Federated.EntityFrameworkCore.Tests.csproj
+++ b/tests/Granit.Identity.Federated.EntityFrameworkCore.Tests/Granit.Identity.Federated.EntityFrameworkCore.Tests.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="Bogus" />
     <PackageReference Include="coverlet.collector" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Granit.Identity.Federated.EntityFrameworkCore.Tests/TestIdentityFederatedDbContextFactory.cs
+++ b/tests/Granit.Identity.Federated.EntityFrameworkCore.Tests/TestIdentityFederatedDbContextFactory.cs
@@ -1,5 +1,6 @@
 using Granit.DataFiltering;
 using Granit.Identity.Federated.EntityFrameworkCore.Internal;
+using Granit.MultiTenancy;
 using Granit.Persistence.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 
@@ -7,17 +8,20 @@ namespace Granit.Identity.Federated.EntityFrameworkCore.Tests;
 
 /// <summary>
 /// Test factory that opens fresh <see cref="IdentityFederatedDbContext"/> instances over a
-/// shared <see cref="DbContextOptions{T}"/>. Each instance is wired with the supplied
-/// <see cref="IDataFilter"/> so tests can opt out of the <c>IMultiTenant</c> filter
-/// without setting up an ambient <c>ICurrentTenant</c>.
+/// shared <see cref="DbContextOptions{T}"/>. Pass an <see cref="ICurrentTenant"/> (e.g. a
+/// <c>FakeCurrentTenant</c>) to exercise the <c>IMultiTenant</c> query filter the way
+/// production scopes do; pass an <see cref="IDataFilter"/> only to opt out of the filter
+/// entirely (legacy tests).
 /// </summary>
 internal sealed class TestIdentityFederatedDbContextFactory(
     DbContextOptions<IdentityFederatedDbContext> options,
-    IDataFilter? dataFilter = null) : IDbContextFactory<IdentityFederatedDbContext>
+    IDataFilter? dataFilter = null,
+    ICurrentTenant? currentTenant = null) : IDbContextFactory<IdentityFederatedDbContext>
 {
     public IdentityFederatedDbContext CreateDbContext()
-        => new(options, GranitDesignTime.CurrentTenant, dataFilter);
+        => new(options, currentTenant ?? GranitDesignTime.CurrentTenant, dataFilter);
 
     public Task<IdentityFederatedDbContext> CreateDbContextAsync(CancellationToken cancellationToken = default)
-        => Task.FromResult<IdentityFederatedDbContext>(new(options, GranitDesignTime.CurrentTenant, dataFilter));
+        => Task.FromResult<IdentityFederatedDbContext>(
+            new(options, currentTenant ?? GranitDesignTime.CurrentTenant, dataFilter));
 }

--- a/tests/Granit.Identity.Federated.EntityFrameworkCore.Tests/packages.lock.json
+++ b/tests/Granit.Identity.Federated.EntityFrameworkCore.Tests/packages.lock.json
@@ -37,6 +37,21 @@
           "Microsoft.Extensions.Logging": "10.0.10"
         }
       },
+      "Microsoft.EntityFrameworkCore.Sqlite": {
+        "type": "Direct",
+        "requested": "[10.*, )",
+        "resolved": "10.0.10",
+        "contentHash": "kzg9MuQNJvZQxAU+piSkEzc7/1tpW6n1nVSGGMObu2GgxLK8Nf+6fvZundaznTZ+O2KhfPZ8HFNCzMH3PWDUmA==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Sqlite.Core": "10.0.10",
+          "Microsoft.Extensions.Caching.Memory": "10.0.10",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.10",
+          "Microsoft.Extensions.DependencyModel": "10.0.10",
+          "Microsoft.Extensions.Logging": "10.0.10",
+          "SQLitePCLRaw.bundle_e_sqlite3": "2.1.11",
+          "SQLitePCLRaw.core": "2.1.11"
+        }
+      },
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
         "requested": "[18.*, )",
@@ -71,6 +86,22 @@
           "DiffEngine": "11.3.0",
           "EmptyFiles": "4.4.0"
         }
+      },
+      "SQLitePCLRaw.bundle_e_sqlite3": {
+        "type": "Direct",
+        "requested": "[3.0.3, )",
+        "resolved": "3.0.3",
+        "contentHash": "Zt8jmSL5zcDWGk8rmzhWBJ6IRyLWh1yWS04Pg72+GIvo3Ba4E/rG4Y/4l7AWlSEogEbzyKRTCXUAs1v/O7Pkkg==",
+        "dependencies": {
+          "SQLitePCLRaw.config.e_sqlite3": "3.0.3",
+          "SourceGear.sqlite3": "3.50.4.5"
+        }
+      },
+      "SQLitePCLRaw.core": {
+        "type": "Direct",
+        "requested": "[3.0.3, )",
+        "resolved": "3.0.3",
+        "contentHash": "bjm6FY4lZyP+t7GmiuvSM0QXpFihAvyE0Y9O2yibm3g95AAWJPNnHOKVNJGyPTGIKuK7Pr4Wh8Rd8/aOtAclQw=="
       },
       "xunit.runner.visualstudio": {
         "type": "Direct",
@@ -129,6 +160,14 @@
         "resolved": "18.8.1",
         "contentHash": "Eclse/ZZjr4lmWzZFNN9h/OluhKL+SK/QbUyKUewgX139aGeyMEO/DkMPwuFs2MixvanTnz6891rF8UHDg+W4Q=="
       },
+      "Microsoft.Data.Sqlite.Core": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "TPCs0ldm7AWqcKmp6f/Xr+14sat7hx4rHfRlS4RgCURBH2thEWbAKEyX7cCWr63zVJVOJIJZTg2cBiUXa8ys6g==",
+        "dependencies": {
+          "SQLitePCLRaw.core": "2.1.11"
+        }
+      },
       "Microsoft.EntityFrameworkCore.Abstractions": {
         "type": "Transitive",
         "resolved": "10.0.10",
@@ -138,6 +177,20 @@
         "type": "Transitive",
         "resolved": "10.0.10",
         "contentHash": "2gLDordUCGf3aNOOuqtTbP5mxhiP9nk6TnvGiE3RnqT891O+Zf/qKu1PIREubs1M16A0SImr4vULBfU5BTDs1Q=="
+      },
+      "Microsoft.EntityFrameworkCore.Sqlite.Core": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "YbVWMIouzwTKBiLms8boa7xeRT88wI14R1msv3XExFk9n0/sa8nU7MwDa1CKtfLGMJs7O7QWuS9/xhcQ72AD2A==",
+        "dependencies": {
+          "Microsoft.Data.Sqlite.Core": "10.0.10",
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.10",
+          "Microsoft.Extensions.Caching.Memory": "10.0.10",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.10",
+          "Microsoft.Extensions.DependencyModel": "10.0.10",
+          "Microsoft.Extensions.Logging": "10.0.10",
+          "SQLitePCLRaw.core": "2.1.11"
+        }
       },
       "Microsoft.Extensions.Configuration": {
         "type": "Transitive",
@@ -415,6 +468,27 @@
         "type": "Transitive",
         "resolved": "5.0.0",
         "contentHash": "dDoKi0PnDz31yAyETfRntsLArTlVAVzUzCIvvEDsDsucrl33Dl8pIJG06ePTJTI3tGpeyHS9Cq7Foc/s4EeKcg=="
+      },
+      "SourceGear.sqlite3": {
+        "type": "Transitive",
+        "resolved": "3.50.4.5",
+        "contentHash": "UtnipXhJYZKQOQIfpws/msLK7IRhMplE1CZCaZLIQXRnGD474QVpO/J9nMlQQY8NZueGz1aidjoxDRnrC1NT3Q=="
+      },
+      "SQLitePCLRaw.config.e_sqlite3": {
+        "type": "Transitive",
+        "resolved": "3.0.3",
+        "contentHash": "caP/ap0X2fyVmstCXu5ueOmcr2XWAxA2XyKghV7H4bOAFmq3nWcsGl9q44iY1HYG+i8Qr4G9XEqdfti0rV6/ZQ==",
+        "dependencies": {
+          "SQLitePCLRaw.provider.e_sqlite3": "3.0.3"
+        }
+      },
+      "SQLitePCLRaw.provider.e_sqlite3": {
+        "type": "Transitive",
+        "resolved": "3.0.3",
+        "contentHash": "wd+fGvZTrr3BJNe48opSczmC176Okd61ZgoZNQcdvZwkek6to978ccdpcFmNo5GHxCnk29KwT+f+lAZYgfLVZg==",
+        "dependencies": {
+          "SQLitePCLRaw.core": "3.0.3"
+        }
       },
       "System.CodeDom": {
         "type": "Transitive",

--- a/tests/Granit.Identity.Federated.EntraId.Tests/EntraIdAdminOptionsTests.cs
+++ b/tests/Granit.Identity.Federated.EntraId.Tests/EntraIdAdminOptionsTests.cs
@@ -52,6 +52,38 @@ public sealed class EntraIdAdminOptionsTests
     }
 
     [Fact]
+    public void GetUsersEndpoint_WithQuoteInSearch_EscapesODataLiteral()
+    {
+        // Graph URL-decodes %27 back to ' before parsing $filter, so a raw quote breaks
+        // out of the literal and rewrites the predicate. OData escaping doubles it.
+        string endpoint = EntraIdAdminOptions.GetUsersEndpoint(search: "O'Brien");
+
+        endpoint.ShouldContain("O%27%27Brien");
+        endpoint.ShouldNotContain("O%27Brien");
+    }
+
+    [Fact]
+    public void GetUsersEndpoint_WithInjectionAttempt_CannotBreakOutOfLiteral()
+    {
+        string endpoint = EntraIdAdminOptions.GetUsersEndpoint(search: "x') or accountEnabled eq true or startswith(mail,'");
+
+        // Every quote in the payload is doubled (OData ABNF) then percent-encoded: after
+        // Graph URL-decodes, the value stays a single string literal and the injected
+        // predicate is inert text. A lone %27 (single quote) would signal a break-out.
+        endpoint.ShouldContain("x%27%27");
+        endpoint.ShouldNotContain("x%27)");
+    }
+
+    [Fact]
+    public void GetAuditSignInsEndpoint_WithQuoteInUserId_EscapesODataLiteral()
+    {
+        string endpoint = EntraIdAdminOptions.GetAuditSignInsEndpoint("abc'def");
+
+        endpoint.ShouldContain("abc%27%27def");
+        endpoint.ShouldNotContain("abc%27def");
+    }
+
+    [Fact]
     public void GetUserEndpoint_ReturnsCorrectUrlWithEscapedUserId()
     {
         string endpoint = EntraIdAdminOptions.GetUserEndpoint("user-123");

--- a/tests/Granit.Identity.Federated.EntraId.Tests/EntraIdIdentityProviderTests.cs
+++ b/tests/Granit.Identity.Federated.EntraId.Tests/EntraIdIdentityProviderTests.cs
@@ -107,6 +107,34 @@ public sealed class EntraIdIdentityProviderTests : IDisposable
         result.ShouldBeEmpty();
     }
 
+    [Theory]
+    [InlineData("x') or accountEnabled eq true or startswith(mail,'")]
+    [InlineData("a\" or 1 eq 1")]
+    [InlineData("test\r\nHost: evil")]
+    public async Task GetUsersAsync_WithInjectionAttemptInSearch_RejectsWithoutCallingGraph(string search)
+    {
+        // OData $filter injection defense: input outside the display-name/email character
+        // whitelist is rejected before any Graph call (same pattern as the Cognito provider).
+        IReadOnlyList<IIdentityUser> result = await _provider.GetUsersAsync(
+            search, cancellationToken: TestContext.Current.CancellationToken);
+
+        result.ShouldBeEmpty();
+        _handler.Requests.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task GetUsersAsync_WithApostropheInSearch_IsAllowedAndODataEscaped()
+    {
+        // Legitimate names contain apostrophes (O'Brien) — allowed through the whitelist,
+        // neutralised by OData quote doubling in the URL builder.
+        _handler.ResponseBody = """{"value":[]}""";
+
+        await _provider.GetUsersAsync("O'Brien", cancellationToken: TestContext.Current.CancellationToken);
+
+        _handler.Requests.Count.ShouldBe(1);
+        _handler.Requests[0].Url.ShouldContain("O%27%27Brien");
+    }
+
     // --- GetUserAsync tests ---
 
     [Fact]

--- a/tests/Granit.Identity.Federated.GoogleCloud.Tests/GoogleCloudIdentityProviderCapabilitiesTests.cs
+++ b/tests/Granit.Identity.Federated.GoogleCloud.Tests/GoogleCloudIdentityProviderCapabilitiesTests.cs
@@ -17,8 +17,9 @@ public sealed class GoogleCloudIdentityProviderCapabilitiesTests
         _sut.SupportsIndividualSessionTermination.ShouldBeFalse();
 
     [Fact]
-    public void SupportsNativePasswordResetEmail_IsTrue() =>
-        _sut.SupportsNativePasswordResetEmail.ShouldBeTrue();
+    public void SupportsNativePasswordResetEmail_IsFalse() =>
+        // Admin SDK generates reset links but never sends the email.
+        _sut.SupportsNativePasswordResetEmail.ShouldBeFalse();
 
     [Fact]
     public void SupportsGroupHierarchy_IsFalse() =>
@@ -33,8 +34,9 @@ public sealed class GoogleCloudIdentityProviderCapabilitiesTests
         _sut.MaxCustomAttributes.ShouldBe(100);
 
     [Fact]
-    public void SupportsCredentialVerification_IsTrue() =>
-        _sut.SupportsCredentialVerification.ShouldBeTrue();
+    public void SupportsCredentialVerification_IsFalse() =>
+        // Admin SDK exposes no password-verify API (needs the REST API + Web API key).
+        _sut.SupportsCredentialVerification.ShouldBeFalse();
 
     [Fact]
     public void SupportsUserCreation_IsTrue() =>

--- a/tests/Granit.Identity.Federated.GoogleCloud.Tests/GoogleCloudIdentityProviderTests.cs
+++ b/tests/Granit.Identity.Federated.GoogleCloud.Tests/GoogleCloudIdentityProviderTests.cs
@@ -231,19 +231,16 @@ public sealed class GoogleCloudIdentityProviderTests
     // ── Password ────────────────────────────────────────────────────────
 
     [Fact]
-    public async Task SendPasswordResetEmailAsync_GeneratesResetLink()
+    public async Task SendPasswordResetEmailAsync_ThrowsNotSupported()
     {
-        UserRecord user = CreateUserRecord("uid-1", "john@example.com", "John Doe");
-        _transport.GetUserAsync("uid-1", Arg.Any<CancellationToken>()).Returns(user);
-        _transport.GeneratePasswordResetLinkAsync("john@example.com", Arg.Any<CancellationToken>())
-            .Returns("https://reset-link");
+        // The Admin SDK can only generate a reset link, never send the email — the
+        // capability is advertised false and a direct call must fail loud instead of
+        // publishing an Eto for an email that never left.
+        await Should.ThrowAsync<NotSupportedException>(
+            () => _sut.SendPasswordResetEmailAsync("uid-1", TestContext.Current.CancellationToken));
 
-        await _sut.SendPasswordResetEmailAsync("uid-1", TestContext.Current.CancellationToken);
-
-        await _transport.Received(1).GeneratePasswordResetLinkAsync("john@example.com", Arg.Any<CancellationToken>());
-        await _distributedEventBus.Received(1).PublishAsync(
-            Arg.Is<IdentityPasswordResetEto>(e => e.UserId == "uid-1"),
-            Arg.Any<CancellationToken>());
+        await _distributedEventBus.DidNotReceive().PublishAsync(
+            Arg.Any<IdentityPasswordResetEto>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -259,14 +256,12 @@ public sealed class GoogleCloudIdentityProviderTests
     // ── Credentials ─────────────────────────────────────────────────────
 
     [Fact]
-    public async Task VerifyUserCredentialsAsync_DelegatesToTransport()
+    public async Task VerifyUserCredentialsAsync_ThrowsNotSupported()
     {
-        _transport.VerifyPasswordAsync("john@example.com", "pass", Arg.Any<CancellationToken>())
-            .Returns(true);
-
-        bool result = await _sut.VerifyUserCredentialsAsync("john@example.com", "pass", TestContext.Current.CancellationToken);
-
-        result.ShouldBeTrue();
+        // The Admin SDK has no password-verify API — the old implementation returned
+        // false for every credential, indistinguishable from "wrong password".
+        await Should.ThrowAsync<NotSupportedException>(
+            () => _sut.VerifyUserCredentialsAsync("john@example.com", "pass", TestContext.Current.CancellationToken));
     }
 
     // ── Helpers ──────────────────────────────────────────────────────────

--- a/tests/Granit.Identity.Federated.Privacy.Tests/DataDeletion/IdentityFederatedPersonalDataDeletionHandlerTests.cs
+++ b/tests/Granit.Identity.Federated.Privacy.Tests/DataDeletion/IdentityFederatedPersonalDataDeletionHandlerTests.cs
@@ -30,16 +30,65 @@ public sealed class IdentityFederatedPersonalDataDeletionHandlerTests
     }
 
     [Fact]
+    public async Task Handle_establishes_the_event_tenant_scope_before_erasing()
+    {
+        // GDPR regression: distributed dispatch carries no ambient tenant, so without an
+        // explicit scope the multi-tenant query filter hides the mirror row and the
+        // erasure silently no-ops while the saga acks the deletion.
+        IFederatedUserCacheEraser cacheEraser = Substitute.For<IFederatedUserCacheEraser>();
+        ICurrentTenant currentTenant = Substitute.For<ICurrentTenant>();
+
+        await IdentityFederatedPersonalDataDeletionHandler.Handle(
+            Eto(Tenant), cacheEraser, currentTenant, TestContext.Current.CancellationToken);
+
+        Received.InOrder(() =>
+        {
+            currentTenant.Change(Tenant);
+            cacheEraser.EraseAsync(User.ToString(), Tenant, Arg.Any<CancellationToken>());
+        });
+    }
+
+    [Fact]
     public async Task Handle_falls_back_to_the_ambient_tenant_when_the_event_has_none()
     {
         IFederatedUserCacheEraser cacheEraser = Substitute.For<IFederatedUserCacheEraser>();
         ICurrentTenant currentTenant = Substitute.For<ICurrentTenant>();
+        currentTenant.IsAvailable.Returns(true);
         currentTenant.Id.Returns(Tenant);
 
         await IdentityFederatedPersonalDataDeletionHandler.Handle(
             Eto(tenantId: null), cacheEraser, currentTenant, TestContext.Current.CancellationToken);
 
         await cacheEraser.Received(1).EraseAsync(User.ToString(), Tenant, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_sweeps_all_tenants_when_no_scope_is_resolvable()
+    {
+        // No tenant on the event and none ambient: Art. 17 must not leave a mirror behind
+        // in any partition — the eraser is invoked with a null scope (all-tenants sweep).
+        IFederatedUserCacheEraser cacheEraser = Substitute.For<IFederatedUserCacheEraser>();
+        ICurrentTenant currentTenant = Substitute.For<ICurrentTenant>();
+        currentTenant.IsAvailable.Returns(false);
+
+        await IdentityFederatedPersonalDataDeletionHandler.Handle(
+            Eto(tenantId: null), cacheEraser, currentTenant, TestContext.Current.CancellationToken);
+
+        await cacheEraser.Received(1).EraseAsync(User.ToString(), null, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_reports_the_erased_row_count_in_the_acknowledgement()
+    {
+        IFederatedUserCacheEraser cacheEraser = Substitute.For<IFederatedUserCacheEraser>();
+        ICurrentTenant currentTenant = Substitute.For<ICurrentTenant>();
+        cacheEraser.EraseAsync(Arg.Any<string>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+            .Returns(3);
+
+        PersonalDataDeletedEto ack = await IdentityFederatedPersonalDataDeletionHandler.Handle(
+            Eto(Tenant), cacheEraser, currentTenant, TestContext.Current.CancellationToken);
+
+        ack.AffectedRecords.ShouldBe(3);
     }
 
     [Fact]
@@ -64,7 +113,7 @@ public sealed class IdentityFederatedPersonalDataDeletionHandlerTests
         IFederatedUserCacheEraser cacheEraser = Substitute.For<IFederatedUserCacheEraser>();
         ICurrentTenant currentTenant = Substitute.For<ICurrentTenant>();
         cacheEraser.EraseAsync(Arg.Any<string>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
-            .Returns<Task>(_ => throw new InvalidOperationException("cache erase failed"));
+            .Returns<Task<int>>(_ => throw new InvalidOperationException("cache erase failed"));
 
         await Should.ThrowAsync<InvalidOperationException>(() => IdentityFederatedPersonalDataDeletionHandler.Handle(
             Eto(Tenant), cacheEraser, currentTenant, TestContext.Current.CancellationToken));

--- a/tests/Granit.Identity.Federated.Tests/Handlers/IdentityUserEventHandlerTests.cs
+++ b/tests/Granit.Identity.Federated.Tests/Handlers/IdentityUserEventHandlerTests.cs
@@ -4,6 +4,7 @@ using Granit.Identity.Federated.Events;
 using Granit.Identity.Federated.Handlers;
 using Granit.Identity.Federated.Internal;
 using Granit.Identity.Federated.RateLimiting;
+using Granit.MultiTenancy;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
 using Xunit;
@@ -15,14 +16,15 @@ public sealed class IdentityUserEventHandlerTests
     private readonly IIdentityProvider _provider = Substitute.For<IIdentityProvider>();
     private readonly IIdentityProviderCapabilities _capabilities = Substitute.For<IIdentityProviderCapabilities>();
     private readonly IUserCacheStore _store = Substitute.For<IUserCacheStore>();
+    private readonly ICurrentTenant _currentTenant = Substitute.For<ICurrentTenant>();
     private readonly ILocalEventBus _localEventBus = Substitute.For<ILocalEventBus>();
     private readonly IDistributedEventBus _distributedEventBus = Substitute.For<IDistributedEventBus>();
     private readonly IUserSyncFailureRateLimiter _rateLimiter = Substitute.For<IUserSyncFailureRateLimiter>();
     private readonly TimeProvider _timeProvider = Substitute.For<TimeProvider>();
 
     private IdentityUserEventHandler CreateHandler() => new(
-        _provider, _capabilities, _store, _localEventBus, _distributedEventBus, _rateLimiter,
-        _timeProvider, NullLogger<IdentityUserEventHandler>.Instance);
+        _provider, _capabilities, _store, _currentTenant, _localEventBus, _distributedEventBus,
+        _rateLimiter, _timeProvider, NullLogger<IdentityUserEventHandler>.Instance);
 
     public IdentityUserEventHandlerTests()
     {
@@ -71,6 +73,26 @@ public sealed class IdentityUserEventHandlerTests
             new IdentityUserDeletedEto("user-1", tenantId), TestContext.Current.CancellationToken);
 
         await _store.Received(1).DeleteByExternalIdAsync("user-1", tenantId, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task HandleDeleted_EstablishesTenantScope_BeforeDeleting()
+    {
+        // GDPR regression: distributed dispatch carries no ambient tenant, so without an
+        // explicit scope the multi-tenant query filter hides the row and the delete
+        // silently no-ops. The handler must establish the event's tenant before touching
+        // the store.
+        var tenantId = Guid.NewGuid();
+        IdentityUserEventHandler handler = CreateHandler();
+
+        await handler.HandleAsync(
+            new IdentityUserDeletedEto("user-1", tenantId), TestContext.Current.CancellationToken);
+
+        Received.InOrder(() =>
+        {
+            _currentTenant.Change(tenantId);
+            _store.DeleteByExternalIdAsync("user-1", tenantId, Arg.Any<CancellationToken>());
+        });
     }
 
     [Fact]


### PR DESCRIPTION
## Context

Vague 0 of the **Granit.Identity\* overhaul** (see the audit-driven refonte plan). This is the corrective/security wave that lands **before** the structural waves, so the later refactors rebase onto correct behaviour. Marked `!` (breaking): two provider capability flags flip and encrypted grid columns are delisted.

## What changed

**GDPR erasure (BREAKING #1 & #2 from the audit)**
- `IdentityFederatedPersonalDataDeletionHandler` and `IdentityUserEventHandler` now establish the event's tenant scope via `ICurrentTenant.Change(...)` before touching the store. Distributed dispatch carries no ambient tenant, so the `GranitDbContext` multi-tenant filter (`CurrentTenantId == null`) used to hide tenant-scoped rows from the explicit delete predicate — the erasure silently no-op'd while the saga ack'd `PersonalDataDeletedEto`.
- A `null` tenant scope now sweeps **all** partitions (the documented `IdentityUserDeletedEto` contract) via an explicit `IgnoreQueryFilters([MultiTenant])`, instead of translating to `TenantId IS NULL` (host rows only).
- `IUserCacheStore.DeleteByExternalIdAsync` / `IFederatedUserCacheEraser.EraseAsync` return the affected row count, so the ack reports reality instead of a hardcoded `AffectedRecords: 0`.
- `FindFirstByExternalIdAsync` (documented "regardless of tenant") bypasses the filter explicitly so the cache-aside path doesn't re-insert a duplicate host-scope row.

**Test substrate**
- `EfCoreUserCacheStoreTests` moved from `UseInMemoryDatabase` (which ignores query filters — exactly how the no-op stayed invisible to CI) to **SQLite with the multi-tenant filter active**. Added red→green regressions: cross-tenant sweep, tenant-scoped delete count, fail-closed scope, cross-tenant isolation. Diagnostics tests that rely on `DateTimeOffset` Min/aggregate (unsupported by SQLite, fine on PostgreSQL) kept on In-Memory in a dedicated file.

**GoogleCloud honest capabilities (BREAKING #3)**
- `SupportsCredentialVerification` and `SupportsNativePasswordResetEmail` → `false` (the Firebase Admin SDK can do neither). The dead verify/reset-link paths now throw `NotSupportedException` instead of rejecting every valid credential / generating a reset link and discarding it while still publishing `IdentityPasswordResetEto`.

**EntraId OData injection (audit ARCHITECTURE, security)**
- Ported Cognito's `[GeneratedRegex]` search whitelist + OData single-quote escaping (`''`) on `$filter`. `Uri.EscapeDataString` alone was insufficient (Graph URL-decodes `%27` before parsing).

**Encrypted-column delisting (audit ARCHITECTURE #1)**
- `UserQueryDefinition` / `FederatedIdentityQueryDefinition`: `[Encrypted]` columns (Email, PhoneNumber, Username, First/LastName) dropped from `Filterable`/`Sortable`/`GlobalSearch` (random-IV AES → filters silently match nothing, sorts order by ciphertext). Columns stay projectable. `EmailHash` dropped as a grid column ("never surfaced to callers").

**Riders**
- `RevokeMyOtherUserSessions` declares its `400`/`401` problem branches (undeclared handler return).
- Federated notification titles `html.escape` external-IdP ids in `<title>`.
- Failed-login logs redact the login identifier (`LogRedaction.Username`).

## Testing

Per-project builds green. Test projects run individually (shard `identity` + `integration`):

- `Granit.Identity.Federated.EntityFrameworkCore.Tests` — 26/26 (SQLite, incl. new GDPR regressions; verified red on the pre-fix predicate)
- `Granit.Identity.Federated.Tests` 53/53 · `.Privacy.Tests` 16/16 · `.GoogleCloud.Tests` 55/55
- `Granit.Identity.Federated.EntraId.Tests` — new injection tests green (9 pre-existing failures are a local `Microsoft.Extensions.Http.Resilience` assembly-load issue, present on `develop`, unrelated to this change — will pass in CI)
- `Granit.Identity.Endpoints.Tests` 192/192 · `.Local.Endpoints.Tests` 195/195 · `.Notifications.Tests` 21/21
- `dotnet format --verify-no-changes` clean on all touched projects.

## Breaking notes

- GoogleCloud hosts gating on `SupportsCredentialVerification` / `SupportsNativePasswordResetEmail` now correctly see `false`; direct calls to those provider methods throw instead of silently failing.
- Admin grids no longer filter/sort/search on encrypted user columns (they never actually worked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)