### PR TITLE
feat(openiddict): reload signing credentials after rotation — read-side rotation-aware (Phase 2A)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -43498,6 +43498,12 @@
           "returnType": "TimeSpan RotationLeadTime { get; set; } = TimeSpan."
         },
         {
+          "name": "FromMinutes",
+          "kind": "method",
+          "signature": "FromMinutes(5)",
+          "returnType": "TimeSpan RefreshCheckInterval { get; set; } = TimeSpan."
+        },
+        {
           "name": "RsaKeySize",
           "kind": "property",
           "signature": "int RsaKeySize",

--- a/src/Granit.OpenIddict/GranitOpenIddictModule.cs
+++ b/src/Granit.OpenIddict/GranitOpenIddictModule.cs
@@ -81,6 +81,10 @@ public sealed class GranitOpenIddictModule : GranitModule
         context.Services.AddSingleton<IPostConfigureOptions<OpenIddictServerOptions>,
             DatabaseSigningKeyPostConfigure>();
 
+        // Keep each replica's loaded credentials in sync with the DB after a rotation (the
+        // post-configure above only runs once). No-op when key rotation is disabled.
+        context.Services.AddHostedService<SigningKeyRefreshService>();
+
         // Identity cookie configuration — neutral names to avoid leaking the technology stack.
         // PostConfigure is required because AddIdentity<TUser, TRole>() registers its own
         // PostConfigure that resets names to ASP.NET Core defaults.

--- a/src/Granit.OpenIddict/Internal/SigningKeyRefreshService.cs
+++ b/src/Granit.OpenIddict/Internal/SigningKeyRefreshService.cs
@@ -1,0 +1,125 @@
+using Granit.OpenIddict.Domain;
+using Granit.OpenIddict.Options;
+using Granit.OpenIddict.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using OpenIddict.Server;
+
+namespace Granit.OpenIddict.Internal;
+
+/// <summary>
+/// Keeps each running instance's OpenIddict signing/encryption credentials in sync with the
+/// database when database-backed key rotation is enabled.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="DatabaseSigningKeyPostConfigure"/> loads the credentials once, at the first resolve
+/// of <see cref="OpenIddictServerOptions"/>. That snapshot never changes afterwards, so after the
+/// rotation job mints a new key on one node the other running replicas keep signing with — and
+/// exposing at <c>/.well-known/jwks</c> — the old key set until they restart. Tokens signed by the
+/// rotated-in key then fail validation on the stale replicas.
+/// </para>
+/// <para>
+/// This service polls the key store every <see cref="GranitKeyRotationOptions.RefreshCheckInterval"/>
+/// and, when the active/retired key set changes, evicts the cached options so the post-configure
+/// re-runs and reloads the current credentials. Each replica polls independently — no distributed
+/// coordination is required because the store is the single source of truth.
+/// </para>
+/// </remarks>
+internal sealed partial class SigningKeyRefreshService(
+    IServiceScopeFactory scopeFactory,
+    IOptionsMonitorCache<OpenIddictServerOptions> optionsCache,
+    IOptionsMonitor<OpenIddictServerOptions> optionsMonitor,
+    IOptions<GranitKeyRotationOptions> rotationOptions,
+    TimeProvider timeProvider,
+    ILogger<SigningKeyRefreshService> logger) : BackgroundService
+{
+    private string? _lastFingerprint;
+
+    /// <inheritdoc/>
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        if (!rotationOptions.Value.Enabled)
+        {
+            // Ephemeral/static keys — nothing to refresh.
+            return;
+        }
+
+        // Prime from the current key set so the first tick reacts only to a subsequent change,
+        // not to the state the post-configure already loaded at startup.
+        await PrimeAsync(stoppingToken).ConfigureAwait(false);
+
+        using PeriodicTimer timer = new(rotationOptions.Value.RefreshCheckInterval, timeProvider);
+        while (await timer.WaitForNextTickAsync(stoppingToken).ConfigureAwait(false))
+        {
+            await RefreshIfChangedAsync(stoppingToken).ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>Captures the current key-set fingerprint without triggering a reload.</summary>
+    internal async Task PrimeAsync(CancellationToken cancellationToken) =>
+        _lastFingerprint = await SafeComputeFingerprintAsync(cancellationToken).ConfigureAwait(false);
+
+    /// <summary>
+    /// Reloads the credentials when the key-set fingerprint has changed since the last check.
+    /// A failed read (schema absent on first boot, transient DB error) is a no-op — the loop
+    /// simply retries on the next tick.
+    /// </summary>
+    internal async Task RefreshIfChangedAsync(CancellationToken cancellationToken)
+    {
+        string? current = await SafeComputeFingerprintAsync(cancellationToken).ConfigureAwait(false);
+        if (current is null || string.Equals(current, _lastFingerprint, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        _lastFingerprint = current;
+
+        // Evict the cached OpenIddictServerOptions so DatabaseSigningKeyPostConfigure re-runs and
+        // reloads the active/retired credentials on the next resolve; rebuild eagerly so live
+        // requests observe the new key set without waiting for the next options access.
+        optionsCache.TryRemove(Microsoft.Extensions.Options.Options.DefaultName);
+        _ = optionsMonitor.Get(Microsoft.Extensions.Options.Options.DefaultName);
+        Log.KeySetChanged(logger);
+    }
+
+    private async Task<string?> SafeComputeFingerprintAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            using IServiceScope scope = scopeFactory.CreateScope();
+            ISigningKeyStore store = scope.ServiceProvider.GetRequiredService<ISigningKeyStore>();
+            IReadOnlyList<SigningKey> keys = await store
+                .GetKeysAsync([SigningKeyStatus.Active, SigningKeyStatus.Retired], cancellationToken)
+                .ConfigureAwait(false);
+
+            return string.Join('|', keys
+                .Select(k => $"{k.KeyId}:{k.Status}")
+                .OrderBy(s => s, StringComparer.Ordinal));
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+#pragma warning disable CA1031 // A background poll must survive transient store failures (incl. schema-absent on first boot) — logged and retried next tick.
+        catch (Exception ex)
+        {
+            Log.FingerprintFailed(logger, ex);
+            return null;
+        }
+#pragma warning restore CA1031
+    }
+
+    private static partial class Log
+    {
+        [LoggerMessage(Level = LogLevel.Information,
+            Message = "Signing key set changed — reloaded OpenIddict credentials from the database.")]
+        public static partial void KeySetChanged(ILogger logger);
+
+        [LoggerMessage(Level = LogLevel.Warning,
+            Message = "Failed to read the signing key set; will retry on the next refresh tick.")]
+        public static partial void FingerprintFailed(ILogger logger, Exception exception);
+    }
+}

--- a/src/Granit.OpenIddict/Options/GranitKeyRotationOptions.cs
+++ b/src/Granit.OpenIddict/Options/GranitKeyRotationOptions.cs
@@ -37,6 +37,14 @@ public sealed class GranitKeyRotationOptions
     public TimeSpan RotationLeadTime { get; set; } = TimeSpan.FromDays(7);
 
     /// <summary>
+    /// Gets or sets how often each running instance polls the key store for changes and reloads the
+    /// signing/encryption credentials when the active key set has changed (e.g. after the rotation
+    /// job minted a new key on another node). Default: 5 minutes. Must be well below
+    /// <see cref="GracePeriod"/> so a rotated-in key is picked up before the retired key is revoked.
+    /// </summary>
+    public TimeSpan RefreshCheckInterval { get; set; } = TimeSpan.FromMinutes(5);
+
+    /// <summary>
     /// Gets or sets the RSA key size in bits.
     /// Default: 2048. Use 4096 for higher security requirements.
     /// </summary>

--- a/tests/Granit.OpenIddict.Tests/Internal/SigningKeyRefreshServiceTests.cs
+++ b/tests/Granit.OpenIddict.Tests/Internal/SigningKeyRefreshServiceTests.cs
@@ -1,0 +1,156 @@
+using Granit.OpenIddict.Domain;
+using Granit.OpenIddict.Internal;
+using Granit.OpenIddict.Options;
+using Granit.OpenIddict.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using OpenIddict.Server;
+using Shouldly;
+using Xunit;
+
+namespace Granit.OpenIddict.Tests.Internal;
+
+/// <summary>
+/// The refresh service evicts the cached OpenIddict options only when the active/retired key set
+/// changes since the last check, and survives a failed key-store read (schema absent, transient DB
+/// error) without invalidating.
+/// </summary>
+public sealed class SigningKeyRefreshServiceTests
+{
+    [Fact]
+    public async Task RefreshIfChangedAsync_KeySetUnchanged_DoesNotInvalidate()
+    {
+        FakeSigningKeyStore store = new([Key("a", SigningKeyStatus.Active)]);
+        RecordingOptionsCache cache = new();
+        SigningKeyRefreshService service = Build(store, cache);
+
+        await service.PrimeAsync(TestContext.Current.CancellationToken);
+        await service.RefreshIfChangedAsync(TestContext.Current.CancellationToken);
+
+        cache.RemoveCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task RefreshIfChangedAsync_KeyRotatedIn_InvalidatesCache()
+    {
+        FakeSigningKeyStore store = new([Key("a", SigningKeyStatus.Active)]);
+        RecordingOptionsCache cache = new();
+        SigningKeyRefreshService service = Build(store, cache);
+
+        await service.PrimeAsync(TestContext.Current.CancellationToken);
+
+        // The rotation job minted a new active key on another node and retired the old one.
+        store.Keys = [Key("a", SigningKeyStatus.Retired), Key("b", SigningKeyStatus.Active)];
+        await service.RefreshIfChangedAsync(TestContext.Current.CancellationToken);
+
+        cache.RemoveCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task RefreshIfChangedAsync_OnlyStatusChanged_InvalidatesCache()
+    {
+        FakeSigningKeyStore store = new([Key("a", SigningKeyStatus.Active)]);
+        RecordingOptionsCache cache = new();
+        SigningKeyRefreshService service = Build(store, cache);
+
+        await service.PrimeAsync(TestContext.Current.CancellationToken);
+
+        store.Keys = [Key("a", SigningKeyStatus.Retired)]; // same key, now retired
+        await service.RefreshIfChangedAsync(TestContext.Current.CancellationToken);
+
+        cache.RemoveCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task RefreshIfChangedAsync_StoreThrows_IsNoOp()
+    {
+        FakeSigningKeyStore store = new([Key("a", SigningKeyStatus.Active)]) { Throw = true };
+        RecordingOptionsCache cache = new();
+        SigningKeyRefreshService service = Build(store, cache);
+
+        await service.RefreshIfChangedAsync(TestContext.Current.CancellationToken);
+
+        cache.RemoveCount.ShouldBe(0);
+    }
+
+    private static SigningKeyRefreshService Build(
+        ISigningKeyStore store, IOptionsMonitorCache<OpenIddictServerOptions> cache)
+    {
+        ServiceProvider provider = new ServiceCollection()
+            .AddScoped(_ => store)
+            .BuildServiceProvider();
+
+        IOptionsMonitor<OpenIddictServerOptions> monitor =
+            Substitute.For<IOptionsMonitor<OpenIddictServerOptions>>();
+        monitor.Get(Arg.Any<string>()).Returns(new OpenIddictServerOptions());
+
+        return new SigningKeyRefreshService(
+            provider.GetRequiredService<IServiceScopeFactory>(),
+            cache,
+            monitor,
+            Microsoft.Extensions.Options.Options.Create(new GranitKeyRotationOptions { Enabled = true }),
+            TimeProvider.System,
+            NullLogger<SigningKeyRefreshService>.Instance);
+    }
+
+    private static SigningKey Key(string keyId, SigningKeyStatus status)
+    {
+        var key = SigningKey.Create(
+            keyId, "signing", "RS256", "encrypted",
+            DateTimeOffset.UnixEpoch, DateTimeOffset.UnixEpoch.AddDays(90));
+        if (status == SigningKeyStatus.Retired)
+        {
+            key.Retire(DateTimeOffset.UnixEpoch.AddDays(80));
+        }
+
+        return key;
+    }
+
+    private sealed class FakeSigningKeyStore(IReadOnlyList<SigningKey> keys) : ISigningKeyStore
+    {
+        public IReadOnlyList<SigningKey> Keys { get; set; } = keys;
+
+        public bool Throw { get; set; }
+
+        public Task<IReadOnlyList<SigningKey>> GetKeysAsync(
+            SigningKeyStatus[] statuses, CancellationToken cancellationToken = default) =>
+            Throw
+                ? throw new InvalidOperationException("relation \"openiddict_signing_keys\" does not exist")
+                : Task.FromResult(Keys);
+
+        public Task<IReadOnlyList<SigningKey>> GetKeysAsync(params SigningKeyStatus[] statuses) =>
+            GetKeysAsync(statuses, default);
+
+        public Task<SigningKey?> GetActiveKeyAsync(string keyType, CancellationToken cancellationToken = default) =>
+            Task.FromResult<SigningKey?>(null);
+
+        public Task CreateAsync(SigningKey key, CancellationToken cancellationToken = default) =>
+            Task.CompletedTask;
+
+        public Task<bool> UpdateAsync(SigningKey key, CancellationToken cancellationToken = default) =>
+            Task.FromResult(true);
+
+        public Task<int> PruneRevokedAsync(DateTimeOffset olderThan, CancellationToken cancellationToken = default) =>
+            Task.FromResult(0);
+    }
+
+    private sealed class RecordingOptionsCache : IOptionsMonitorCache<OpenIddictServerOptions>
+    {
+        public int RemoveCount { get; private set; }
+
+        public bool TryRemove(string? name)
+        {
+            RemoveCount++;
+            return true;
+        }
+
+        public OpenIddictServerOptions GetOrAdd(string? name, Func<OpenIddictServerOptions> createOptions) =>
+            createOptions();
+
+        public bool TryAdd(string? name, OpenIddictServerOptions options) => true;
+
+        public void Clear() { }
+    }
+}


### PR DESCRIPTION
## Contexte

Refonte `Granit.OpenIddict*` — **Phase 2A**, le **finding ARCHITECTURE #1**.

`DatabaseSigningKeyPostConfigure` charge les credentials **une seule fois** (premier resolve d'`OpenIddictServerOptions`) ; ce snapshot ne change jamais. Après que le job de rotation a généré une nouvelle clé sur un nœud, les autres replicas continuent à signer avec — et publier à `/.well-known/jwks` — l'ancien set jusqu'au redémarrage ; les tokens signés par la clé rotated-in échouent à la validation sur ces replicas.

## Changement

`SigningKeyRefreshService` (`BackgroundService`) : quand la rotation est activée, poll le key store toutes les `GranitKeyRotationOptions.RefreshCheckInterval` (défaut 5 min), calcule une **empreinte** du set actif/retired, et au changement **évince** l'`OpenIddictServerOptions` caché → le post-configure re-run et recharge les credentials courants.

- Chaque replica poll **indépendamment** — le store est la source de vérité unique, aucune coordination distribuée.
- Une lecture en échec (schéma absent au premier boot, erreur DB transitoire) est **loggée et retentée** au tick suivant, sans tuer la boucle (couvre aussi le CrashLoop du finding « base non migrée »).

## Tests

- No-op si inchangé · invalidation sur clé rotated-in **et** sur changement de statut seul · survie à un store qui throw sans invalider.
- `Granit.OpenIddict.Tests` : **265/265** ✓ · `dotnet format` clean.
- Le chemin de reload complet (post-configure re-run sur Postgres) sera couvert par la suite d'intégration.

## Suite Phase 2A

- First-boot generate-on-empty (sous le gate de concurrence optimiste existant).
- Guard éphémère → `IValidateOptions<OpenIddictServerOptions>` (après post-config).
- Chargement rollover explicite (signing = active seule ; validation = active + retired dans la grâce).

> Hunk distinct de #3055 (PS256) dans `GranitOpenIddictModule` — pas de conflit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)