### PR TITLE
feat(openiddict): generate initial signing keys on first boot (Phase 2A)

### DIFF
--- a/src/Granit.OpenIddict/Internal/SigningKeyRefreshService.cs
+++ b/src/Granit.OpenIddict/Internal/SigningKeyRefreshService.cs
@@ -47,6 +47,10 @@ internal sealed partial class SigningKeyRefreshService(
             return;
         }
 
+        // First boot: generate the initial key set when the store is empty, so a deployment that
+        // opted into rotation does not silently fall back to ephemeral keys.
+        await EnsureInitializedAsync(stoppingToken).ConfigureAwait(false);
+
         // Prime from the current key set so the first tick reacts only to a subsequent change,
         // not to the state the post-configure already loaded at startup.
         await PrimeAsync(stoppingToken).ConfigureAwait(false);
@@ -76,13 +80,60 @@ internal sealed partial class SigningKeyRefreshService(
         }
 
         _lastFingerprint = current;
+        InvalidateOptionsCache();
+        Log.KeySetChanged(logger);
+    }
 
-        // Evict the cached OpenIddictServerOptions so DatabaseSigningKeyPostConfigure re-runs and
-        // reloads the active/retired credentials on the next resolve; rebuild eagerly so live
-        // requests observe the new key set without waiting for the next options access.
+    /// <summary>
+    /// Generates the initial signing/encryption keys when rotation is enabled but the store is
+    /// empty (fresh deployment) — without this the server would silently fall back to ephemeral
+    /// keys despite the operator opting into rotation.
+    /// </summary>
+    /// <remarks>
+    /// The pre-check narrows — but does not eliminate — the window in which two replicas booting
+    /// against an empty store each generate a key; the surplus keys are all valid and are pruned by
+    /// a later rotation cycle. A failed attempt (schema absent on first boot, transient DB error) is
+    /// logged and retried at the next boot or by the rotation job — the server stays on ephemeral
+    /// keys until then rather than crash-looping.
+    /// </remarks>
+    internal async Task EnsureInitializedAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            using IServiceScope scope = scopeFactory.CreateScope();
+            ISigningKeyStore store = scope.ServiceProvider.GetRequiredService<ISigningKeyStore>();
+            if (await store.GetActiveKeyAsync("signing", cancellationToken).ConfigureAwait(false) is not null)
+            {
+                return;
+            }
+
+            IKeyRotationService rotation = scope.ServiceProvider.GetRequiredService<IKeyRotationService>();
+            KeyRotationResult result = await rotation.RotateAsync(cancellationToken).ConfigureAwait(false);
+            if (result.KeysGenerated > 0)
+            {
+                Log.FirstBootGenerated(logger, result.KeysGenerated);
+                InvalidateOptionsCache();
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+#pragma warning disable CA1031 // First-boot generation must survive a transient/absent store — logged, retried at next boot or by the rotation job.
+        catch (Exception ex)
+        {
+            Log.FirstBootFailed(logger, ex);
+        }
+#pragma warning restore CA1031
+    }
+
+    // Evict the cached OpenIddictServerOptions so DatabaseSigningKeyPostConfigure re-runs and
+    // reloads the credentials on the next resolve; rebuild eagerly so live requests observe the
+    // new key set without waiting for the next options access.
+    private void InvalidateOptionsCache()
+    {
         optionsCache.TryRemove(Microsoft.Extensions.Options.Options.DefaultName);
         _ = optionsMonitor.Get(Microsoft.Extensions.Options.Options.DefaultName);
-        Log.KeySetChanged(logger);
     }
 
     private async Task<string?> SafeComputeFingerprintAsync(CancellationToken cancellationToken)
@@ -117,6 +168,14 @@ internal sealed partial class SigningKeyRefreshService(
         [LoggerMessage(Level = LogLevel.Information,
             Message = "Signing key set changed — reloaded OpenIddict credentials from the database.")]
         public static partial void KeySetChanged(ILogger logger);
+
+        [LoggerMessage(Level = LogLevel.Information,
+            Message = "First boot: generated {Count} initial signing/encryption key(s) and loaded them.")]
+        public static partial void FirstBootGenerated(ILogger logger, int count);
+
+        [LoggerMessage(Level = LogLevel.Warning,
+            Message = "First-boot key generation failed; staying on ephemeral keys until the next boot or rotation.")]
+        public static partial void FirstBootFailed(ILogger logger, Exception exception);
 
         [LoggerMessage(Level = LogLevel.Warning,
             Message = "Failed to read the signing key set; will retry on the next refresh tick.")]

--- a/tests/Granit.OpenIddict.Tests/Internal/SigningKeyRefreshServiceTests.cs
+++ b/tests/Granit.OpenIddict.Tests/Internal/SigningKeyRefreshServiceTests.cs
@@ -75,11 +75,58 @@ public sealed class SigningKeyRefreshServiceTests
         cache.RemoveCount.ShouldBe(0);
     }
 
+    [Fact]
+    public async Task EnsureInitializedAsync_EmptyStore_GeneratesAndReloads()
+    {
+        FakeSigningKeyStore store = new([]); // fresh deployment, no keys
+        RecordingOptionsCache cache = new();
+        IKeyRotationService rotation = Substitute.For<IKeyRotationService>();
+        rotation.RotateAsync(Arg.Any<CancellationToken>())
+            .Returns(new KeyRotationResult(KeysGenerated: 2, KeysRetired: 0, KeysRevoked: 0, KeysPruned: 0));
+        SigningKeyRefreshService service = Build(store, cache, rotation);
+
+        await service.EnsureInitializedAsync(TestContext.Current.CancellationToken);
+
+        await rotation.Received(1).RotateAsync(Arg.Any<CancellationToken>());
+        cache.RemoveCount.ShouldBe(1, "freshly minted credentials must be loaded immediately");
+    }
+
+    [Fact]
+    public async Task EnsureInitializedAsync_KeysAlreadyPresent_DoesNotGenerate()
+    {
+        FakeSigningKeyStore store = new([Key("a", SigningKeyStatus.Active)]);
+        RecordingOptionsCache cache = new();
+        IKeyRotationService rotation = Substitute.For<IKeyRotationService>();
+        SigningKeyRefreshService service = Build(store, cache, rotation);
+
+        await service.EnsureInitializedAsync(TestContext.Current.CancellationToken);
+
+        await rotation.DidNotReceive().RotateAsync(Arg.Any<CancellationToken>());
+        cache.RemoveCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task EnsureInitializedAsync_StoreThrows_IsNoOp()
+    {
+        FakeSigningKeyStore store = new([]) { Throw = true }; // schema absent on first boot
+        RecordingOptionsCache cache = new();
+        IKeyRotationService rotation = Substitute.For<IKeyRotationService>();
+        SigningKeyRefreshService service = Build(store, cache, rotation);
+
+        await service.EnsureInitializedAsync(TestContext.Current.CancellationToken);
+
+        await rotation.DidNotReceive().RotateAsync(Arg.Any<CancellationToken>());
+        cache.RemoveCount.ShouldBe(0);
+    }
+
     private static SigningKeyRefreshService Build(
-        ISigningKeyStore store, IOptionsMonitorCache<OpenIddictServerOptions> cache)
+        ISigningKeyStore store,
+        IOptionsMonitorCache<OpenIddictServerOptions> cache,
+        IKeyRotationService? rotation = null)
     {
         ServiceProvider provider = new ServiceCollection()
             .AddScoped(_ => store)
+            .AddScoped(_ => rotation ?? Substitute.For<IKeyRotationService>())
             .BuildServiceProvider();
 
         IOptionsMonitor<OpenIddictServerOptions> monitor =
@@ -124,7 +171,10 @@ public sealed class SigningKeyRefreshServiceTests
             GetKeysAsync(statuses, default);
 
         public Task<SigningKey?> GetActiveKeyAsync(string keyType, CancellationToken cancellationToken = default) =>
-            Task.FromResult<SigningKey?>(null);
+            Throw
+                ? throw new InvalidOperationException("relation \"openiddict_signing_keys\" does not exist")
+                : Task.FromResult(Keys.FirstOrDefault(
+                    k => k.KeyType == keyType && k.Status == SigningKeyStatus.Active));
 
         public Task CreateAsync(SigningKey key, CancellationToken cancellationToken = default) =>
             Task.CompletedTask;


### PR DESCRIPTION
## Contexte

Refonte `Granit.OpenIddict*` — **Phase 2A**, item 3 (first-boot).

Rotation activée mais table de clés **vide** (déploiement neuf) : `DatabaseSigningKeyPostConfigure` logguait « no keys found » et le serveur retombait **silencieusement sur des clés éphémères** — le chicken-and-egg du first-boot : l'opérateur opte pour la rotation persistante mais obtient des clés non-persistantes.

## Changement

`SigningKeyRefreshService.EnsureInitializedAsync` au démarrage : si aucune clé de signature active, appelle `IKeyRotationService.RotateAsync` (qui génère les clés signing + encryption initiales) et évince le cache d'options pour charger les credentials **immédiatement** (pas 5 min plus tard).

- Une tentative en échec (schéma absent avant migration, erreur DB transitoire) est **loggée et retentée** au prochain boot ou par le job de rotation — le serveur reste sur clés éphémères au lieu de **crash-looper** (finding « DB non migrée au démarrage »).
- Le pré-check `GetActiveKeyAsync` **réduit** (sans éliminer) la fenêtre où deux replicas au boot génèrent chacun ; les clés en surplus sont toutes valides et réconciliées par une rotation ultérieure. Un **index unique filtré** pour un first-boot totalement race-free est un follow-up documenté.

## Tests

- Génère + recharge si vide · no-op si clé présente · survit à un store qui throw.
- `Granit.OpenIddict.Tests` : **271/271** ✓ · `dotnet format` clean.
- Le chemin complet (vrai Postgres) sera couvert par la suite d'intégration.

## Note environnement

Docker Desktop est présent côté Windows mais l'**intégration WSL n'est pas activée** pour cette distro (`docker` = binaire Windows non exécutable ici, pas de socket) → je n'ai pas pu lancer Testcontainers en local ; validation unitaire locale + intégration en CI. Pour débloquer : Docker Desktop → Settings → Resources → WSL Integration.

## Suite Phase 2A

- Durcissement race first-boot (index unique filtré `WHERE Status=Active`, validable via SQLite).
- Guard éphémère → `IValidateOptions` · chargement rollover explicite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)