### PR TITLE
fix(openiddict): return 409 Conflict on duplicate OIDC application/scope creation (Phase 4)

### DIFF
--- a/src/Granit.OpenIddict.Endpoints/Endpoints/AdminOidcEndpoints.cs
+++ b/src/Granit.OpenIddict.Endpoints/Endpoints/AdminOidcEndpoints.cs
@@ -49,6 +49,7 @@ internal static class AdminOidcEndpoints
             .Produces<AdminOidcApplicationResponse>(StatusCodes.Status201Created)
             .ProducesValidationProblem(StatusCodes.Status422UnprocessableEntity)
             .ProducesProblem(StatusCodes.Status403Forbidden)
+            .ProducesProblem(StatusCodes.Status409Conflict)
             .RequireAuthorization(OpenIddictPermissions.Applications.Manage);
 
         apps.MapPut("/{clientId}", UpdateApplicationAsync)
@@ -102,6 +103,7 @@ internal static class AdminOidcEndpoints
             .Produces<AdminOidcScopeResponse>(StatusCodes.Status201Created)
             .ProducesValidationProblem(StatusCodes.Status422UnprocessableEntity)
             .ProducesProblem(StatusCodes.Status403Forbidden)
+            .ProducesProblem(StatusCodes.Status409Conflict)
             .RequireAuthorization(OpenIddictPermissions.Scopes.Manage);
 
         scopes.MapPut("/{scopeName}", UpdateScopeAsync)
@@ -211,6 +213,15 @@ internal static class AdminOidcEndpoints
             return TypedResults.Problem(
                 detail: "A tenant-scoped administrator cannot assign an application to a different tenant.",
                 statusCode: StatusCodes.Status403Forbidden);
+        }
+
+        // ClientId is globally unique; a duplicate would otherwise surface as a 500 from the
+        // manager's unique-constraint violation. Report the documented 409 instead.
+        if (await applicationManager.FindByClientIdAsync(request.ClientId, cancellationToken).ConfigureAwait(false) is not null)
+        {
+            return TypedResults.Problem(
+                detail: $"An OIDC application with client ID '{request.ClientId}' already exists.",
+                statusCode: StatusCodes.Status409Conflict);
         }
 
         var descriptor = new OpenIddictApplicationDescriptor
@@ -460,6 +471,14 @@ internal static class AdminOidcEndpoints
             return TypedResults.Problem(
                 detail: "A tenant-scoped administrator cannot assign a scope to a different tenant.",
                 statusCode: StatusCodes.Status403Forbidden);
+        }
+
+        // Scope names are unique; a duplicate would otherwise surface as a 500. Report 409.
+        if (await scopeManager.FindByNameAsync(request.Name, cancellationToken).ConfigureAwait(false) is not null)
+        {
+            return TypedResults.Problem(
+                detail: $"An OIDC scope named '{request.Name}' already exists.",
+                statusCode: StatusCodes.Status409Conflict);
         }
 
         var descriptor = new OpenIddictScopeDescriptor

--- a/tests/Granit.OpenIddict.Endpoints.Tests/Integration/AdminOidcEndpointsIntegrationTests.cs
+++ b/tests/Granit.OpenIddict.Endpoints.Tests/Integration/AdminOidcEndpointsIntegrationTests.cs
@@ -105,6 +105,38 @@ public sealed class AdminOidcEndpointsIntegrationTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task CreateApplication_DuplicateClientId_Returns409()
+    {
+        _server.ApplicationManager.FindByClientIdAsync("dup-client", Arg.Any<CancellationToken>())
+            .Returns(new GranitOpenIddictApplication());
+
+        AdminOidcCreateApplicationRequest request = new("dup-client", "Dup", null, "web");
+
+        HttpResponseMessage response = await _server.AuthenticatedClient
+            .PostAsJsonAsync("/admin/oidc/applications", request, TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Conflict);
+        await _server.ApplicationManager.DidNotReceive().CreateAsync(
+            Arg.Any<OpenIddictApplicationDescriptor>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task CreateScope_DuplicateName_Returns409()
+    {
+        _server.ScopeManager.FindByNameAsync("dup_scope", Arg.Any<CancellationToken>())
+            .Returns(new GranitOpenIddictScope());
+
+        AdminOidcCreateScopeRequest request = new("dup_scope", "Dup", Resources: []);
+
+        HttpResponseMessage response = await _server.AuthenticatedClient
+            .PostAsJsonAsync("/admin/oidc/scopes", request, TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Conflict);
+        await _server.ScopeManager.DidNotReceive().CreateAsync(
+            Arg.Any<OpenIddictScopeDescriptor>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task CreateApplication_ReturnsCreated()
     {
         GranitOpenIddictApplication createdApp = new() { TenantId = null };


### PR DESCRIPTION
## Contexte

Refonte `Granit.OpenIddict*` — **Phase 4 (hygiène)**, vérité de l'API admin.

Les descriptions OpenAPI des endpoints de création promettaient « Returns 409 Conflict if a client with the same client ID already exists » (idem scope), mais **aucun handler ne vérifiait le doublon** : la violation de contrainte d'unicité du manager remontait en **500**, et le 409 documenté n'était **jamais** émis (ni déclaré via `ProducesProblem`).

## Changement

- `CreateApplicationAsync` / `CreateScopeAsync` : check `FindByClientIdAsync` / `FindByNameAsync` avant `CreateAsync` → **409** si doublon.
- `.ProducesProblem(409)` déclaré sur les deux routes → le contrat OpenAPI colle à la réalité.

## Tests

- ClientId dupliqué et nom de scope dupliqué renvoient chacun **409** et n'appellent **jamais** `CreateAsync`.
- `Granit.OpenIddict.Endpoints.Tests` : **132/132** ✓ · architecture **262/262** ✓ · `dotnet format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)