### PR TITLE
feat(openiddict): make concurrent first-boot key generation race-safe (Phase 2A)

### DIFF
--- a/src/Granit.OpenIddict.EntityFrameworkCore/Extensions/OpenIddictModelBuilderExtensions.cs
+++ b/src/Granit.OpenIddict.EntityFrameworkCore/Extensions/OpenIddictModelBuilderExtensions.cs
@@ -194,6 +194,15 @@ public static class OpenIddictModelBuilderExtensions
 
             b.HasIndex(k => new { k.KeyType, k.Status })
                 .HasDatabaseName($"ix_{prefix}signing_keys_type_status");
+
+            // At most one Active key per type. Makes concurrent first-boot generation race-safe:
+            // when two replicas boot against an empty store, the second replica's insert of a
+            // duplicate active key is rejected by the database (SigningKeyRefreshService swallows
+            // the loss and reloads the winner's keys). Status is persisted as its PascalCase string.
+            b.HasIndex(k => k.KeyType)
+                .IsUnique()
+                .HasFilter("\"Status\" = 'Active'")
+                .HasDatabaseName($"uq_{prefix}signing_keys_active_type");
         });
 
         // ──── Dynamic user extension columns ────

--- a/src/Granit.OpenIddict/Internal/SigningKeyRefreshService.cs
+++ b/src/Granit.OpenIddict/Internal/SigningKeyRefreshService.cs
@@ -104,15 +104,30 @@ internal sealed partial class SigningKeyRefreshService(
             ISigningKeyStore store = scope.ServiceProvider.GetRequiredService<ISigningKeyStore>();
             if (await store.GetActiveKeyAsync("signing", cancellationToken).ConfigureAwait(false) is not null)
             {
+                // Already initialised — the post-configure loaded the keys at startup.
                 return;
             }
 
-            IKeyRotationService rotation = scope.ServiceProvider.GetRequiredService<IKeyRotationService>();
-            KeyRotationResult result = await rotation.RotateAsync(cancellationToken).ConfigureAwait(false);
-            if (result.KeysGenerated > 0)
+            // Empty at startup. Generate the initial key set; a peer racing us against the same empty
+            // store may win first — the unique "one active key per type" index rejects our duplicate
+            // insert, which surfaces here as an exception we swallow (the peer's keys are authoritative).
+            try
             {
-                Log.FirstBootGenerated(logger, result.KeysGenerated);
+                IKeyRotationService rotation = scope.ServiceProvider.GetRequiredService<IKeyRotationService>();
+                await rotation.RotateAsync(cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                Log.FirstBootGenerationRace(logger, ex);
+            }
+
+            // Whether we generated the keys or a racing peer did, the post-configure loaded none at
+            // startup — reload so this replica serves the persisted keys instead of its bootstrap
+            // ephemeral set. Without this a replica that lost the generation race stays ephemeral.
+            if (await store.GetActiveKeyAsync("signing", cancellationToken).ConfigureAwait(false) is not null)
+            {
                 InvalidateOptionsCache();
+                Log.FirstBootInitialized(logger);
             }
         }
         catch (OperationCanceledException)
@@ -170,8 +185,12 @@ internal sealed partial class SigningKeyRefreshService(
         public static partial void KeySetChanged(ILogger logger);
 
         [LoggerMessage(Level = LogLevel.Information,
-            Message = "First boot: generated {Count} initial signing/encryption key(s) and loaded them.")]
-        public static partial void FirstBootGenerated(ILogger logger, int count);
+            Message = "First boot: initial signing/encryption keys are present — loaded them from the database.")]
+        public static partial void FirstBootInitialized(ILogger logger);
+
+        [LoggerMessage(Level = LogLevel.Information,
+            Message = "First-boot key generation lost the race to another replica (its keys are authoritative) or hit a transient error.")]
+        public static partial void FirstBootGenerationRace(ILogger logger, Exception exception);
 
         [LoggerMessage(Level = LogLevel.Warning,
             Message = "First-boot key generation failed; staying on ephemeral keys until the next boot or rotation.")]

--- a/tests/Granit.OpenIddict.Tests.Integration/Persistence/SigningKeyActiveUniqueIndexTests.cs
+++ b/tests/Granit.OpenIddict.Tests.Integration/Persistence/SigningKeyActiveUniqueIndexTests.cs
@@ -1,0 +1,100 @@
+using Granit.MultiTenancy;
+using Granit.OpenIddict.Domain;
+using Granit.OpenIddict.EntityFrameworkCore.Internal;
+using Granit.OpenIddict.Tests.Integration.Fixtures;
+using Granit.Persistence.EntityFrameworkCore.Interceptors;
+using Microsoft.EntityFrameworkCore;
+using Shouldly;
+using Xunit;
+
+#pragma warning disable EF1001 // EfSigningKeyStore / OpenIddictDbContext are internal — accessible via InternalsVisibleTo
+
+namespace Granit.OpenIddict.Tests.Integration.Persistence;
+
+/// <summary>
+/// Validates the filtered unique index that permits at most one <em>Active</em> signing/encryption
+/// key per type — the database-level guard that makes concurrent first-boot key generation
+/// race-safe. Needs real PostgreSQL because the partial-index filter (<c>WHERE "Status" = 'Active'</c>)
+/// is not exercised by a mock or the SQLite in-memory provider used elsewhere.
+/// </summary>
+public sealed class SigningKeyActiveUniqueIndexTests : IAsyncLifetime
+{
+    private readonly PostgresFixture _postgres = new();
+    private Factory? _factory;
+
+    private EfSigningKeyStore Store => new(_factory!);
+
+    public async ValueTask InitializeAsync()
+    {
+        await _postgres.InitializeAsync();
+
+        DbContextOptions<OpenIddictDbContext> options =
+            new DbContextOptionsBuilder<OpenIddictDbContext>()
+                .UseNpgsql(_postgres.ConnectionString)
+                .AddInterceptors(new ConcurrencyStampInterceptor())
+                .Options;
+
+        _factory = new Factory(options);
+
+        await using OpenIddictDbContext db = _factory.CreateDbContext();
+        await db.Database.EnsureCreatedAsync(TestContext.Current.CancellationToken);
+    }
+
+    public async ValueTask DisposeAsync() => await _postgres.DisposeAsync();
+
+    [Fact]
+    public async Task SecondActiveKeyOfSameType_IsRejected()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+        await Store.CreateAsync(ActiveKey("signing"), ct);
+
+        // A racing replica tries to persist a second active signing key — the partial unique index
+        // must reject it so first-boot generation cannot mint two active keys.
+        await Should.ThrowAsync<DbUpdateException>(() => Store.CreateAsync(ActiveKey("signing"), ct));
+    }
+
+    [Fact]
+    public async Task ActiveAndRetiredOfSameType_Coexist()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+
+        SigningKey first = ActiveKey("signing");
+        await Store.CreateAsync(first, ct);
+        SigningKey loaded = (await Store.GetActiveKeyAsync("signing", ct))!;
+        loaded.Retire(DateTimeOffset.UnixEpoch.AddDays(1));
+        await Store.UpdateAsync(loaded, ct);
+
+        // The filter only constrains Active rows, so a new active key alongside the retired one is fine.
+        await Should.NotThrowAsync(() => Store.CreateAsync(ActiveKey("signing"), ct));
+
+        (await Store.GetKeysAsync([SigningKeyStatus.Active, SigningKeyStatus.Retired], ct)).Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task ActiveKeysOfDifferentTypes_Coexist()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+
+        await Store.CreateAsync(ActiveKey("signing"), ct);
+
+        // The uniqueness is per KeyType, so a signing and an encryption key are both active at once.
+        await Should.NotThrowAsync(() => Store.CreateAsync(ActiveKey("encryption"), ct));
+    }
+
+    private sealed class Factory(DbContextOptions<OpenIddictDbContext> options)
+        : IDbContextFactory<OpenIddictDbContext>
+    {
+        public OpenIddictDbContext CreateDbContext() => new(options, NullTenantContext.Instance);
+    }
+
+    private static SigningKey ActiveKey(string keyType) =>
+        SigningKey.Create(
+            keyId: $"{keyType}-{Guid.NewGuid():N}",
+            keyType: keyType,
+            algorithm: keyType == "signing" ? "RS256" : "RSA-OAEP",
+            encryptedKeyMaterial: "encrypted-material",
+            activatedAt: DateTimeOffset.UnixEpoch,
+            expiresAt: DateTimeOffset.UnixEpoch.AddDays(90));
+}
+
+#pragma warning restore EF1001

--- a/tests/Granit.OpenIddict.Tests/Internal/SigningKeyRefreshServiceTests.cs
+++ b/tests/Granit.OpenIddict.Tests/Internal/SigningKeyRefreshServiceTests.cs
@@ -82,13 +82,39 @@ public sealed class SigningKeyRefreshServiceTests
         RecordingOptionsCache cache = new();
         IKeyRotationService rotation = Substitute.For<IKeyRotationService>();
         rotation.RotateAsync(Arg.Any<CancellationToken>())
-            .Returns(new KeyRotationResult(KeysGenerated: 2, KeysRetired: 0, KeysRevoked: 0, KeysPruned: 0));
+            .Returns(_ =>
+            {
+                store.Keys = [Key("a", SigningKeyStatus.Active)]; // generation persisted the key
+                return new KeyRotationResult(KeysGenerated: 2, KeysRetired: 0, KeysRevoked: 0, KeysPruned: 0);
+            });
         SigningKeyRefreshService service = Build(store, cache, rotation);
 
         await service.EnsureInitializedAsync(TestContext.Current.CancellationToken);
 
         await rotation.Received(1).RotateAsync(Arg.Any<CancellationToken>());
         cache.RemoveCount.ShouldBe(1, "freshly minted credentials must be loaded immediately");
+    }
+
+    [Fact]
+    public async Task EnsureInitializedAsync_LostGenerationRace_ReloadsPeerKeys()
+    {
+        FakeSigningKeyStore store = new([]); // empty at startup
+        RecordingOptionsCache cache = new();
+        IKeyRotationService rotation = Substitute.For<IKeyRotationService>();
+
+        // A peer wins the race: it persisted the active key, then our duplicate insert is rejected.
+        rotation.RotateAsync(Arg.Any<CancellationToken>())
+            .Returns<KeyRotationResult>(_ =>
+            {
+                store.Keys = [Key("peer", SigningKeyStatus.Active)];
+                throw new InvalidOperationException("duplicate key value violates unique constraint");
+            });
+        SigningKeyRefreshService service = Build(store, cache, rotation);
+
+        await service.EnsureInitializedAsync(TestContext.Current.CancellationToken);
+
+        // The race loss is swallowed, but the peer's keys must still be loaded — not left ephemeral.
+        cache.RemoveCount.ShouldBe(1, "a replica that lost the race must still load the peer's keys");
     }
 
     [Fact]


### PR DESCRIPTION
## Contexte

Refonte `Granit.OpenIddict*` — **Phase 2A**, durcissement du first-boot (#3068).

La génération first-boot (#3068) **réduisait** mais ne **fermait** pas la fenêtre où deux replicas démarrant sur un store vide génèrent chacun une clé active. On la ferme au niveau DB et on fait récupérer proprement le perdant.

## Changement

- **Index unique filtré** sur `SigningKey (KeyType) WHERE Status = 'Active'` → **au plus une clé active par type**. L'insert dupliqué du second replica est rejeté par la base.
- `SigningKeyRefreshService.EnsureInitializedAsync` : avale l'exception de course perdue et, qu'il ait généré les clés ou qu'un pair l'ait fait, **recharge dès que des clés existent** → le replica qui perd la course sert les clés persistées au lieu de rester sur son set éphémère de bootstrap (le bug que l'index seul introduirait).

## Tests

- **Unit** : store vide → génère + recharge · course perdue → recharge les clés du pair · clés présentes → no-op · store qui throw → survit.
- **Intégration (vrai Postgres)** : 2e clé active du même type **rejetée** · active + retired coexistent · clés actives de types différents coexistent (valide le SQL du filtre partiel).
- Base **272/272** · EFCore **42/42** · OpenIddict integration **28/28** · `dotnet format` clean.

## Schéma

Changement additif : les hosts régénèrent leurs migrations OpenIddict pour prendre l'index (suppose aucune clé active dupliquée pré-existante, ce que le lifecycle antérieur excluait déjà).

> Deuxième vrai test d'intégration Postgres du refonte (avec #3072).

🤖 Generated with [Claude Code](https://claude.com/claude-code)