### PR TITLE
feat(openiddict): guarantee the account-deletion erasure event via a reconciliation sweep (Phase 2C)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -42707,6 +42707,31 @@
       ]
     },
     {
+      "name": "OpenIddictAccountDeletionEtoDispatchHandler",
+      "fqn": "Granit.OpenIddict.BackgroundJobs.Jobs.OpenIddictAccountDeletionEtoDispatchHandler",
+      "kind": "class",
+      "project": "Granit.OpenIddict.BackgroundJobs",
+      "file": "src/Granit.OpenIddict.BackgroundJobs/Jobs/OpenIddictAccountDeletionEtoDispatchHandler.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "HandleAsync",
+          "kind": "method",
+          "signature": "HandleAsync(OpenIddictAccountDeletionEtoDispatchJob _, IAccountDeletionEtoReconciler reconciler, CancellationToken cancellationToken)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "OpenIddictAccountDeletionEtoDispatchJob",
+      "fqn": "Granit.OpenIddict.BackgroundJobs.Jobs.OpenIddictAccountDeletionEtoDispatchJob",
+      "kind": "record",
+      "project": "Granit.OpenIddict.BackgroundJobs",
+      "file": "src/Granit.OpenIddict.BackgroundJobs/Jobs/OpenIddictAccountDeletionEtoDispatchJob.cs",
+      "line": 15,
+      "members": []
+    },
+    {
       "name": "OpenIddictIdleSessionEnforcementHandler",
       "fqn": "Granit.OpenIddict.BackgroundJobs.Jobs.OpenIddictIdleSessionEnforcementHandler",
       "kind": "class",
@@ -43792,6 +43817,22 @@
       ]
     },
     {
+      "name": "IAccountDeletionEtoReconciler",
+      "fqn": "Granit.OpenIddict.Services.IAccountDeletionEtoReconciler",
+      "kind": "interface",
+      "project": "Granit.OpenIddict.Abstractions",
+      "file": "src/Granit.OpenIddict.Abstractions/Services/IAccountDeletionEtoReconciler.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "ReconcileAsync",
+          "kind": "method",
+          "signature": "ReconcileAsync(CancellationToken cancellationToken)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
       "name": "IClaimsDestinationProvider",
       "fqn": "Granit.OpenIddict.Services.IClaimsDestinationProvider",
       "kind": "interface",
@@ -43842,6 +43883,28 @@
           "kind": "method",
           "signature": "CreateClientPrincipal(string clientId, ImmutableArray<string> scopes, string authenticationScheme)",
           "returnType": "ClaimsPrincipal"
+        }
+      ]
+    },
+    {
+      "name": "IPendingAccountDeletionStore",
+      "fqn": "Granit.OpenIddict.Services.IPendingAccountDeletionStore",
+      "kind": "interface",
+      "project": "Granit.OpenIddict.Abstractions",
+      "file": "src/Granit.OpenIddict.Abstractions/Services/IPendingAccountDeletionStore.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "GetPendingAsync",
+          "kind": "method",
+          "signature": "GetPendingAsync(int max, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<PendingAccountDeletion>>"
+        },
+        {
+          "name": "MarkDispatchedAsync",
+          "kind": "method",
+          "signature": "MarkDispatchedAsync(Guid userId, DateTimeOffset dispatchedAt, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
         }
       ]
     },
@@ -43898,6 +43961,15 @@
       "project": "Granit.OpenIddict.Abstractions",
       "file": "src/Granit.OpenIddict.Abstractions/Services/IKeyRotationService.cs",
       "line": 29,
+      "members": []
+    },
+    {
+      "name": "PendingAccountDeletion",
+      "fqn": "Granit.OpenIddict.Services.PendingAccountDeletion",
+      "kind": "record",
+      "project": "Granit.OpenIddict.Abstractions",
+      "file": "src/Granit.OpenIddict.Abstractions/Services/IPendingAccountDeletionStore.cs",
+      "line": 33,
       "members": []
     },
     {

--- a/src/Granit.Identity.Local/Domain/LocalIdentity.cs
+++ b/src/Granit.Identity.Local/Domain/LocalIdentity.cs
@@ -77,6 +77,14 @@ public class LocalIdentity
     /// <summary>Gets or sets the identifier of the user who performed the deletion.</summary>
     public string? DeletedBy { get; set; }
 
+    /// <summary>
+    /// Gets or sets the UTC timestamp at which the <c>AccountDeletedEto</c> was dispatched for this
+    /// deletion. <see langword="null"/> while the deletion is soft-deleted but the erasure event has
+    /// not yet been published — the reconciliation job sweeps these and publishes idempotently, so
+    /// the GDPR Art. 17 event survives a crash between the soft-delete commit and the publish.
+    /// </summary>
+    public DateTimeOffset? DeletionEventDispatchedAt { get; set; }
+
     /// <summary>Gets or sets a JSON column for custom extensible attributes.</summary>
     public string? CustomAttributesJson { get; set; }
 

--- a/src/Granit.OpenIddict.Abstractions/Services/IAccountDeletionEtoReconciler.cs
+++ b/src/Granit.OpenIddict.Abstractions/Services/IAccountDeletionEtoReconciler.cs
@@ -1,0 +1,13 @@
+namespace Granit.OpenIddict.Services;
+
+/// <summary>
+/// Publishes the GDPR Art. 17 erasure event for soft-deleted users whose event has not yet been
+/// dispatched. Driven by a recurring background job so the event survives a crash between the
+/// soft-delete commit and the publish.
+/// </summary>
+public interface IAccountDeletionEtoReconciler
+{
+    /// <summary>Publishes pending erasure events and marks them dispatched.</summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task ReconcileAsync(CancellationToken cancellationToken);
+}

--- a/src/Granit.OpenIddict.Abstractions/Services/IPendingAccountDeletionStore.cs
+++ b/src/Granit.OpenIddict.Abstractions/Services/IPendingAccountDeletionStore.cs
@@ -1,0 +1,33 @@
+namespace Granit.OpenIddict.Services;
+
+/// <summary>
+/// Reads soft-deleted users whose <c>AccountDeletedEto</c> has not yet been dispatched, and marks
+/// them dispatched — the durable state the reconciliation job uses to guarantee the GDPR Art. 17
+/// erasure event is published exactly-eventually, even if the process crashes between the
+/// soft-delete commit and the event publish.
+/// </summary>
+public interface IPendingAccountDeletionStore
+{
+    /// <summary>
+    /// Returns soft-deleted users with no dispatched erasure event, across every tenant (the sweep
+    /// runs in host context, so the multi-tenant filter is bypassed for this read).
+    /// </summary>
+    /// <param name="max">Maximum number of pending deletions to return in one sweep.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<IReadOnlyList<PendingAccountDeletion>> GetPendingAsync(
+        int max, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Stamps <c>DeletionEventDispatchedAt</c> on the user so the deletion is not re-published.
+    /// </summary>
+    /// <param name="userId">The user whose erasure event was dispatched.</param>
+    /// <param name="dispatchedAt">The dispatch timestamp.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task MarkDispatchedAsync(
+        Guid userId, DateTimeOffset dispatchedAt, CancellationToken cancellationToken = default);
+}
+
+/// <summary>A soft-deleted user awaiting erasure-event dispatch.</summary>
+/// <param name="UserId">The deleted user's identifier.</param>
+/// <param name="TenantId">The owning tenant, or <see langword="null"/> for a global user.</param>
+public sealed record PendingAccountDeletion(Guid UserId, Guid? TenantId);

--- a/src/Granit.OpenIddict.BackgroundJobs/Jobs/OpenIddictAccountDeletionEtoDispatchHandler.cs
+++ b/src/Granit.OpenIddict.BackgroundJobs/Jobs/OpenIddictAccountDeletionEtoDispatchHandler.cs
@@ -1,0 +1,16 @@
+using Granit.OpenIddict.Services;
+
+namespace Granit.OpenIddict.BackgroundJobs.Jobs;
+
+/// <summary>
+/// Handler for <see cref="OpenIddictAccountDeletionEtoDispatchJob"/>. Delegates to
+/// <see cref="IAccountDeletionEtoReconciler"/> to publish pending erasure events.
+/// </summary>
+public class OpenIddictAccountDeletionEtoDispatchHandler
+{
+    public static Task HandleAsync(
+        OpenIddictAccountDeletionEtoDispatchJob _,
+        IAccountDeletionEtoReconciler reconciler,
+        CancellationToken cancellationToken) =>
+        reconciler.ReconcileAsync(cancellationToken);
+}

--- a/src/Granit.OpenIddict.BackgroundJobs/Jobs/OpenIddictAccountDeletionEtoDispatchJob.cs
+++ b/src/Granit.OpenIddict.BackgroundJobs/Jobs/OpenIddictAccountDeletionEtoDispatchJob.cs
@@ -1,0 +1,15 @@
+using Granit.BackgroundJobs;
+
+namespace Granit.OpenIddict.BackgroundJobs.Jobs;
+
+/// <summary>
+/// Recurring job that publishes the GDPR Art. 17 erasure event (<c>AccountDeletedEto</c>) for any
+/// soft-deleted user whose event has not yet been dispatched.
+/// </summary>
+/// <remarks>
+/// Runs every five minutes. The account-deletion service records the soft-delete durably but does
+/// not publish inline (the OpenIddict DbContext is not enrolled in the Wolverine outbox); this job
+/// reconciles the durable soft-delete rows into published events at-least-once.
+/// </remarks>
+[RecurringJob("*/5 * * * *", "openiddict-account-deletion-eto-dispatch")]
+public sealed record OpenIddictAccountDeletionEtoDispatchJob : IBackgroundJob;

--- a/src/Granit.OpenIddict.EntityFrameworkCore/GranitOpenIddictEntityFrameworkCoreModule.cs
+++ b/src/Granit.OpenIddict.EntityFrameworkCore/GranitOpenIddictEntityFrameworkCoreModule.cs
@@ -40,6 +40,7 @@ public sealed class GranitOpenIddictEntityFrameworkCoreModule : GranitModule
         // EF Core stores
         context.Services.TryAddScoped<ILocalIdentityGroupStore, OpenIddictGroupStore>();
         context.Services.TryAddScoped<ISigningKeyStore, EfSigningKeyStore>();
+        context.Services.TryAddScoped<IPendingAccountDeletionStore, EfPendingAccountDeletionStore>();
 
         // LocalIdentity implements IHasMetadata — apps can extend user properties
         // by calling AddMetadataMappings<LocalIdentity> in their own module.

--- a/src/Granit.OpenIddict.EntityFrameworkCore/Internal/EfPendingAccountDeletionStore.cs
+++ b/src/Granit.OpenIddict.EntityFrameworkCore/Internal/EfPendingAccountDeletionStore.cs
@@ -1,0 +1,53 @@
+using Granit.Identity.Local.Domain;
+using Granit.OpenIddict.Services;
+using Granit.Persistence.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
+
+namespace Granit.OpenIddict.EntityFrameworkCore.Internal;
+
+/// <summary>
+/// EF Core implementation of <see cref="IPendingAccountDeletionStore"/> over the consolidated
+/// <see cref="OpenIddictDbContext"/>.
+/// </summary>
+/// <remarks>
+/// The reconciliation sweep runs in host context with no active tenant, so it ignores the query
+/// filters: the multi-tenant filter (to see every tenant's deletions) and the soft-delete filter
+/// (to see the deleted users at all — a soft-deleted row is hidden by default).
+/// </remarks>
+internal sealed class EfPendingAccountDeletionStore(
+    IDbContextFactory<OpenIddictDbContext> dbFactory) : IPendingAccountDeletionStore
+{
+    /// <inheritdoc/>
+    public async Task<IReadOnlyList<PendingAccountDeletion>> GetPendingAsync(
+        int max, CancellationToken cancellationToken = default)
+    {
+        await using OpenIddictDbContext db = await dbFactory
+            .CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+
+        return await db.Set<LocalIdentity>()
+            .IgnoreQueryFilters([GranitFilterNames.SoftDelete, GranitFilterNames.MultiTenant])
+            .AsNoTracking()
+            .Where(u => u.IsDeleted && u.DeletionEventDispatchedAt == null)
+            .OrderBy(u => u.DeletedAt)
+            .Take(max)
+            .Select(u => new PendingAccountDeletion(u.Id, u.TenantId))
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    /// <inheritdoc/>
+    public async Task MarkDispatchedAsync(
+        Guid userId, DateTimeOffset dispatchedAt, CancellationToken cancellationToken = default)
+    {
+        await using OpenIddictDbContext db = await dbFactory
+            .CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+
+        await db.Set<LocalIdentity>()
+            .IgnoreQueryFilters([GranitFilterNames.SoftDelete, GranitFilterNames.MultiTenant])
+            .Where(u => u.Id == userId)
+            .ExecuteUpdateAsync(
+                s => s.SetProperty(u => u.DeletionEventDispatchedAt, dispatchedAt),
+                cancellationToken)
+            .ConfigureAwait(false);
+    }
+}

--- a/src/Granit.OpenIddict/GranitOpenIddictModule.cs
+++ b/src/Granit.OpenIddict/GranitOpenIddictModule.cs
@@ -78,6 +78,7 @@ public sealed class GranitOpenIddictModule : GranitModule
         context.Services.TryAddScoped<IOidcPrincipalFactory, OidcPrincipalFactory>();
         context.Services.TryAddScoped<ITotpService, DefaultTotpService>();
         context.Services.TryAddScoped<IAccountDeletionService, Internal.AspNetAccountDeletionService>();
+        context.Services.TryAddScoped<IAccountDeletionEtoReconciler, Internal.AccountDeletionEtoReconciler>();
         context.Services.TryAddScoped<IImpersonationService, Internal.AspNetImpersonationService>();
         context.Services.TryAddScoped<IKeyRotationService, Internal.KeyRotationService>();
 

--- a/src/Granit.OpenIddict/Internal/AccountDeletionEtoReconciler.cs
+++ b/src/Granit.OpenIddict/Internal/AccountDeletionEtoReconciler.cs
@@ -1,0 +1,63 @@
+using Granit.Events;
+using Granit.Identity.Local.Events;
+using Granit.OpenIddict.Services;
+using Granit.Timing;
+using Microsoft.Extensions.Logging;
+
+namespace Granit.OpenIddict.Internal;
+
+/// <summary>
+/// Publishes the <see cref="AccountDeletedEto"/> for every soft-deleted user whose erasure event has
+/// not yet been dispatched, then marks it dispatched.
+/// </summary>
+/// <remarks>
+/// The account-deletion service records the soft-delete durably but does not publish the event
+/// inline — the OpenIddict DbContext is not enrolled in the Wolverine outbox, so an inline publish
+/// after the commit could be lost to a crash before it reaches the durable outbox. This reconciler
+/// (driven by a recurring job) closes that gap: the soft-delete row is the durable intent, and the
+/// event is published at-least-once from it. Consumers of <see cref="AccountDeletedEto"/> are already
+/// idempotent, so a rare re-publish (crash between publish and mark) is safe.
+/// </remarks>
+internal sealed partial class AccountDeletionEtoReconciler(
+    IPendingAccountDeletionStore store,
+    IDistributedEventBus eventBus,
+    IClock clock,
+    ILogger<AccountDeletionEtoReconciler> logger) : IAccountDeletionEtoReconciler
+{
+    private const int BatchSize = 500;
+
+    public async Task ReconcileAsync(CancellationToken cancellationToken)
+    {
+        IReadOnlyList<PendingAccountDeletion> pending = await store
+            .GetPendingAsync(BatchSize, cancellationToken).ConfigureAwait(false);
+
+        if (pending.Count == 0)
+        {
+            return;
+        }
+
+        LogReconciling(logger, pending.Count);
+
+        foreach (PendingAccountDeletion deletion in pending)
+        {
+            // Publish before marking: if the process dies between the two, the next sweep re-publishes
+            // (at-least-once). Marking first would risk dropping the event entirely.
+            await eventBus.PublishAsync(
+                new AccountDeletedEto(deletion.UserId, deletion.TenantId), cancellationToken)
+                .ConfigureAwait(false);
+
+            await store.MarkDispatchedAsync(deletion.UserId, clock.Now, cancellationToken)
+                .ConfigureAwait(false);
+
+            LogDispatched(logger, deletion.UserId);
+        }
+    }
+
+    [LoggerMessage(Level = LogLevel.Information,
+        Message = "Reconciling {Count} pending account-deletion erasure event(s).")]
+    private static partial void LogReconciling(ILogger logger, int count);
+
+    [LoggerMessage(Level = LogLevel.Debug,
+        Message = "Dispatched AccountDeletedEto for user {UserId}.")]
+    private static partial void LogDispatched(ILogger logger, Guid userId);
+}

--- a/src/Granit.OpenIddict/Internal/AspNetAccountDeletionService.cs
+++ b/src/Granit.OpenIddict/Internal/AspNetAccountDeletionService.cs
@@ -1,6 +1,4 @@
-using Granit.Events;
 using Granit.Identity.Local.Domain;
-using Granit.Identity.Local.Events;
 using Granit.Identity.Local.Services;
 using Granit.Timing;
 using Microsoft.AspNetCore.Identity;
@@ -10,13 +8,18 @@ namespace Granit.OpenIddict.Internal;
 
 /// <summary>
 /// <see cref="IAccountDeletionService"/> implementation backed by ASP.NET Core Identity.
-/// Soft-deletes the user, revokes all active tokens, and publishes <see cref="AccountDeletedEto"/>
-/// via <see cref="IDistributedEventBus"/>.
+/// Soft-deletes the user and revokes all active tokens.
 /// </summary>
+/// <remarks>
+/// The GDPR Art. 17 erasure event (<c>AccountDeletedEto</c>) is <em>not</em> published inline: the
+/// OpenIddict DbContext is not enrolled in the Wolverine outbox, so a post-commit publish could be
+/// lost to a crash. The soft-delete row (<see cref="LocalIdentity.IsDeleted"/> with a null
+/// <see cref="LocalIdentity.DeletionEventDispatchedAt"/>) is the durable intent; the recurring
+/// reconciler (<c>AccountDeletionEtoReconciler</c>) publishes the event at-least-once from it.
+/// </remarks>
 internal sealed class AspNetAccountDeletionService(
     UserManager<LocalIdentity> userManager,
     IOpenIddictTokenManager tokenManager,
-    IDistributedEventBus eventBus,
     IClock clock) : IAccountDeletionService
 {
     /// <inheritdoc/>
@@ -49,9 +52,7 @@ internal sealed class AspNetAccountDeletionService(
             await tokenManager.TryRevokeAsync(token, cancellationToken).ConfigureAwait(false);
         }
 
-        // Publish integration event for downstream cleanup
-        await eventBus.PublishAsync(
-            new AccountDeletedEto(user.Id, user.TenantId),
-            cancellationToken).ConfigureAwait(false);
+        // The AccountDeletedEto is published by AccountDeletionEtoReconciler from the durable
+        // soft-delete row — see the class remarks — so a crash here cannot drop the erasure event.
     }
 }

--- a/tests/Granit.OpenIddict.Tests.Integration/Persistence/PendingAccountDeletionStoreTests.cs
+++ b/tests/Granit.OpenIddict.Tests.Integration/Persistence/PendingAccountDeletionStoreTests.cs
@@ -1,0 +1,102 @@
+using Granit.Identity.Local.Domain;
+using Granit.MultiTenancy;
+using Granit.OpenIddict.EntityFrameworkCore.Internal;
+using Granit.OpenIddict.Services;
+using Granit.OpenIddict.Tests.Integration.Fixtures;
+using Microsoft.EntityFrameworkCore;
+using Shouldly;
+using Xunit;
+
+#pragma warning disable EF1001 // EfPendingAccountDeletionStore / OpenIddictDbContext are internal — accessible via InternalsVisibleTo
+
+namespace Granit.OpenIddict.Tests.Integration.Persistence;
+
+/// <summary>
+/// Validates that <see cref="EfPendingAccountDeletionStore"/> finds soft-deleted, undispatched users
+/// across every tenant and stops returning them once marked. Needs real PostgreSQL: the query bypasses
+/// both the multi-tenant and the soft-delete query filters, and marking uses a bulk
+/// <c>ExecuteUpdate</c> — neither is faithfully exercised by mocks.
+/// </summary>
+public sealed class PendingAccountDeletionStoreTests : IAsyncLifetime
+{
+    private static readonly Guid TenantA = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    private static readonly DateTimeOffset DeletedAt = DateTimeOffset.UnixEpoch;
+
+    private readonly PostgresFixture _postgres = new();
+    private Factory? _factory;
+
+    private EfPendingAccountDeletionStore Store => new(_factory!);
+
+    public async ValueTask InitializeAsync()
+    {
+        await _postgres.InitializeAsync();
+
+        DbContextOptions<OpenIddictDbContext> options =
+            new DbContextOptionsBuilder<OpenIddictDbContext>()
+                .UseNpgsql(_postgres.ConnectionString)
+                .Options;
+        _factory = new Factory(options);
+
+        await using OpenIddictDbContext db = _factory.CreateDbContext();
+        await db.Database.EnsureCreatedAsync(TestContext.Current.CancellationToken);
+    }
+
+    public async ValueTask DisposeAsync() => await _postgres.DisposeAsync();
+
+    [Fact]
+    public async Task GetPending_ReturnsSoftDeletedUndispatched_AcrossTenants()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+        Guid globalPending = await SeedAsync(tenantId: null, deleted: true, dispatched: false, ct);
+        Guid tenantPending = await SeedAsync(tenantId: TenantA, deleted: true, dispatched: false, ct);
+        await SeedAsync(tenantId: null, deleted: false, dispatched: false, ct);       // not deleted
+        await SeedAsync(tenantId: TenantA, deleted: true, dispatched: true, ct);      // already dispatched
+
+        IReadOnlyList<PendingAccountDeletion> pending = await Store.GetPendingAsync(100, ct);
+
+        pending.Select(p => p.UserId).ShouldBe([globalPending, tenantPending], ignoreOrder: true);
+        pending.Single(p => p.UserId == tenantPending).TenantId.ShouldBe(TenantA);
+        pending.Single(p => p.UserId == globalPending).TenantId.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task MarkDispatched_ExcludesFromNextSweep()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+        Guid userId = await SeedAsync(tenantId: TenantA, deleted: true, dispatched: false, ct);
+
+        (await Store.GetPendingAsync(100, ct)).ShouldContain(p => p.UserId == userId);
+
+        await Store.MarkDispatchedAsync(userId, DateTimeOffset.UnixEpoch.AddDays(1), ct);
+
+        (await Store.GetPendingAsync(100, ct)).ShouldNotContain(p => p.UserId == userId);
+    }
+
+    private async Task<Guid> SeedAsync(Guid? tenantId, bool deleted, bool dispatched, CancellationToken ct)
+    {
+        var id = Guid.NewGuid();
+        await using OpenIddictDbContext db = _factory!.CreateDbContext();
+        db.Set<LocalIdentity>().Add(new LocalIdentity
+        {
+            Id = id,
+            UserName = id.ToString("N"),
+            NormalizedUserName = id.ToString("N").ToUpperInvariant(),
+            Email = $"{id:N}@example.com",
+            SecurityStamp = Guid.NewGuid().ToString("N"),
+            TenantId = tenantId,
+            IsDeleted = deleted,
+            DeletedAt = deleted ? DeletedAt : null,
+            DeletionEventDispatchedAt = dispatched ? DeletedAt : null,
+        });
+        await db.SaveChangesAsync(ct);
+        return id;
+    }
+
+    private sealed class Factory(DbContextOptions<OpenIddictDbContext> options)
+        : IDbContextFactory<OpenIddictDbContext>
+    {
+        public OpenIddictDbContext CreateDbContext() => new(options, NullTenantContext.Instance);
+    }
+}
+
+#pragma warning restore EF1001

--- a/tests/Granit.OpenIddict.Tests/AspNetAccountDeletionServiceTests.cs
+++ b/tests/Granit.OpenIddict.Tests/AspNetAccountDeletionServiceTests.cs
@@ -1,6 +1,4 @@
-using Granit.Events;
 using Granit.Identity.Local.Domain;
-using Granit.Identity.Local.Events;
 using Granit.OpenIddict.Internal;
 using Granit.Timing;
 using Microsoft.AspNetCore.Identity;
@@ -17,7 +15,6 @@ public sealed class AspNetAccountDeletionServiceTests
 
     private readonly UserManager<LocalIdentity> _userManager;
     private readonly IOpenIddictTokenManager _tokenManager = Substitute.For<IOpenIddictTokenManager>();
-    private readonly IDistributedEventBus _eventBus = Substitute.For<IDistributedEventBus>();
     private readonly IClock _clock = Substitute.For<IClock>();
     private readonly AspNetAccountDeletionService _sut;
 
@@ -32,7 +29,6 @@ public sealed class AspNetAccountDeletionServiceTests
         _sut = new AspNetAccountDeletionService(
             _userManager,
             _tokenManager,
-            _eventBus,
             _clock);
     }
 
@@ -92,11 +88,11 @@ public sealed class AspNetAccountDeletionServiceTests
     }
 
     [Fact]
-    public async Task InitiateAsync_UserExists_PublishesAccountDeletedEto()
+    public async Task InitiateAsync_LeavesErasureEventPending()
     {
+        // The service records the soft-delete durably but does NOT publish inline — the erasure
+        // event stays pending (DeletionEventDispatchedAt null) for the reconciler to publish.
         LocalIdentity user = CreateUser();
-        var tenantId = Guid.NewGuid();
-        user.TenantId = tenantId;
         string userId = user.Id.ToString();
 
         _userManager.FindByIdAsync(userId).Returns(user);
@@ -107,33 +103,8 @@ public sealed class AspNetAccountDeletionServiceTests
 
         await _sut.InitiateAsync(userId, TestContext.Current.CancellationToken);
 
-        await _eventBus.Received(1).PublishAsync(
-            Arg.Is<AccountDeletedEto>(e =>
-                e.UserId == user.Id &&
-                e.TenantId == tenantId),
-            Arg.Any<CancellationToken>());
-    }
-
-    [Fact]
-    public async Task InitiateAsync_UserWithNoTenant_PublishesEventWithNullTenant()
-    {
-        LocalIdentity user = CreateUser();
-        user.TenantId = null;
-        string userId = user.Id.ToString();
-
-        _userManager.FindByIdAsync(userId).Returns(user);
-        _userManager.UpdateAsync(user).Returns(IdentityResult.Success);
-        _userManager.SetLockoutEndDateAsync(user, Arg.Any<DateTimeOffset>()).Returns(IdentityResult.Success);
-        _userManager.UpdateSecurityStampAsync(user).Returns(IdentityResult.Success);
-        SetupEmptyTokenStream(userId);
-
-        await _sut.InitiateAsync(userId, TestContext.Current.CancellationToken);
-
-        await _eventBus.Received(1).PublishAsync(
-            Arg.Is<AccountDeletedEto>(e =>
-                e.UserId == user.Id &&
-                e.TenantId == null),
-            Arg.Any<CancellationToken>());
+        user.IsDeleted.ShouldBeTrue();
+        user.DeletionEventDispatchedAt.ShouldBeNull("the erasure event is dispatched by the reconciler, not inline");
     }
 
     // ────────────────────── InitiateAsync — token revocation ──────────────────────
@@ -223,7 +194,6 @@ public sealed class AspNetAccountDeletionServiceTests
 
         await _userManager.DidNotReceive().SetLockoutEndDateAsync(Arg.Any<LocalIdentity>(), Arg.Any<DateTimeOffset>());
         await _userManager.DidNotReceive().UpdateSecurityStampAsync(Arg.Any<LocalIdentity>());
-        await _eventBus.DidNotReceive().PublishAsync(Arg.Any<AccountDeletedEto>(), Arg.Any<CancellationToken>());
     }
 
     // ────────────────────── Helpers ──────────────────────

--- a/tests/Granit.OpenIddict.Tests/Internal/AccountDeletionEtoReconcilerTests.cs
+++ b/tests/Granit.OpenIddict.Tests/Internal/AccountDeletionEtoReconcilerTests.cs
@@ -1,0 +1,66 @@
+using Granit.Events;
+using Granit.Identity.Local.Events;
+using Granit.OpenIddict.Internal;
+using Granit.OpenIddict.Services;
+using Granit.Timing;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Xunit;
+
+namespace Granit.OpenIddict.Tests.Internal;
+
+/// <summary>
+/// The reconciler publishes an <see cref="AccountDeletedEto"/> for every pending deletion and marks
+/// each dispatched — publishing before marking so a crash between the two re-publishes (at-least-once)
+/// rather than dropping the erasure event.
+/// </summary>
+public sealed class AccountDeletionEtoReconcilerTests
+{
+    [Fact]
+    public async Task ReconcileAsync_PublishesAndMarksEachPending()
+    {
+        PendingAccountDeletion tenantUser = new(Guid.NewGuid(), Guid.NewGuid());
+        PendingAccountDeletion globalUser = new(Guid.NewGuid(), null);
+
+        IPendingAccountDeletionStore store = Substitute.For<IPendingAccountDeletionStore>();
+        store.GetPendingAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns([tenantUser, globalUser]);
+        IDistributedEventBus bus = Substitute.For<IDistributedEventBus>();
+        IClock clock = Substitute.For<IClock>();
+        clock.Now.Returns(DateTimeOffset.UnixEpoch);
+
+        AccountDeletionEtoReconciler reconciler = new(
+            store, bus, clock, NullLogger<AccountDeletionEtoReconciler>.Instance);
+
+        await reconciler.ReconcileAsync(TestContext.Current.CancellationToken);
+
+        await bus.Received(1).PublishAsync(
+            Arg.Is<AccountDeletedEto>(e => e.UserId == tenantUser.UserId && e.TenantId == tenantUser.TenantId),
+            Arg.Any<CancellationToken>());
+        await bus.Received(1).PublishAsync(
+            Arg.Is<AccountDeletedEto>(e => e.UserId == globalUser.UserId && e.TenantId == null),
+            Arg.Any<CancellationToken>());
+        await store.Received(1).MarkDispatchedAsync(
+            tenantUser.UserId, DateTimeOffset.UnixEpoch, Arg.Any<CancellationToken>());
+        await store.Received(1).MarkDispatchedAsync(
+            globalUser.UserId, DateTimeOffset.UnixEpoch, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ReconcileAsync_NoPending_PublishesNothing()
+    {
+        IPendingAccountDeletionStore store = Substitute.For<IPendingAccountDeletionStore>();
+        store.GetPendingAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns([]);
+        IDistributedEventBus bus = Substitute.For<IDistributedEventBus>();
+
+        AccountDeletionEtoReconciler reconciler = new(
+            store, bus, Substitute.For<IClock>(), NullLogger<AccountDeletionEtoReconciler>.Instance);
+
+        await reconciler.ReconcileAsync(TestContext.Current.CancellationToken);
+
+        await bus.DidNotReceive().PublishAsync(Arg.Any<AccountDeletedEto>(), Arg.Any<CancellationToken>());
+        await store.DidNotReceive().MarkDispatchedAsync(
+            Arg.Any<Guid>(), Arg.Any<DateTimeOffset>(), Arg.Any<CancellationToken>());
+    }
+}


### PR DESCRIPTION
## Contexte

Refonte `Granit.OpenIddict*` — **Phase 2C (outbox Etos identité)**, cas RGPD Art. 17.

L'événement d'effacement (`AccountDeletedEto`) était publié **inline, après le commit UserManager**. Le `OpenIddictDbContext` **n'est pas enrôlé dans l'outbox Wolverine**, donc un crash entre le commit du soft-delete et le publish **perdait l'événement** → l'effacement des données downstream ne tournait jamais.

## Changement — Option B (réconciliation, zéro couplage Wolverine dans la base)

- `LocalIdentity` gagne `DeletionEventDispatchedAt` ; la ligne soft-delete (`IsDeleted`, dispatched-at null) est l'**intention durable**. `AspNetAccountDeletionService` ne publie plus inline.
- `IAccountDeletionEtoReconciler` (base) publie l'événement pour chaque suppression en attente, **puis** marque dispatché — **publish-before-mark** : un crash entre les deux **re-publie** (at-least-once ; les consommateurs sont déjà idempotents) plutôt que de perdre l'événement.
- `IPendingAccountDeletionStore` + impl EF lisent les users soft-deleted non-dispatchés **de tous les tenants** (sweep host-context — ignore les filtres nommés `SoftDelete` et `MultiTenant`) et marquent via `ExecuteUpdate` bulk.
- `OpenIddictAccountDeletionEtoDispatchJob` (`[RecurringJob]`, toutes les 5 min) pilote le reconciler.

## Tests

- **Unit** : reconciler publie + marque chaque pending, ne publie rien si vide ; le service de suppression laisse l'événement pending.
- **Intégration (vrai Postgres)** : le store trouve les users soft-deleted non-dispatchés cross-tenant et les exclut une fois marqués.
- Base **273/273** · EFCore **42/42** · background-jobs **15/15** · OpenIddict integration (dont 2 neufs) vert · architecture **262/262** · `dotnet format` clean.

## Note

Les Etos external-login et impersonation (même pattern inline-publish) suivront séparément. Schéma : les hosts régénèrent leurs migrations pour la colonne additive `DeletionEventDispatchedAt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)