### PR TITLE
refactor(identity)!: unify the federated write path behind FederatedIdentityWriter (Vague 4b / G5)

### DIFF
--- a/src/Granit.Identity.Federated.Endpoints/UserCacheSyncMiddleware.cs
+++ b/src/Granit.Identity.Federated.Endpoints/UserCacheSyncMiddleware.cs
@@ -28,6 +28,7 @@ internal sealed class UserCacheSyncMiddleware(RequestDelegate next)
         ICurrentUserService currentUserService,
         ICurrentTenant currentTenant,
         IUserCacheStore store,
+        IFederatedIdentityWriter writer,
         TimeProvider timeProvider,
         IOptions<UserCacheOptions> options,
         IIdentityProviderCapabilities capabilities)
@@ -53,19 +54,18 @@ internal sealed class UserCacheSyncMiddleware(RequestDelegate next)
 
             if (existing is null || now - existing.LastSyncedAt >= options.Value.StalenessThreshold)
             {
-                var entry = new FederatedIdentity
-                {
-                    ExternalUserId = userId,
-                    Username = currentUserService.UserName,
-                    Email = currentUserService.Email,
-                    FirstName = currentUserService.FirstName,
-                    LastName = currentUserService.LastName,
-                    Enabled = true,
-                    LastSyncedAt = now,
-                    TenantId = tenantId
-                };
+                // Route through the shared writer so login-time claim sync gets the same ADR-051
+                // joint hydration (canonical User + aligned Id/UserId) as the other paths, instead
+                // of inserting a FederatedIdentity with UserId = Guid.Empty and no User row.
+                var claimsUser = new FederatedIdentityUser(
+                    userId,
+                    currentUserService.UserName,
+                    currentUserService.Email,
+                    currentUserService.FirstName,
+                    currentUserService.LastName,
+                    Enabled: true);
 
-                await store.UpsertAsync(entry, httpContext.RequestAborted).ConfigureAwait(false);
+                await writer.WriteAsync(claimsUser, existing, httpContext.RequestAborted).ConfigureAwait(false);
             }
         }
 

--- a/src/Granit.Identity.Federated.EntityFrameworkCore/Extensions/IdentityFederatedEntityFrameworkCoreHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Identity.Federated.EntityFrameworkCore/Extensions/IdentityFederatedEntityFrameworkCoreHostApplicationBuilderExtensions.cs
@@ -52,6 +52,9 @@ public static class IdentityFederatedEntityFrameworkCoreHostApplicationBuilderEx
         builder.Services.Replace(ServiceDescriptor.Scoped<IUserLookupService, CachedUserLookupService>());
         builder.Services.Replace(ServiceDescriptor.Scoped<IUserCacheStats, EfCoreUserCacheStats>());
         builder.Services.TryAddScoped<IUserCacheStore, EfCoreUserCacheStore>();
+        // The single joint-hydration write path (ADR-051), shared by the cache-aside service,
+        // the provider webhook handler, and the login-time sync middleware.
+        builder.Services.TryAddScoped<IFederatedIdentityWriter, FederatedIdentityWriter>();
         builder.Services.TryAddScoped<IFederatedUserCacheReader, FederatedUserCacheReaderAdapter>();
         builder.Services.TryAddScoped<IFederatedUserCacheEraser, FederatedUserCacheEraserAdapter>();
         builder.Services.AddOptions<UserCacheOptions>()

--- a/src/Granit.Identity.Federated/Handlers/IdentityUserEventHandler.cs
+++ b/src/Granit.Identity.Federated/Handlers/IdentityUserEventHandler.cs
@@ -16,6 +16,7 @@ internal sealed partial class IdentityUserEventHandler(
     IIdentityProvider identityProvider,
     IIdentityProviderCapabilities providerCapabilities,
     IUserCacheStore store,
+    IFederatedIdentityWriter writer,
     ICurrentTenant currentTenant,
     ILocalEventBus localEventBus,
     IDistributedEventBus distributedEventBus,
@@ -100,18 +101,10 @@ internal sealed partial class IdentityUserEventHandler(
             return;
         }
 
-        var entry = new FederatedIdentity
-        {
-            ExternalUserId = user.UserId,
-            Username = user.Username,
-            Email = user.Email,
-            FirstName = user.FirstName,
-            LastName = user.LastName,
-            Enabled = user.Enabled,
-            LastSyncedAt = timeProvider.GetUtcNow()
-        };
-
-        await store.UpsertAsync(entry, cancellationToken).ConfigureAwait(false);
+        // Route through the shared writer so the webhook path gets the same ADR-051 joint
+        // hydration (canonical User + aligned Id/UserId) as the cache-aside path — the old
+        // inline upsert inserted a FederatedIdentity with UserId = Guid.Empty and no User row.
+        FederatedIdentity entry = await writer.SyncAsync(user, cancellationToken).ConfigureAwait(false);
 
         await distributedEventBus.PublishAsync(
             new UserCacheSyncedEto(user.UserId, entry.TenantId, entry.LastSyncedAt), cancellationToken)

--- a/src/Granit.Identity.Federated/Internal/CachedUserLookupService.cs
+++ b/src/Granit.Identity.Federated/Internal/CachedUserLookupService.cs
@@ -1,5 +1,3 @@
-using Granit.Guids;
-using Granit.Identity.Domain;
 using Granit.Identity.Federated.Domain;
 using Granit.Identity.Federated.Options;
 using Granit.MultiTenancy;
@@ -18,8 +16,7 @@ internal sealed partial class CachedUserLookupService(
     IIdentityProvider identityProvider,
     ICurrentTenant currentTenant,
     TimeProvider timeProvider,
-    IGuidGenerator guidGenerator,
-    IUserDirectoryWriter userDirectoryWriter,
+    IFederatedIdentityWriter writer,
     IOptions<UserCacheOptions> options,
     ILogger<CachedUserLookupService> logger) : IUserLookupService
 {
@@ -48,7 +45,7 @@ internal sealed partial class CachedUserLookupService(
 
             if (providerUser is not null)
             {
-                await EnsureCachedAndUserAsync(providerUser, entry, cancellationToken).ConfigureAwait(false);
+                await writer.WriteAsync(providerUser, entry, cancellationToken).ConfigureAwait(false);
                 return providerUser;
             }
 
@@ -115,7 +112,7 @@ internal sealed partial class CachedUserLookupService(
                 if (providerUser is not null)
                 {
                     cachedDict.TryGetValue(id, out FederatedIdentity? existing);
-                    await EnsureCachedAndUserAsync(providerUser, existing, cancellationToken).ConfigureAwait(false);
+                    await writer.WriteAsync(providerUser, existing, cancellationToken).ConfigureAwait(false);
                     result.Add(providerUser);
                 }
                 else if (cachedDict.TryGetValue(id, out FederatedIdentity? staleEntry))
@@ -178,7 +175,7 @@ internal sealed partial class CachedUserLookupService(
             ? await store.FindByExternalIdAsync(userId, currentTenant.Id, cancellationToken).ConfigureAwait(false)
             : await store.FindFirstByExternalIdAsync(userId, cancellationToken).ConfigureAwait(false);
 
-        await EnsureCachedAndUserAsync(providerUser, existing, cancellationToken).ConfigureAwait(false);
+        await writer.WriteAsync(providerUser, existing, cancellationToken).ConfigureAwait(false);
         return providerUser;
     }
 
@@ -211,7 +208,7 @@ internal sealed partial class CachedUserLookupService(
             foreach (IIdentityUser providerUser in page)
             {
                 existingByExternalId.TryGetValue(providerUser.UserId, out FederatedIdentity? existing);
-                await EnsureCachedAndUserAsync(providerUser, existing, cancellationToken).ConfigureAwait(false);
+                await writer.WriteAsync(providerUser, existing, cancellationToken).ConfigureAwait(false);
             }
 
             synced += page.Count;
@@ -252,7 +249,7 @@ internal sealed partial class CachedUserLookupService(
             FederatedIdentity? existing = await store
                 .FindByExternalIdAsync(userId, tenantId, cancellationToken).ConfigureAwait(false);
 
-            await EnsureCachedAndUserAsync(providerUser, existing, cancellationToken).ConfigureAwait(false);
+            await writer.WriteAsync(providerUser, existing, cancellationToken).ConfigureAwait(false);
             refreshed++;
         }
 
@@ -278,99 +275,8 @@ internal sealed partial class CachedUserLookupService(
 
     // -- Helpers --
 
-    /// <summary>
-    /// Joint hydration of <see cref="FederatedIdentity"/> + canonical
-    /// <see cref="User"/> per ADR-051 B-step 3.5. On the insert path the
-    /// canonical user is created first (mirroring the local-side B-step 2.5
-    /// pattern) so admin grids and BI exports see the row immediately.
-    /// On the update path only the federated cache row is touched —
-    /// the canonical user already exists.
-    /// </summary>
-    /// <remarks>
-    /// Compensation: if the <see cref="FederatedIdentity"/> insert fails
-    /// after the <see cref="User"/> row was created, the freshly-created
-    /// user is hard-deleted to keep the canonical directory consistent.
-    /// </remarks>
-    private async Task EnsureCachedAndUserAsync(
-        IIdentityUser providerUser,
-        FederatedIdentity? existing,
-        CancellationToken cancellationToken)
-    {
-        if (existing is not null)
-        {
-            // Update path — preserve the existing identifier pair so the
-            // canonical User row continues to resolve via FederatedIdentity.UserId.
-            FederatedIdentity entry = ToCacheEntry(providerUser);
-            entry.Id = existing.Id;
-            entry.UserId = existing.UserId;
-            await store.UpsertAsync(entry, cancellationToken).ConfigureAwait(false);
-            return;
-        }
-
-        // Insert path — generate one Guid up front, materialise the
-        // canonical User first, then add the federated cache row.
-        FederatedIdentity newEntry = ToCacheEntry(providerUser);
-
-        var canonical = User.Create(
-            id: newEntry.Id,
-            email: providerUser.Email ?? string.Empty,
-            displayName: ResolveDisplayName(providerUser),
-            firstName: providerUser.FirstName,
-            lastName: providerUser.LastName,
-            tenantId: newEntry.TenantId);
-
-        await userDirectoryWriter.CreateAsync(canonical, cancellationToken).ConfigureAwait(false);
-
-        try
-        {
-            await store.UpsertAsync(newEntry, cancellationToken).ConfigureAwait(false);
-        }
-        catch
-        {
-            await userDirectoryWriter.DeleteAsync(newEntry.Id, cancellationToken).ConfigureAwait(false);
-            throw;
-        }
-    }
-
-    private static string ResolveDisplayName(IIdentityUser providerUser)
-    {
-        string composed = $"{providerUser.FirstName} {providerUser.LastName}".Trim();
-        if (!string.IsNullOrWhiteSpace(composed))
-        {
-            return composed;
-        }
-
-        return !string.IsNullOrWhiteSpace(providerUser.Email)
-            ? providerUser.Email
-            : providerUser.Username ?? providerUser.UserId;
-    }
-
     private bool IsFresh(FederatedIdentity entry) =>
         timeProvider.GetUtcNow() - entry.LastSyncedAt < _options.StalenessThreshold;
-
-    private FederatedIdentity ToCacheEntry(IIdentityUser user)
-    {
-        // Per ADR-051 B-step 3, pre-assign the Guid so FederatedIdentity.UserId
-        // can be aligned with .Id at construction time. The store preserves
-        // these identifiers on update — only an INSERT path adopts the
-        // freshly-generated value, so the alignment invariant
-        // (FederatedIdentity.Id == FederatedIdentity.UserId == User.Id)
-        // is enforced from the very first row.
-        Guid id = guidGenerator.Create();
-        return new FederatedIdentity
-        {
-            Id = id,
-            UserId = id,
-            ExternalUserId = user.UserId,
-            Username = user.Username,
-            Email = user.Email,
-            FirstName = user.FirstName,
-            LastName = user.LastName,
-            Enabled = user.Enabled,
-            LastSyncedAt = timeProvider.GetUtcNow(),
-            TenantId = currentTenant.IsAvailable ? currentTenant.Id : null,
-        };
-    }
 
     // -- Source-generated log messages --
 

--- a/src/Granit.Identity.Federated/Internal/FederatedIdentityWriter.cs
+++ b/src/Granit.Identity.Federated/Internal/FederatedIdentityWriter.cs
@@ -1,0 +1,129 @@
+using Granit.Guids;
+using Granit.Identity.Domain;
+using Granit.Identity.Federated.Domain;
+using Granit.MultiTenancy;
+
+namespace Granit.Identity.Federated.Internal;
+
+/// <summary>
+/// The single write path for the federated user cache. Every ingestion route — cache-aside
+/// lookup, provider webhook events, and login-time claim sync — funnels through here so the
+/// ADR-051 joint-hydration invariant (a <c>FederatedIdentity</c> row always has a matching
+/// canonical <c>User</c>, with the aligned identifier triple
+/// <c>FederatedIdentity.Id = FederatedIdentity.UserId = User.Id</c>) is enforced in one place.
+/// </summary>
+internal interface IFederatedIdentityWriter
+{
+    /// <summary>Finds the tenant-scoped cache entry for the provider user, then writes it.</summary>
+    Task<FederatedIdentity> SyncAsync(IIdentityUser providerUser, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Joint hydration of the cache row and its canonical <c>User</c>. Callers that already
+    /// resolved the existing row pass it to avoid a second lookup. Returns the written entry.
+    /// </summary>
+    Task<FederatedIdentity> WriteAsync(
+        IIdentityUser providerUser, FederatedIdentity? existing, CancellationToken cancellationToken = default);
+}
+
+/// <inheritdoc cref="IFederatedIdentityWriter"/>
+/// <remarks>
+/// On the insert path the canonical <see cref="User"/> is created first (mirroring the local-side
+/// pattern) so admin grids and BI exports see the row immediately; if the cache insert then fails,
+/// the freshly-created user is hard-deleted to keep the canonical directory consistent. On the
+/// update path only the cache row is touched — the identifier pair is preserved so the canonical
+/// user keeps resolving via <see cref="FederatedIdentity.UserId"/>.
+/// </remarks>
+internal sealed class FederatedIdentityWriter(
+    IUserCacheStore store,
+    IUserDirectoryWriter userDirectoryWriter,
+    IGuidGenerator guidGenerator,
+    ICurrentTenant currentTenant,
+    TimeProvider timeProvider) : IFederatedIdentityWriter
+{
+    /// <inheritdoc/>
+    public async Task<FederatedIdentity> SyncAsync(
+        IIdentityUser providerUser, CancellationToken cancellationToken = default)
+    {
+        Guid? tenantId = currentTenant.IsAvailable ? currentTenant.Id : null;
+        FederatedIdentity? existing = await store
+            .FindByExternalIdAsync(providerUser.UserId, tenantId, cancellationToken).ConfigureAwait(false);
+        return await WriteAsync(providerUser, existing, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc/>
+    public async Task<FederatedIdentity> WriteAsync(
+        IIdentityUser providerUser, FederatedIdentity? existing, CancellationToken cancellationToken = default)
+    {
+        if (existing is not null)
+        {
+            // Update path — preserve the existing identifier pair so the canonical User row
+            // continues to resolve via FederatedIdentity.UserId.
+            FederatedIdentity entry = ToCacheEntry(providerUser);
+            entry.Id = existing.Id;
+            entry.UserId = existing.UserId;
+            await store.UpsertAsync(entry, cancellationToken).ConfigureAwait(false);
+            return entry;
+        }
+
+        // Insert path — generate one Guid up front, materialise the canonical User first, then
+        // add the federated cache row (with compensation if the cache insert fails).
+        FederatedIdentity newEntry = ToCacheEntry(providerUser);
+
+        var canonical = User.Create(
+            id: newEntry.Id,
+            email: providerUser.Email ?? string.Empty,
+            displayName: ResolveDisplayName(providerUser),
+            firstName: providerUser.FirstName,
+            lastName: providerUser.LastName,
+            tenantId: newEntry.TenantId);
+
+        await userDirectoryWriter.CreateAsync(canonical, cancellationToken).ConfigureAwait(false);
+
+        try
+        {
+            await store.UpsertAsync(newEntry, cancellationToken).ConfigureAwait(false);
+        }
+        catch
+        {
+            await userDirectoryWriter.DeleteAsync(newEntry.Id, cancellationToken).ConfigureAwait(false);
+            throw;
+        }
+
+        return newEntry;
+    }
+
+    private static string ResolveDisplayName(IIdentityUser providerUser)
+    {
+        string composed = $"{providerUser.FirstName} {providerUser.LastName}".Trim();
+        if (!string.IsNullOrWhiteSpace(composed))
+        {
+            return composed;
+        }
+
+        return !string.IsNullOrWhiteSpace(providerUser.Email)
+            ? providerUser.Email
+            : providerUser.Username ?? providerUser.UserId;
+    }
+
+    private FederatedIdentity ToCacheEntry(IIdentityUser user)
+    {
+        // Per ADR-051 B-step 3, pre-assign the Guid so FederatedIdentity.UserId can be aligned
+        // with .Id at construction time. The store preserves these identifiers on update — only an
+        // INSERT path adopts the freshly-generated value, so the alignment invariant
+        // (FederatedIdentity.Id == FederatedIdentity.UserId == User.Id) holds from the first row.
+        Guid id = guidGenerator.Create();
+        return new FederatedIdentity
+        {
+            Id = id,
+            UserId = id,
+            ExternalUserId = user.UserId,
+            Username = user.Username,
+            Email = user.Email,
+            FirstName = user.FirstName,
+            LastName = user.LastName,
+            Enabled = user.Enabled,
+            LastSyncedAt = timeProvider.GetUtcNow(),
+            TenantId = currentTenant.IsAvailable ? currentTenant.Id : null,
+        };
+    }
+}

--- a/tests/Granit.Identity.Federated.Endpoints.Tests/UserCacheSyncMiddlewareTests.cs
+++ b/tests/Granit.Identity.Federated.Endpoints.Tests/UserCacheSyncMiddlewareTests.cs
@@ -12,14 +12,15 @@ using Xunit;
 namespace Granit.Identity.Federated.Endpoints.Tests;
 
 /// <summary>
-/// Behaviour cover for the login-time <see cref="UserCacheSyncMiddleware"/> after its move out of the
-/// federated domain package into this ASP.NET Core integration package (Vague 4a). The middleware upserts
-/// the current authenticated user's cache entry from JWT claims when the entry is missing or stale, and
-/// short-circuits for local stores, unauthenticated requests, disabled sync, and fresh entries.
+/// Behaviour cover for the login-time <see cref="UserCacheSyncMiddleware"/>. When the cache entry is
+/// missing or stale it routes the claim-derived user through the shared <see cref="IFederatedIdentityWriter"/>
+/// (ADR-051 joint hydration), and short-circuits for local stores, unauthenticated requests, disabled sync,
+/// and fresh entries.
 /// </summary>
 public sealed class UserCacheSyncMiddlewareTests
 {
     private readonly IUserCacheStore _store = Substitute.For<IUserCacheStore>();
+    private readonly IFederatedIdentityWriter _writer = Substitute.For<IFederatedIdentityWriter>();
     private readonly ICurrentUserService _currentUser = Substitute.For<ICurrentUserService>();
     private readonly ICurrentTenant _currentTenant = Substitute.For<ICurrentTenant>();
     private readonly IIdentityProviderCapabilities _capabilities = Substitute.For<IIdentityProviderCapabilities>();
@@ -40,6 +41,7 @@ public sealed class UserCacheSyncMiddlewareTests
             _currentUser,
             _currentTenant,
             _store,
+            _writer,
             _time,
             Microsoft.Extensions.Options.Options.Create(options ?? new UserCacheOptions()),
             _capabilities);
@@ -55,7 +57,7 @@ public sealed class UserCacheSyncMiddlewareTests
         await Invoke();
 
         _nextCalled.ShouldBeTrue();
-        await _store.DidNotReceiveWithAnyArgs().UpsertAsync(default!, Ct);
+        await _writer.DidNotReceiveWithAnyArgs().WriteAsync(default!, default, Ct);
     }
 
     [Fact]
@@ -67,11 +69,11 @@ public sealed class UserCacheSyncMiddlewareTests
         await Invoke();
 
         _nextCalled.ShouldBeTrue();
-        await _store.DidNotReceiveWithAnyArgs().UpsertAsync(default!, Ct);
+        await _writer.DidNotReceiveWithAnyArgs().WriteAsync(default!, default, Ct);
     }
 
     [Fact]
-    public async Task Upserts_WhenNoCachedEntry()
+    public async Task WritesThroughWriter_WhenNoCachedEntry()
     {
         _capabilities.IsLocalStore.Returns(false);
         _currentUser.IsAuthenticated.Returns(true);
@@ -82,14 +84,15 @@ public sealed class UserCacheSyncMiddlewareTests
 
         await Invoke();
 
-        await _store.Received(1).UpsertAsync(
-            Arg.Is<FederatedIdentity>(e => e.ExternalUserId == "user-1" && e.Email == "jane@test.com"),
+        await _writer.Received(1).WriteAsync(
+            Arg.Is<IIdentityUser>(u => u.UserId == "user-1" && u.Email == "jane@test.com"),
+            null,
             Arg.Any<CancellationToken>());
         _nextCalled.ShouldBeTrue();
     }
 
     [Fact]
-    public async Task SkipsUpsert_WhenCachedEntryIsFresh()
+    public async Task SkipsWrite_WhenCachedEntryIsFresh()
     {
         _capabilities.IsLocalStore.Returns(false);
         _currentUser.IsAuthenticated.Returns(true);
@@ -99,25 +102,28 @@ public sealed class UserCacheSyncMiddlewareTests
 
         await Invoke(new UserCacheOptions { StalenessThreshold = TimeSpan.FromHours(24) });
 
-        await _store.DidNotReceiveWithAnyArgs().UpsertAsync(default!, Ct);
+        await _writer.DidNotReceiveWithAnyArgs().WriteAsync(default!, default, Ct);
         _nextCalled.ShouldBeTrue();
     }
 
     [Fact]
-    public async Task Upserts_WhenCachedEntryIsStale()
+    public async Task WritesThroughWriter_WhenCachedEntryIsStale()
     {
         _capabilities.IsLocalStore.Returns(false);
         _currentUser.IsAuthenticated.Returns(true);
         _currentUser.UserId.Returns("user-1");
+        FederatedIdentity stale = new()
+        {
+            ExternalUserId = "user-1",
+            LastSyncedAt = _time.GetUtcNow() - TimeSpan.FromDays(2),
+        };
         _store.FindByExternalIdAsync("user-1", Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
-            .Returns(new FederatedIdentity
-            {
-                ExternalUserId = "user-1",
-                LastSyncedAt = _time.GetUtcNow() - TimeSpan.FromDays(2),
-            });
+            .Returns(stale);
 
         await Invoke(new UserCacheOptions { StalenessThreshold = TimeSpan.FromHours(24) });
 
-        await _store.Received(1).UpsertAsync(Arg.Any<FederatedIdentity>(), Arg.Any<CancellationToken>());
+        // Passes the stale row so the writer takes the update path (preserving the id pair).
+        await _writer.Received(1).WriteAsync(
+            Arg.Is<IIdentityUser>(u => u.UserId == "user-1"), stale, Arg.Any<CancellationToken>());
     }
 }

--- a/tests/Granit.Identity.Federated.Tests/Handlers/IdentityUserEventHandlerTests.cs
+++ b/tests/Granit.Identity.Federated.Tests/Handlers/IdentityUserEventHandlerTests.cs
@@ -16,6 +16,7 @@ public sealed class IdentityUserEventHandlerTests
     private readonly IIdentityProvider _provider = Substitute.For<IIdentityProvider>();
     private readonly IIdentityProviderCapabilities _capabilities = Substitute.For<IIdentityProviderCapabilities>();
     private readonly IUserCacheStore _store = Substitute.For<IUserCacheStore>();
+    private readonly IFederatedIdentityWriter _writer = Substitute.For<IFederatedIdentityWriter>();
     private readonly ICurrentTenant _currentTenant = Substitute.For<ICurrentTenant>();
     private readonly ILocalEventBus _localEventBus = Substitute.For<ILocalEventBus>();
     private readonly IDistributedEventBus _distributedEventBus = Substitute.For<IDistributedEventBus>();
@@ -23,7 +24,7 @@ public sealed class IdentityUserEventHandlerTests
     private readonly TimeProvider _timeProvider = Substitute.For<TimeProvider>();
 
     private IdentityUserEventHandler CreateHandler() => new(
-        _provider, _capabilities, _store, _currentTenant, _localEventBus, _distributedEventBus,
+        _provider, _capabilities, _store, _writer, _currentTenant, _localEventBus, _distributedEventBus,
         _rateLimiter, _timeProvider, NullLogger<IdentityUserEventHandler>.Instance);
 
     public IdentityUserEventHandlerTests()
@@ -31,10 +32,12 @@ public sealed class IdentityUserEventHandlerTests
         _timeProvider.GetUtcNow().Returns(DateTimeOffset.UtcNow);
         _capabilities.ProviderName.Returns("Keycloak");
         _rateLimiter.TryAcquire(Arg.Any<string>(), Arg.Any<string>()).Returns(true);
+        _writer.SyncAsync(Arg.Any<IIdentityUser>(), Arg.Any<CancellationToken>())
+            .Returns(ci => new FederatedIdentity { ExternalUserId = ci.Arg<IIdentityUser>().UserId });
     }
 
     [Fact]
-    public async Task HandleUpdated_FetchesAndUpsertsCache()
+    public async Task HandleUpdated_FetchesAndSyncsThroughWriter()
     {
         var user = new FederatedIdentityUser("user-1", "jdoe", "jdoe@test.com", "John", "Doe", true);
         _provider.GetUserAsync("user-1", Arg.Any<CancellationToken>())
@@ -44,13 +47,16 @@ public sealed class IdentityUserEventHandlerTests
         await handler.HandleAsync(
             new IdentityUserUpdatedEto("user-1"), TestContext.Current.CancellationToken);
 
-        await _store.Received(1).UpsertAsync(
-            Arg.Is<FederatedIdentity>(e => e.ExternalUserId == "user-1" && e.Username == "jdoe"),
+        // The webhook path funnels through the shared writer (ADR-051 joint hydration), never a
+        // direct store.UpsertAsync that would insert a FederatedIdentity with UserId = Guid.Empty.
+        await _writer.Received(1).SyncAsync(
+            Arg.Is<IIdentityUser>(u => u.UserId == "user-1" && u.Username == "jdoe"),
             Arg.Any<CancellationToken>());
+        await _store.DidNotReceiveWithAnyArgs().UpsertAsync(default!, TestContext.Current.CancellationToken);
     }
 
     [Fact]
-    public async Task HandleUpdated_DoesNotUpsert_WhenProviderReturnsNull()
+    public async Task HandleUpdated_DoesNotSync_WhenProviderReturnsNull()
     {
         _provider.GetUserAsync("user-1", Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<IIdentityUser?>(null));
@@ -59,6 +65,7 @@ public sealed class IdentityUserEventHandlerTests
         await handler.HandleAsync(
             new IdentityUserUpdatedEto("user-1"), TestContext.Current.CancellationToken);
 
+        await _writer.DidNotReceiveWithAnyArgs().SyncAsync(default!, TestContext.Current.CancellationToken);
         await _store.DidNotReceive().UpsertAsync(
             Arg.Any<FederatedIdentity>(), Arg.Any<CancellationToken>());
     }

--- a/tests/Granit.Identity.Federated.Tests/Internal/CachedUserLookupServiceTests.cs
+++ b/tests/Granit.Identity.Federated.Tests/Internal/CachedUserLookupServiceTests.cs
@@ -1,5 +1,3 @@
-using Granit.Guids;
-using Granit.Identity.Domain;
 using Granit.Identity.Federated.Domain;
 using Granit.Identity.Federated.Internal;
 using Granit.Identity.Federated.Options;
@@ -20,15 +18,14 @@ public sealed class CachedUserLookupServiceTests
     private readonly IIdentityProvider _provider = Substitute.For<IIdentityProvider>();
     private readonly ICurrentTenant _tenant = Substitute.For<ICurrentTenant>();
     private readonly TimeProvider _timeProvider = Substitute.For<TimeProvider>();
-    private readonly IGuidGenerator _guidGenerator = Substitute.For<IGuidGenerator>();
-    private readonly IUserDirectoryWriter _userDirectoryWriter = Substitute.For<IUserDirectoryWriter>();
+    private readonly IFederatedIdentityWriter _writer = Substitute.For<IFederatedIdentityWriter>();
     private readonly IOptions<UserCacheOptions> _options = Microsoft.Extensions.Options.Options.Create(new UserCacheOptions
     {
         StalenessThreshold = TimeSpan.FromHours(24)
     });
 
     private CachedUserLookupService CreateService() => new(
-        _store, _provider, _tenant, _timeProvider, _guidGenerator, _userDirectoryWriter, _options,
+        _store, _provider, _tenant, _timeProvider, _writer, _options,
         NullLogger<CachedUserLookupService>.Instance);
 
     private static FederatedIdentityUser CreateUser(string id = "user-1") => new(
@@ -54,6 +51,8 @@ public sealed class CachedUserLookupServiceTests
         _tenant.IsAvailable.Returns(true);
         _tenant.Id.Returns(Guid.NewGuid());
         _timeProvider.GetUtcNow().Returns(DateTimeOffset.UtcNow);
+        _writer.WriteAsync(Arg.Any<IIdentityUser>(), Arg.Any<FederatedIdentity?>(), Arg.Any<CancellationToken>())
+            .Returns(ci => new FederatedIdentity { ExternalUserId = ci.Arg<IIdentityUser>().UserId });
     }
 
     [Fact]
@@ -69,10 +68,11 @@ public sealed class CachedUserLookupServiceTests
         result.ShouldNotBeNull();
         result.Username.ShouldBe("jdoe");
         await _provider.DidNotReceive().GetUserAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await _writer.DidNotReceiveWithAnyArgs().WriteAsync(default!, default, TestContext.Current.CancellationToken);
     }
 
     [Fact]
-    public async Task FindByIdAsync_FetchesFromProvider_WhenStale()
+    public async Task FindByIdAsync_FetchesFromProvider_AndWrites_WhenStale()
     {
         FederatedIdentity staleEntry = CreateCacheEntry(lastSyncedAt: DateTimeOffset.UtcNow.AddDays(-2));
         _store.FindByExternalIdAsync("user-1", Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
@@ -85,7 +85,9 @@ public sealed class CachedUserLookupServiceTests
 
         result.ShouldNotBeNull();
         await _provider.Received(1).GetUserAsync("user-1", Arg.Any<CancellationToken>());
-        await _store.Received(1).UpsertAsync(Arg.Any<FederatedIdentity>(), Arg.Any<CancellationToken>());
+        // Delegates the write (joint hydration) to the shared writer, passing the existing row.
+        await _writer.Received(1).WriteAsync(
+            Arg.Is<IIdentityUser>(u => u.UserId == "user-1"), staleEntry, Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -144,7 +146,7 @@ public sealed class CachedUserLookupServiceTests
     }
 
     [Fact]
-    public async Task RefreshByIdAsync_ForcesProviderFetch()
+    public async Task RefreshByIdAsync_ForcesProviderFetch_AndWrites()
     {
         _provider.GetUserAsync("user-1", Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<IIdentityUser?>(CreateUser()));
@@ -153,7 +155,8 @@ public sealed class CachedUserLookupServiceTests
         IIdentityUser? result = await service.RefreshByIdAsync("user-1", TestContext.Current.CancellationToken);
 
         result.ShouldNotBeNull();
-        await _store.Received(1).UpsertAsync(Arg.Any<FederatedIdentity>(), Arg.Any<CancellationToken>());
+        await _writer.Received(1).WriteAsync(
+            Arg.Is<IIdentityUser>(u => u.UserId == "user-1"), Arg.Any<FederatedIdentity?>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -166,11 +169,11 @@ public sealed class CachedUserLookupServiceTests
         IIdentityUser? result = await service.RefreshByIdAsync("user-1", TestContext.Current.CancellationToken);
 
         result.ShouldBeNull();
-        await _store.DidNotReceive().UpsertAsync(Arg.Any<FederatedIdentity>(), Arg.Any<CancellationToken>());
+        await _writer.DidNotReceiveWithAnyArgs().WriteAsync(default!, default, TestContext.Current.CancellationToken);
     }
 
     [Fact]
-    public async Task RefreshAllAsync_PaginatesThroughProvider()
+    public async Task RefreshAllAsync_PaginatesThroughProvider_WritingEachRow()
     {
         IReadOnlyList<IIdentityUser> page1 = Enumerable.Range(0, 100).Select(i => (IIdentityUser)CreateUser($"user-{i}")).ToList();
         IReadOnlyList<IIdentityUser> page2 = Enumerable.Range(100, 50).Select(i => (IIdentityUser)CreateUser($"user-{i}")).ToList();
@@ -180,15 +183,14 @@ public sealed class CachedUserLookupServiceTests
         _provider.GetUsersAsync(null, 100, 100, Arg.Any<CancellationToken>())
             .Returns(page2);
 
-        // Joint hydration drives one UpsertAsync per provider row instead
-        // of a single UpsertManyAsync: per ADR-051 B-step 3.5 each new
-        // row materialises a canonical User first, so the batch path
-        // unfolds into per-row sequencing.
+        // Joint hydration drives one writer call per provider row (per ADR-051 each new row
+        // materialises a canonical User first), so the batch path unfolds into per-row sequencing.
         CachedUserLookupService service = CreateService();
         int synced = await service.RefreshAllAsync(TestContext.Current.CancellationToken);
 
         synced.ShouldBe(150);
-        await _store.Received(150).UpsertAsync(Arg.Any<FederatedIdentity>(), Arg.Any<CancellationToken>());
+        await _writer.Received(150).WriteAsync(
+            Arg.Any<IIdentityUser>(), Arg.Any<FederatedIdentity?>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -221,137 +223,5 @@ public sealed class CachedUserLookupServiceTests
 
         result.Items.Count.ShouldBe(1);
         result.TotalCount.ShouldBe(1);
-    }
-
-    // ──── Joint User + FederatedIdentity hydration (ADR-051 B-step 3.5) ────
-
-    [Fact]
-    public async Task FindByIdAsync_OnCacheMiss_CreatesCanonicalUser_BeforeFederatedIdentity()
-    {
-        // No existing cache row. Provider returns the user. The joint
-        // hydration helper must create the canonical User row first
-        // (mirroring B-step 2.5) so admin grids see it immediately.
-        var generatedId = Guid.NewGuid();
-        _guidGenerator.Create().Returns(generatedId);
-
-        _store.FindByExternalIdAsync("user-1", Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
-            .Returns((FederatedIdentity?)null);
-        _provider.GetUserAsync("user-1", Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult<IIdentityUser?>(CreateUser()));
-
-        CachedUserLookupService service = CreateService();
-        await service.FindByIdAsync("user-1", TestContext.Current.CancellationToken);
-
-        await _userDirectoryWriter.Received(1).CreateAsync(
-            Arg.Is<User>(u =>
-                u.Id == generatedId
-                && u.Email == "jdoe@test.com"
-                && u.DisplayName == "John Doe"),
-            Arg.Any<CancellationToken>());
-        await _store.Received(1).UpsertAsync(
-            Arg.Is<FederatedIdentity>(e => e.Id == generatedId && e.UserId == generatedId),
-            Arg.Any<CancellationToken>());
-    }
-
-    [Fact]
-    public async Task FindByIdAsync_OnExistingStaleEntry_DoesNotCreateUser_OnRefresh()
-    {
-        // Existing entry exists (with its own Id/UserId already aligned).
-        // The provider returns a fresh copy. The update path must
-        // preserve the existing identifier pair and SKIP the User create.
-        var existingId = Guid.NewGuid();
-        FederatedIdentity stale = CreateCacheEntry(lastSyncedAt: DateTimeOffset.UtcNow.AddDays(-2));
-        stale.Id = existingId;
-        stale.UserId = existingId;
-
-        _store.FindByExternalIdAsync("user-1", Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
-            .Returns(stale);
-        _provider.GetUserAsync("user-1", Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult<IIdentityUser?>(CreateUser()));
-
-        CachedUserLookupService service = CreateService();
-        await service.FindByIdAsync("user-1", TestContext.Current.CancellationToken);
-
-        await _userDirectoryWriter.DidNotReceive().CreateAsync(Arg.Any<User>(), Arg.Any<CancellationToken>());
-        await _store.Received(1).UpsertAsync(
-            Arg.Is<FederatedIdentity>(e => e.Id == existingId && e.UserId == existingId),
-            Arg.Any<CancellationToken>());
-    }
-
-    [Fact]
-    public async Task FindByIdAsync_CompensatesUserDelete_WhenFederatedInsertFails()
-    {
-        // The User row is created first; if the FederatedIdentity insert
-        // throws, the canonical row would orphan — the helper must
-        // hard-delete it to keep the directory consistent.
-        var generatedId = Guid.NewGuid();
-        _guidGenerator.Create().Returns(generatedId);
-
-        _store.FindByExternalIdAsync("user-1", Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
-            .Returns((FederatedIdentity?)null);
-        _provider.GetUserAsync("user-1", Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult<IIdentityUser?>(CreateUser()));
-        _store.UpsertAsync(Arg.Any<FederatedIdentity>(), Arg.Any<CancellationToken>())
-            .Throws(new InvalidOperationException("store offline"));
-
-        CachedUserLookupService service = CreateService();
-
-        // FindByIdAsync wraps the cache-miss block in a try/catch that
-        // swallows non-cancellation exceptions and returns the stale
-        // entry — so the throw is absorbed by the caller, not surfaced.
-        // We just verify the compensation ran.
-        await service.FindByIdAsync("user-1", TestContext.Current.CancellationToken);
-
-        await _userDirectoryWriter.Received(1).CreateAsync(
-            Arg.Is<User>(u => u.Id == generatedId), Arg.Any<CancellationToken>());
-        await _userDirectoryWriter.Received(1).DeleteAsync(generatedId, Arg.Any<CancellationToken>());
-    }
-
-    [Fact]
-    public async Task FindByIdAsync_FallsBackToEmail_AsDisplayName_WhenNamesAreMissing()
-    {
-        var generatedId = Guid.NewGuid();
-        _guidGenerator.Create().Returns(generatedId);
-
-        FederatedIdentityUser nameless = new(
-            UserId: "user-2", Username: "anon", Email: "anon@test.com",
-            FirstName: null, LastName: null, Enabled: true);
-
-        _store.FindByExternalIdAsync("user-2", Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
-            .Returns((FederatedIdentity?)null);
-        _provider.GetUserAsync("user-2", Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult<IIdentityUser?>(nameless));
-
-        CachedUserLookupService service = CreateService();
-        await service.FindByIdAsync("user-2", TestContext.Current.CancellationToken);
-
-        await _userDirectoryWriter.Received(1).CreateAsync(
-            Arg.Is<User>(u => u.DisplayName == "anon@test.com"),
-            Arg.Any<CancellationToken>());
-    }
-
-    [Fact]
-    public async Task RefreshByIdAsync_FetchesExistingFirst_BeforeJointHydration()
-    {
-        // RefreshByIdAsync didn't previously do an existence check — the
-        // joint hydration adds one so updates correctly preserve the
-        // existing Id/UserId pair instead of generating fresh ones.
-        var existingId = Guid.NewGuid();
-        FederatedIdentity existing = CreateCacheEntry();
-        existing.Id = existingId;
-        existing.UserId = existingId;
-
-        _store.FindByExternalIdAsync("user-1", Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
-            .Returns(existing);
-        _provider.GetUserAsync("user-1", Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult<IIdentityUser?>(CreateUser()));
-
-        CachedUserLookupService service = CreateService();
-        await service.RefreshByIdAsync("user-1", TestContext.Current.CancellationToken);
-
-        await _userDirectoryWriter.DidNotReceive().CreateAsync(Arg.Any<User>(), Arg.Any<CancellationToken>());
-        await _store.Received(1).UpsertAsync(
-            Arg.Is<FederatedIdentity>(e => e.Id == existingId && e.UserId == existingId),
-            Arg.Any<CancellationToken>());
     }
 }

--- a/tests/Granit.Identity.Federated.Tests/Internal/FederatedIdentityWriterTests.cs
+++ b/tests/Granit.Identity.Federated.Tests/Internal/FederatedIdentityWriterTests.cs
@@ -1,0 +1,144 @@
+using Granit.Guids;
+using Granit.Identity.Domain;
+using Granit.Identity.Federated.Domain;
+using Granit.Identity.Federated.Internal;
+using Granit.MultiTenancy;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Identity.Federated.Tests.Internal;
+
+/// <summary>
+/// The single joint-hydration write path (ADR-051 B-step 3.5): every ingestion route funnels
+/// through <see cref="FederatedIdentityWriter"/> so a <see cref="FederatedIdentity"/> row always
+/// has a matching canonical <see cref="User"/> with the aligned identifier triple
+/// <c>FederatedIdentity.Id == FederatedIdentity.UserId == User.Id</c>. These tests moved here from
+/// <c>CachedUserLookupServiceTests</c> when the logic was extracted into the shared writer.
+/// </summary>
+public sealed class FederatedIdentityWriterTests
+{
+    private readonly IUserCacheStore _store = Substitute.For<IUserCacheStore>();
+    private readonly IUserDirectoryWriter _userDirectoryWriter = Substitute.For<IUserDirectoryWriter>();
+    private readonly IGuidGenerator _guidGenerator = Substitute.For<IGuidGenerator>();
+    private readonly ICurrentTenant _tenant = Substitute.For<ICurrentTenant>();
+    private readonly TimeProvider _timeProvider = Substitute.For<TimeProvider>();
+
+    private FederatedIdentityWriter CreateWriter() =>
+        new(_store, _userDirectoryWriter, _guidGenerator, _tenant, _timeProvider);
+
+    private static FederatedIdentityUser CreateUser(string id = "user-1") => new(
+        UserId: id, Username: "jdoe", Email: "jdoe@test.com",
+        FirstName: "John", LastName: "Doe", Enabled: true);
+
+    public FederatedIdentityWriterTests()
+    {
+        _tenant.IsAvailable.Returns(true);
+        _tenant.Id.Returns(Guid.NewGuid());
+        _timeProvider.GetUtcNow().Returns(DateTimeOffset.UtcNow);
+    }
+
+    [Fact]
+    public async Task WriteAsync_OnInsert_CreatesCanonicalUser_BeforeFederatedIdentity_WithAlignedIds()
+    {
+        var generatedId = Guid.NewGuid();
+        _guidGenerator.Create().Returns(generatedId);
+
+        FederatedIdentityWriter writer = CreateWriter();
+        await writer.WriteAsync(CreateUser(), existing: null, TestContext.Current.CancellationToken);
+
+        await _userDirectoryWriter.Received(1).CreateAsync(
+            Arg.Is<User>(u =>
+                u.Id == generatedId
+                && u.Email == "jdoe@test.com"
+                && u.DisplayName == "John Doe"),
+            Arg.Any<CancellationToken>());
+        await _store.Received(1).UpsertAsync(
+            Arg.Is<FederatedIdentity>(e => e.Id == generatedId && e.UserId == generatedId),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task WriteAsync_OnUpdate_PreservesExistingIdPair_AndSkipsUserCreate()
+    {
+        var existingId = Guid.NewGuid();
+        FederatedIdentity existing = new()
+        {
+            Id = existingId,
+            UserId = existingId,
+            ExternalUserId = "user-1",
+            LastSyncedAt = DateTimeOffset.UtcNow.AddDays(-2),
+        };
+
+        FederatedIdentityWriter writer = CreateWriter();
+        await writer.WriteAsync(CreateUser(), existing, TestContext.Current.CancellationToken);
+
+        await _userDirectoryWriter.DidNotReceive().CreateAsync(Arg.Any<User>(), Arg.Any<CancellationToken>());
+        await _store.Received(1).UpsertAsync(
+            Arg.Is<FederatedIdentity>(e => e.Id == existingId && e.UserId == existingId),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task WriteAsync_CompensatesUserDelete_WhenFederatedInsertFails()
+    {
+        var generatedId = Guid.NewGuid();
+        _guidGenerator.Create().Returns(generatedId);
+        _store.UpsertAsync(Arg.Any<FederatedIdentity>(), Arg.Any<CancellationToken>())
+            .Throws(new InvalidOperationException("store offline"));
+
+        FederatedIdentityWriter writer = CreateWriter();
+
+        // The canonical User is created first; if the cache insert throws, the freshly-created
+        // user must be hard-deleted so the directory does not orphan it. The exception surfaces.
+        await Should.ThrowAsync<InvalidOperationException>(() =>
+            writer.WriteAsync(CreateUser(), existing: null, TestContext.Current.CancellationToken));
+
+        await _userDirectoryWriter.Received(1).CreateAsync(
+            Arg.Is<User>(u => u.Id == generatedId), Arg.Any<CancellationToken>());
+        await _userDirectoryWriter.Received(1).DeleteAsync(generatedId, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task WriteAsync_FallsBackToEmail_AsDisplayName_WhenNamesAreMissing()
+    {
+        var generatedId = Guid.NewGuid();
+        _guidGenerator.Create().Returns(generatedId);
+
+        FederatedIdentityUser nameless = new(
+            UserId: "user-2", Username: "anon", Email: "anon@test.com",
+            FirstName: null, LastName: null, Enabled: true);
+
+        FederatedIdentityWriter writer = CreateWriter();
+        await writer.WriteAsync(nameless, existing: null, TestContext.Current.CancellationToken);
+
+        await _userDirectoryWriter.Received(1).CreateAsync(
+            Arg.Is<User>(u => u.DisplayName == "anon@test.com"),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task SyncAsync_FindsExistingTenantScopedRow_ThenWrites()
+    {
+        var existingId = Guid.NewGuid();
+        FederatedIdentity existing = new()
+        {
+            Id = existingId,
+            UserId = existingId,
+            ExternalUserId = "user-1",
+            LastSyncedAt = DateTimeOffset.UtcNow.AddDays(-2),
+        };
+        _store.FindByExternalIdAsync("user-1", Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+            .Returns(existing);
+
+        FederatedIdentityWriter writer = CreateWriter();
+        await writer.SyncAsync(CreateUser(), TestContext.Current.CancellationToken);
+
+        // Existing row found → update path preserves the id pair, no canonical User created.
+        await _userDirectoryWriter.DidNotReceive().CreateAsync(Arg.Any<User>(), Arg.Any<CancellationToken>());
+        await _store.Received(1).UpsertAsync(
+            Arg.Is<FederatedIdentity>(e => e.Id == existingId && e.UserId == existingId),
+            Arg.Any<CancellationToken>());
+    }
+}


### PR DESCRIPTION
## Context

Vague 4b of the **Granit.Identity\* overhaul** ([EPIC #3057](https://github.com/granit-fx/granit-dotnet/issues/3057), [FEATURE #3062](https://github.com/granit-fx/granit-dotnet/issues/3062)) — the behavioural half of G5, following the package restructuring in [#3078](https://github.com/granit-fx/granit-dotnet/pull/3078).

The federated user cache had three ingestion routes, but **only the cache-aside path performed ADR-051 joint hydration**. The webhook handler and the login middleware each inserted a `FederatedIdentity` with `UserId = Guid.Empty` and **no canonical `User` row** — violating the invariant the entity documents (`Id == UserId == User.Id`) and leaving the canonical directory missing rows the admin grids and BI exports expect (audit ARCHITECTURE finding).

## What changed

- **Extract the joint-hydration logic** — create the canonical `User` first on insert, preserve the id pair on update, compensate by hard-deleting the `User` if the cache insert fails — out of `CachedUserLookupService` into a single internal `IFederatedIdentityWriter` / `FederatedIdentityWriter`.
- **Route all three paths through it**:
  - `CachedUserLookupService` delegates its five write sites to `writer.WriteAsync` (passing the row it already resolved for its freshness check).
  - `IdentityUserEventHandler` (webhook) and `UserCacheSyncMiddleware` (login claims — building a `FederatedIdentityUser` from the claims) call the writer instead of a bare `store.UpsertAsync`.
- Register the writer scoped alongside the cache-aside service.

## Testing

- The joint-hydration unit tests **move** from `CachedUserLookupServiceTests` to a new `FederatedIdentityWriterTests` (insert creates User + aligned ids, update preserves the pair, compensation on failure, display-name fallback, `SyncAsync` find-then-write). The service, handler, and middleware tests now assert **delegation to the writer** (proving the webhook/middleware paths no longer bypass joint hydration).
- **Architecture suite green (262/262)**.
- `Granit.Identity.Federated.Tests` 58/58, `.EntityFrameworkCore.Tests` 26/26, `.Endpoints.Tests` 5/5. `dotnet format` clean. **No lock changes.**

## Deferred to Vague 4c

Kept out to keep this PR focused on the ADR-051 invariant fix:
- **DB-native upsert-retry** for the find-then-add race — must be done in the store seam so it doesn't silently orphan the writer's just-created canonical `User` row (the current throw-and-compensate is safe; a naive retry would break compensation).
- **`EfCoreUserCacheStats` relocation** to the base module (it has no EF usage — audit misnomer).
- **`IdentityFederatedDbContext` `ICurrentTenant?` ctor rider** (persistence-convention nicety).

## Breaking

- Internal wiring only (the writer and the three consumers are all internal). No public API change beyond what #3078 already shipped. Pre-1.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)