### PR TITLE
feat(imaging)!: async stream loading and pipeline hardening

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -33635,7 +33635,7 @@
       "kind": "class",
       "project": "Granit.Imaging.AI",
       "file": "src/Granit.Imaging.AI/Extensions/ImagingAIHostApplicationBuilderExtensions.cs",
-      "line": 16,
+      "line": 17,
       "members": [
         {
           "name": "AddGranitImagingAI",
@@ -33824,7 +33824,7 @@
       "kind": "interface",
       "project": "Granit.Imaging",
       "file": "src/Granit.Imaging/IImagePipeline.cs",
-      "line": 23,
+      "line": 24,
       "members": [
         {
           "name": "Resize",
@@ -33888,13 +33888,13 @@
       "kind": "interface",
       "project": "Granit.Imaging",
       "file": "src/Granit.Imaging/IImageProcessor.cs",
-      "line": 20,
+      "line": 23,
       "members": [
         {
-          "name": "Load",
+          "name": "LoadAsync",
           "kind": "method",
-          "signature": "Load(Stream source)",
-          "returnType": "IImagePipeline"
+          "signature": "LoadAsync(Stream source, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IImagePipeline>"
         },
         {
           "name": "Load",

--- a/src/Granit.Imaging.AI/Extensions/ImagingAIHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Imaging.AI/Extensions/ImagingAIHostApplicationBuilderExtensions.cs
@@ -6,6 +6,7 @@ using Granit.Imaging.AI.Options;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
 
 namespace Granit.Imaging.AI.Extensions;
 
@@ -31,7 +32,11 @@ public static class ImagingAIHostApplicationBuilderExtensions
 
         builder.Services
             .AddOptions<ImagingAIOptions>()
-            .BindConfiguration(ImagingAIOptions.SectionName);
+            .BindConfiguration(ImagingAIOptions.SectionName)
+            .ValidateOnStart();
+
+        builder.Services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<IValidateOptions<ImagingAIOptions>, ImagingAIOptionsValidator>());
 
         builder.Services.TryAddSingleton<ImagingAIMetrics>();
         // Scoped because LlmImageAnalyzer depends on IAIChatClientFactory (scoped).

--- a/src/Granit.Imaging.AI/Options/ImagingAIOptionsValidator.cs
+++ b/src/Granit.Imaging.AI/Options/ImagingAIOptionsValidator.cs
@@ -1,0 +1,23 @@
+using Microsoft.Extensions.Options;
+
+namespace Granit.Imaging.AI.Options;
+
+/// <summary>
+/// Validates <see cref="ImagingAIOptions"/> at startup (fail-fast on an unusable timeout).
+/// </summary>
+internal sealed class ImagingAIOptionsValidator : IValidateOptions<ImagingAIOptions>
+{
+    private const int MaxTimeoutSeconds = 300;
+
+    /// <inheritdoc/>
+    public ValidateOptionsResult Validate(string? name, ImagingAIOptions options)
+    {
+        if (options.TimeoutSeconds is < 1 or > MaxTimeoutSeconds)
+        {
+            return ValidateOptionsResult.Fail(
+                $"{nameof(options.TimeoutSeconds)} must be between 1 and {MaxTimeoutSeconds} seconds.");
+        }
+
+        return ValidateOptionsResult.Success;
+    }
+}

--- a/src/Granit.Imaging.MagickNet/Internal/MagickNetImagePipeline.cs
+++ b/src/Granit.Imaging.MagickNet/Internal/MagickNetImagePipeline.cs
@@ -114,6 +114,8 @@ internal sealed class MagickNetImagePipeline : IImagePipeline
         WatermarkPosition position = WatermarkPosition.BottomRight,
         float opacity = 0.5f)
     {
+        ValidateOpacity(opacity);
+
         using MagickImage overlay = new(watermark.Span);
         ApplyWatermark(overlay, position, opacity);
         return this;
@@ -125,9 +127,17 @@ internal sealed class MagickNetImagePipeline : IImagePipeline
         WatermarkPosition position = WatermarkPosition.BottomRight,
         float opacity = 0.5f)
     {
+        ValidateOpacity(opacity);
+
         using MagickImage overlay = new(watermark);
         ApplyWatermark(overlay, position, opacity);
         return this;
+    }
+
+    private static void ValidateOpacity(float opacity)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(opacity);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(opacity, 1f);
     }
 
     /// <inheritdoc/>
@@ -138,25 +148,25 @@ internal sealed class MagickNetImagePipeline : IImagePipeline
     }
 
     /// <inheritdoc/>
-    public async Task<ImageResult> ToResultAsync(CancellationToken cancellationToken = default)
+    public Task<ImageResult> ToResultAsync(CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
 
         ApplyOutputSettings();
 
         ImageFormat outputFormat = _targetFormat ?? SourceFormat;
-        await using MemoryStream ms = new();
-        await _image.WriteAsync(ms, MagickFormatMapper.ToMagickFormat(outputFormat), cancellationToken).ConfigureAwait(false);
+
+        // ToByteArray encodes straight from the native blob into a single managed array —
+        // no intermediate MemoryStream + ToArray() double copy. Encoding is CPU-bound.
+        byte[] content = _image.ToByteArray(MagickFormatMapper.ToMagickFormat(outputFormat));
 
         RecordMetrics(outputFormat);
 
-        ImageResult result = new(
-            ms.ToArray(),
+        return Task.FromResult(new ImageResult(
+            content,
             outputFormat,
             (int)_image.Width,
-            (int)_image.Height);
-
-        return result;
+            (int)_image.Height));
     }
 
     /// <inheritdoc/>

--- a/src/Granit.Imaging.MagickNet/Internal/MagickNetImageProcessor.cs
+++ b/src/Granit.Imaging.MagickNet/Internal/MagickNetImageProcessor.cs
@@ -15,25 +15,31 @@ internal sealed class MagickNetImageProcessor(
     IOptions<ImagingMagickNetOptions> options) : IImageProcessor
 {
     /// <inheritdoc/>
-    public IImagePipeline Load(Stream source)
+    public async Task<IImagePipeline> LoadAsync(Stream source, CancellationToken cancellationToken = default)
     {
+        ArgumentNullException.ThrowIfNull(source);
+
         if (!source.CanSeek)
         {
-            using MemoryStream buffer = new();
-            source.CopyTo(buffer);
-            buffer.Position = 0;
+            MemoryStream buffer = new();
+            await using (buffer.ConfigureAwait(false))
+            {
+                await source.CopyToAsync(buffer, cancellationToken).ConfigureAwait(false);
+                buffer.Position = 0;
 
-            ValidateInputSize(buffer.Length);
-            ValidateFormat(buffer);
+                ValidateInputSize(buffer.Length);
+                ValidateFormat(buffer);
 
-            MagickImage bufferedImage = new(buffer);
-            return new MagickNetImagePipeline(bufferedImage, metrics);
+                MagickImage bufferedImage = new(buffer);
+                return new MagickNetImagePipeline(bufferedImage, metrics);
+            }
         }
 
         ValidateInputSize(source.Length);
-        ValidateFormat(source);
+        await ValidateFormatAsync(source, cancellationToken).ConfigureAwait(false);
 
-        MagickImage image = new(source);
+        MagickImage image = new();
+        await image.ReadAsync(source, cancellationToken).ConfigureAwait(false);
         return new MagickNetImagePipeline(image, metrics);
     }
 
@@ -87,12 +93,29 @@ internal sealed class MagickNetImageProcessor(
 
     private static void ValidateFormat(Stream source)
     {
+        // ReadAtLeast: a single Read may legally return fewer bytes than requested even
+        // mid-stream, which would reject a valid image on a short first chunk.
         Span<byte> header = stackalloc byte[ImageFormatDetector.RequiredHeaderLength];
         long position = source.Position;
-        int bytesRead = source.Read(header);
+        int bytesRead = source.ReadAtLeast(header, ImageFormatDetector.RequiredHeaderLength, throwOnEndOfStream: false);
         source.Position = position;
 
         if (!ImageFormatDetector.IsSafeRasterFormat(header[..bytesRead]))
+        {
+            throw new UnsupportedImageFormatException("unknown");
+        }
+    }
+
+    private static async Task ValidateFormatAsync(Stream source, CancellationToken cancellationToken)
+    {
+        byte[] header = new byte[ImageFormatDetector.RequiredHeaderLength];
+        long position = source.Position;
+        int bytesRead = await source
+            .ReadAtLeastAsync(header, ImageFormatDetector.RequiredHeaderLength, throwOnEndOfStream: false, cancellationToken)
+            .ConfigureAwait(false);
+        source.Position = position;
+
+        if (!ImageFormatDetector.IsSafeRasterFormat(header.AsSpan(0, bytesRead)))
         {
             throw new UnsupportedImageFormatException("unknown");
         }

--- a/src/Granit.Imaging/IImagePipeline.cs
+++ b/src/Granit.Imaging/IImagePipeline.cs
@@ -4,7 +4,8 @@ namespace Granit.Imaging;
 /// Fluent pipeline for chaining image transformation operations.
 /// </summary>
 /// <remarks>
-/// Created by <see cref="IImageProcessor.Load(Stream)"/>. Each transformation method
+/// Created by <see cref="IImageProcessor.LoadAsync(Stream, CancellationToken)"/> or
+/// <see cref="IImageProcessor.Load(ReadOnlyMemory{byte})"/>. Each transformation method
 /// mutates the underlying image and returns <see langword="this"/> for chaining.
 /// Call a terminal method (<see cref="ToResultAsync"/> or <see cref="SaveToStreamAsync"/>)
 /// to produce the output.
@@ -70,6 +71,7 @@ public interface IImagePipeline : IAsyncDisposable
     /// <param name="position">Placement on the target image (default: <see cref="WatermarkPosition.BottomRight"/>).</param>
     /// <param name="opacity">Opacity from 0.0 (invisible) to 1.0 (opaque). Default: 0.5.</param>
     /// <returns>This pipeline for chaining.</returns>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="opacity"/> is outside the [0, 1] range.</exception>
     IImagePipeline Watermark(
         ReadOnlyMemory<byte> watermark,
         WatermarkPosition position = WatermarkPosition.BottomRight,
@@ -82,6 +84,7 @@ public interface IImagePipeline : IAsyncDisposable
     /// <param name="position">Placement on the target image (default: <see cref="WatermarkPosition.BottomRight"/>).</param>
     /// <param name="opacity">Opacity from 0.0 (invisible) to 1.0 (opaque). Default: 0.5.</param>
     /// <returns>This pipeline for chaining.</returns>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="opacity"/> is outside the [0, 1] range.</exception>
     IImagePipeline Watermark(
         Stream watermark,
         WatermarkPosition position = WatermarkPosition.BottomRight,

--- a/src/Granit.Imaging/IImageProcessor.cs
+++ b/src/Granit.Imaging/IImageProcessor.cs
@@ -4,12 +4,15 @@ namespace Granit.Imaging;
 /// Entry point for image processing. Injected via dependency injection.
 /// </summary>
 /// <remarks>
-/// Use <see cref="Load(Stream)"/> or <see cref="Load(ReadOnlyMemory{byte})"/> to create
-/// an <see cref="IImagePipeline"/> that provides a fluent API for image transformations.
+/// Use <see cref="LoadAsync(Stream, CancellationToken)"/> or
+/// <see cref="Load(ReadOnlyMemory{byte})"/> to create an <see cref="IImagePipeline"/> that
+/// provides a fluent API for image transformations. Stream loading is asynchronous because
+/// reading the source is I/O; the in-memory overloads stay synchronous — decoding is pure
+/// CPU work and a <c>Task</c> wrapper would be dishonest.
 /// <para>
 /// The returned pipeline must be disposed after use to release native resources:
 /// <code>
-/// await using IImagePipeline pipeline = imageProcessor.Load(stream);
+/// await using IImagePipeline pipeline = await imageProcessor.LoadAsync(stream);
 /// ImageResult result = await pipeline
 ///     .Resize(800, 600, ResizeMode.Crop)
 ///     .Compress(quality: 75)
@@ -21,10 +24,12 @@ public interface IImageProcessor
 {
     /// <summary>
     /// Loads an image from a <see cref="Stream"/> and returns a processing pipeline.
+    /// Non-seekable streams are buffered asynchronously before decoding.
     /// </summary>
     /// <param name="source">The stream containing the image data.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>A fluent pipeline for chaining image operations.</returns>
-    IImagePipeline Load(Stream source);
+    Task<IImagePipeline> LoadAsync(Stream source, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Loads an image from a byte buffer and returns a processing pipeline.

--- a/tests/Granit.Imaging.AI.Tests/ImagingAIOptionsValidatorTests.cs
+++ b/tests/Granit.Imaging.AI.Tests/ImagingAIOptionsValidatorTests.cs
@@ -1,0 +1,28 @@
+using Granit.Imaging.AI.Options;
+using Shouldly;
+
+namespace Granit.Imaging.AI.Tests;
+
+public sealed class ImagingAIOptionsValidatorTests
+{
+    private readonly ImagingAIOptionsValidator _validator = new();
+
+    [Fact]
+    public void Defaults_are_valid() =>
+        _validator.Validate(null, new ImagingAIOptions()).Succeeded.ShouldBeTrue();
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-5)]
+    [InlineData(301)]
+    public void Unusable_timeouts_fail(int timeoutSeconds) =>
+        _validator.Validate(null, new ImagingAIOptions { TimeoutSeconds = timeoutSeconds })
+            .Failed.ShouldBeTrue();
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(300)]
+    public void Boundary_timeouts_pass(int timeoutSeconds) =>
+        _validator.Validate(null, new ImagingAIOptions { TimeoutSeconds = timeoutSeconds })
+            .Succeeded.ShouldBeTrue();
+}

--- a/tests/Granit.Imaging.MagickNet.Tests/Internal/ImageFormatDetectorTests.cs
+++ b/tests/Granit.Imaging.MagickNet.Tests/Internal/ImageFormatDetectorTests.cs
@@ -1,0 +1,78 @@
+using System.Text;
+using Granit.Imaging.MagickNet.Internal;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Imaging.MagickNet.Tests.Internal;
+
+/// <summary>
+/// Direct coverage of the magic-byte allowlist — the security control that keeps dangerous
+/// formats (SVG, MSL, MVG, PDF, EPS) away from the native ImageMagick decoder.
+/// </summary>
+public sealed class ImageFormatDetectorTests
+{
+    private static byte[] Pad(byte[] header)
+    {
+        byte[] padded = new byte[ImageFormatDetector.RequiredHeaderLength];
+        header.CopyTo(padded, 0);
+        return padded;
+    }
+
+    public static TheoryData<string, byte[]> SafeHeaders => new()
+    {
+        { "jpeg", Pad([0xFF, 0xD8, 0xFF, 0xE0]) },
+        { "png", Pad([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]) },
+        { "gif87a", Pad("GIF87a"u8.ToArray()) },
+        { "gif89a", Pad("GIF89a"u8.ToArray()) },
+        { "bmp", Pad("BM"u8.ToArray()) },
+        { "tiff-le", Pad([0x49, 0x49, 0x2A, 0x00]) },
+        { "tiff-be", Pad([0x4D, 0x4D, 0x00, 0x2A]) },
+        { "webp", [0x52, 0x49, 0x46, 0x46, 0x10, 0x00, 0x00, 0x00, 0x57, 0x45, 0x42, 0x50] },
+        { "avif", [0x00, 0x00, 0x00, 0x1C, 0x66, 0x74, 0x79, 0x70, 0x61, 0x76, 0x69, 0x66] },
+        { "avis", [0x00, 0x00, 0x00, 0x1C, 0x66, 0x74, 0x79, 0x70, 0x61, 0x76, 0x69, 0x73] },
+    };
+
+    [Theory]
+    [MemberData(nameof(SafeHeaders))]
+    public void Accepts_every_allowlisted_raster_format(string format, byte[] header)
+    {
+        format.ShouldNotBeNullOrEmpty();
+        ImageFormatDetector.IsSafeRasterFormat(header).ShouldBeTrue();
+    }
+
+    public static TheoryData<string, byte[]> DangerousHeaders => new()
+    {
+        { "svg", Pad(Encoding.ASCII.GetBytes("<svg xmlns=\"")) },
+        { "xml-prolog", Pad(Encoding.ASCII.GetBytes("<?xml versio")) },
+        { "pdf", Pad(Encoding.ASCII.GetBytes("%PDF-1.7")) },
+        { "eps", Pad(Encoding.ASCII.GetBytes("%!PS-Adobe-3")) },
+        { "msl", Pad(Encoding.ASCII.GetBytes("<msl>")) },
+        { "mvg", Pad(Encoding.ASCII.GetBytes("push graphic")) },
+        { "riff-wave-not-webp", [0x52, 0x49, 0x46, 0x46, 0x10, 0x00, 0x00, 0x00, 0x57, 0x41, 0x56, 0x45] },
+        { "ftyp-mp42-not-avif", [0x00, 0x00, 0x00, 0x1C, 0x66, 0x74, 0x79, 0x70, 0x6D, 0x70, 0x34, 0x32] },
+        { "all-zero", new byte[12] },
+    };
+
+    [Theory]
+    [MemberData(nameof(DangerousHeaders))]
+    public void Rejects_dangerous_or_unknown_formats(string format, byte[] header)
+    {
+        format.ShouldNotBeNullOrEmpty();
+        ImageFormatDetector.IsSafeRasterFormat(header).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Rejects_a_truncated_header_shorter_than_twelve_bytes()
+    {
+        // A valid PNG signature cut to 11 bytes must be rejected: the detector needs the
+        // full window to vet container formats (WebP, AVIF) safely.
+        byte[] truncated = new byte[11];
+        new byte[] { 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A }.CopyTo(truncated, 0);
+
+        ImageFormatDetector.IsSafeRasterFormat(truncated).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Rejects_an_empty_span() =>
+        ImageFormatDetector.IsSafeRasterFormat([]).ShouldBeFalse();
+}

--- a/tests/Granit.Imaging.MagickNet.Tests/Internal/MagickNetImagePipelineFormatConversionTests.cs
+++ b/tests/Granit.Imaging.MagickNet.Tests/Internal/MagickNetImagePipelineFormatConversionTests.cs
@@ -17,12 +17,12 @@ public sealed class MagickNetImagePipelineFormatConversionTests
         return new ImagingMetrics(factory);
     }
 
-    private static MagickNetImagePipeline CreatePipeline()
+    private static async Task<MagickNetImagePipeline> CreatePipelineAsync()
     {
         Stream stream = typeof(MagickNetImagePipelineFormatConversionTests).Assembly
             .GetManifestResourceStream("Granit.Imaging.MagickNet.Tests.TestAssets.test-image.png")!;
         MagickNetImageProcessor processor = new(CreateTestMetrics(), Microsoft.Extensions.Options.Options.Create(new ImagingMagickNetOptions()));
-        return (MagickNetImagePipeline)processor.Load(stream);
+        return (MagickNetImagePipeline)await processor.LoadAsync(stream);
     }
 
     [Theory]
@@ -34,7 +34,7 @@ public sealed class MagickNetImagePipelineFormatConversionTests
     [InlineData(ImageFormat.Tiff)]
     public async Task ConvertTo_AllFormats_ProducesValidOutput(ImageFormat format)
     {
-        await using MagickNetImagePipeline pipeline = CreatePipeline();
+        await using MagickNetImagePipeline pipeline = await CreatePipelineAsync();
 
         ImageResult result = await pipeline
             .ConvertTo(format)
@@ -49,7 +49,7 @@ public sealed class MagickNetImagePipelineFormatConversionTests
     [Fact]
     public async Task ConvertTo_Jpeg_StripsPngTransparency()
     {
-        await using MagickNetImagePipeline pipeline = CreatePipeline();
+        await using MagickNetImagePipeline pipeline = await CreatePipelineAsync();
 
         ImageResult result = await pipeline
             .ConvertTo(ImageFormat.Jpeg)
@@ -64,8 +64,8 @@ public sealed class MagickNetImagePipelineFormatConversionTests
     public async Task ConvertTo_Jpeg_WithCompression_ProducesSmallerFile()
     {
         // JPEG compression is more predictable than WebP on tiny images
-        await using MagickNetImagePipeline highQuality = CreatePipeline();
-        await using MagickNetImagePipeline lowQuality = CreatePipeline();
+        await using MagickNetImagePipeline highQuality = await CreatePipelineAsync();
+        await using MagickNetImagePipeline lowQuality = await CreatePipelineAsync();
 
         ImageResult highResult = await highQuality
             .ConvertTo(ImageFormat.Jpeg)
@@ -85,7 +85,7 @@ public sealed class MagickNetImagePipelineFormatConversionTests
     {
         using CancellationTokenSource cts = new();
         cts.Cancel();
-        MagickNetImagePipeline pipeline = CreatePipeline();
+        MagickNetImagePipeline pipeline = await CreatePipelineAsync();
         await using MemoryStream output = new();
 
         Func<Task> act = () => pipeline.SaveToStreamAsync(output, cts.Token);
@@ -95,8 +95,8 @@ public sealed class MagickNetImagePipelineFormatConversionTests
     [Fact]
     public async Task SaveToStreamAsync_ProducesSameFormatAsToResult()
     {
-        await using MagickNetImagePipeline pipeline1 = CreatePipeline();
-        await using MagickNetImagePipeline pipeline2 = CreatePipeline();
+        await using MagickNetImagePipeline pipeline1 = await CreatePipelineAsync();
+        await using MagickNetImagePipeline pipeline2 = await CreatePipelineAsync();
 
         ImageResult resultA = await pipeline1
             .ConvertTo(ImageFormat.Jpeg)

--- a/tests/Granit.Imaging.MagickNet.Tests/Internal/MagickNetImagePipelineTests.cs
+++ b/tests/Granit.Imaging.MagickNet.Tests/Internal/MagickNetImagePipelineTests.cs
@@ -17,19 +17,19 @@ public sealed class MagickNetImagePipelineTests
         return new ImagingMetrics(factory);
     }
 
-    private static MagickNetImagePipeline CreatePipeline()
+    private static async Task<MagickNetImagePipeline> CreatePipelineAsync()
     {
         Stream stream = typeof(MagickNetImagePipelineTests).Assembly
             .GetManifestResourceStream("Granit.Imaging.MagickNet.Tests.TestAssets.test-image.png")!;
         MagickNetImageProcessor processor = new(CreateTestMetrics(), Microsoft.Extensions.Options.Options.Create(new ImagingMagickNetOptions()));
-        return (MagickNetImagePipeline)processor.Load(stream);
+        return (MagickNetImagePipeline)await processor.LoadAsync(stream);
     }
 
     [Fact]
     public async Task Resize_Max_PreservesAspectRatioWithinBounds()
     {
         // Arrange
-        await using MagickNetImagePipeline pipeline = CreatePipeline();
+        await using MagickNetImagePipeline pipeline = await CreatePipelineAsync();
 
         // Act — 100x100 image resized to Max(50, 80)
         ImageResult result = await pipeline
@@ -45,7 +45,7 @@ public sealed class MagickNetImagePipelineTests
     public async Task Resize_Crop_FillsExactDimensions()
     {
         // Arrange
-        await using MagickNetImagePipeline pipeline = CreatePipeline();
+        await using MagickNetImagePipeline pipeline = await CreatePipelineAsync();
 
         // Act — 100x100 image crop-resized to 60x40
         ImageResult result = await pipeline
@@ -61,7 +61,7 @@ public sealed class MagickNetImagePipelineTests
     public async Task Resize_Pad_PadsToExactDimensions()
     {
         // Arrange
-        await using MagickNetImagePipeline pipeline = CreatePipeline();
+        await using MagickNetImagePipeline pipeline = await CreatePipelineAsync();
 
         // Act — 100x100 image padded to 150x200
         ImageResult result = await pipeline
@@ -77,7 +77,7 @@ public sealed class MagickNetImagePipelineTests
     public async Task Resize_Stretch_DistortsToExactDimensions()
     {
         // Arrange
-        await using MagickNetImagePipeline pipeline = CreatePipeline();
+        await using MagickNetImagePipeline pipeline = await CreatePipelineAsync();
 
         // Act — 100x100 image stretched to 60x30
         ImageResult result = await pipeline
@@ -93,7 +93,7 @@ public sealed class MagickNetImagePipelineTests
     public async Task Resize_Min_CoversTargetArea()
     {
         // Arrange
-        await using MagickNetImagePipeline pipeline = CreatePipeline();
+        await using MagickNetImagePipeline pipeline = await CreatePipelineAsync();
 
         // Act — 100x100 square, min 50x80 → 80x80 (fills 80 height, width follows)
         ImageResult result = await pipeline
@@ -109,7 +109,7 @@ public sealed class MagickNetImagePipelineTests
     public async Task Crop_ReturnsCorrectDimensions()
     {
         // Arrange
-        await using MagickNetImagePipeline pipeline = CreatePipeline();
+        await using MagickNetImagePipeline pipeline = await CreatePipelineAsync();
 
         // Act
         ImageResult result = await pipeline
@@ -125,7 +125,7 @@ public sealed class MagickNetImagePipelineTests
     public async Task ConvertTo_ChangesOutputFormat()
     {
         // Arrange
-        await using MagickNetImagePipeline pipeline = CreatePipeline();
+        await using MagickNetImagePipeline pipeline = await CreatePipelineAsync();
 
         // Act
         ImageResult result = await pipeline
@@ -141,7 +141,7 @@ public sealed class MagickNetImagePipelineTests
     public async Task ConvertTo_WebP_ProducesValidOutput()
     {
         // Arrange
-        await using MagickNetImagePipeline pipeline = CreatePipeline();
+        await using MagickNetImagePipeline pipeline = await CreatePipelineAsync();
 
         // Act
         ImageResult result = await pipeline
@@ -157,8 +157,8 @@ public sealed class MagickNetImagePipelineTests
     public async Task Compress_AffectsOutputSize()
     {
         // Arrange
-        await using MagickNetImagePipeline highQuality = CreatePipeline();
-        await using MagickNetImagePipeline lowQuality = CreatePipeline();
+        await using MagickNetImagePipeline highQuality = await CreatePipelineAsync();
+        await using MagickNetImagePipeline lowQuality = await CreatePipelineAsync();
 
         // Act
         ImageResult highResult = await highQuality
@@ -179,7 +179,7 @@ public sealed class MagickNetImagePipelineTests
     public async Task StripMetadata_RemovesExifData()
     {
         // Arrange
-        await using MagickNetImagePipeline pipeline = CreatePipeline();
+        await using MagickNetImagePipeline pipeline = await CreatePipelineAsync();
 
         // Act
         ImageResult result = await pipeline
@@ -195,7 +195,7 @@ public sealed class MagickNetImagePipelineTests
     public async Task SaveToStreamAsync_WritesToStream()
     {
         // Arrange
-        await using MagickNetImagePipeline pipeline = CreatePipeline();
+        await using MagickNetImagePipeline pipeline = await CreatePipelineAsync();
         await using MemoryStream output = new();
 
         // Act
@@ -209,7 +209,7 @@ public sealed class MagickNetImagePipelineTests
     public async Task FullPipeline_ResizeCompressConvertStripMetadata()
     {
         // Arrange
-        await using MagickNetImagePipeline pipeline = CreatePipeline();
+        await using MagickNetImagePipeline pipeline = await CreatePipelineAsync();
 
         // Act
         ImageResult result = await pipeline
@@ -230,7 +230,7 @@ public sealed class MagickNetImagePipelineTests
     public async Task ToResultAsync_PreservesSourceFormatWhenNoConversion()
     {
         // Arrange
-        await using MagickNetImagePipeline pipeline = CreatePipeline();
+        await using MagickNetImagePipeline pipeline = await CreatePipelineAsync();
 
         // Act
         ImageResult result = await pipeline.ToResultAsync(TestContext.Current.CancellationToken);
@@ -243,7 +243,7 @@ public sealed class MagickNetImagePipelineTests
     public async Task DisposeAsync_ReleasesResources()
     {
         // Arrange
-        MagickNetImagePipeline pipeline = CreatePipeline();
+        MagickNetImagePipeline pipeline = await CreatePipelineAsync();
 
         // Act
         await pipeline.DisposeAsync();
@@ -259,7 +259,7 @@ public sealed class MagickNetImagePipelineTests
         // Arrange
         using CancellationTokenSource cts = new();
         cts.Cancel();
-        MagickNetImagePipeline pipeline = CreatePipeline();
+        MagickNetImagePipeline pipeline = await CreatePipelineAsync();
 
         // Act & Assert
         Func<Task> act = () => pipeline.ToResultAsync(cts.Token);

--- a/tests/Granit.Imaging.MagickNet.Tests/Internal/MagickNetImagePipelineWatermarkTests.cs
+++ b/tests/Granit.Imaging.MagickNet.Tests/Internal/MagickNetImagePipelineWatermarkTests.cs
@@ -18,12 +18,12 @@ public sealed class MagickNetImagePipelineWatermarkTests
         return new ImagingMetrics(factory);
     }
 
-    private static MagickNetImagePipeline CreatePipeline()
+    private static async Task<MagickNetImagePipeline> CreatePipelineAsync()
     {
         Stream stream = typeof(MagickNetImagePipelineWatermarkTests).Assembly
             .GetManifestResourceStream("Granit.Imaging.MagickNet.Tests.TestAssets.test-image.png")!;
         MagickNetImageProcessor processor = new(CreateTestMetrics(), Microsoft.Extensions.Options.Options.Create(new ImagingMagickNetOptions()));
-        return (MagickNetImagePipeline)processor.Load(stream);
+        return (MagickNetImagePipeline)await processor.LoadAsync(stream);
     }
 
     private static ReadOnlyMemory<byte> CreateWatermarkBytes()
@@ -51,7 +51,7 @@ public sealed class MagickNetImagePipelineWatermarkTests
     [InlineData(WatermarkPosition.BottomRight)]
     public async Task Watermark_AllPositions_ProduceValidOutput(WatermarkPosition position)
     {
-        await using MagickNetImagePipeline pipeline = CreatePipeline();
+        await using MagickNetImagePipeline pipeline = await CreatePipelineAsync();
         ReadOnlyMemory<byte> watermark = CreateWatermarkBytes();
 
         ImageResult result = await pipeline
@@ -72,7 +72,7 @@ public sealed class MagickNetImagePipelineWatermarkTests
     [InlineData(1.0f)]
     public async Task Watermark_DifferentOpacities_ProduceValidOutput(float opacity)
     {
-        await using MagickNetImagePipeline pipeline = CreatePipeline();
+        await using MagickNetImagePipeline pipeline = await CreatePipelineAsync();
         ReadOnlyMemory<byte> watermark = CreateWatermarkBytes();
 
         ImageResult result = await pipeline
@@ -82,12 +82,27 @@ public sealed class MagickNetImagePipelineWatermarkTests
         result.Content.Length.ShouldBeGreaterThan(0);
     }
 
+    [Theory]
+    [InlineData(-0.1f)]
+    [InlineData(1.1f)]
+    public async Task Watermark_OpacityOutsideUnitRange_Throws(float opacity)
+    {
+        await using MagickNetImagePipeline pipeline = await CreatePipelineAsync();
+        ReadOnlyMemory<byte> watermark = CreateWatermarkBytes();
+
+        Should.Throw<ArgumentOutOfRangeException>(() =>
+            pipeline.Watermark(watermark, WatermarkPosition.Center, opacity));
+        await using MemoryStream watermarkStream = CreateWatermarkStream();
+        Should.Throw<ArgumentOutOfRangeException>(() =>
+            pipeline.Watermark(watermarkStream, WatermarkPosition.Center, opacity));
+    }
+
     // ── Stream overload ─────────────────────────────────────────────────────
 
     [Fact]
     public async Task Watermark_FromStream_ProducesValidOutput()
     {
-        await using MagickNetImagePipeline pipeline = CreatePipeline();
+        await using MagickNetImagePipeline pipeline = await CreatePipelineAsync();
         await using MemoryStream watermarkStream = CreateWatermarkStream();
 
         ImageResult result = await pipeline
@@ -102,7 +117,7 @@ public sealed class MagickNetImagePipelineWatermarkTests
     [Fact]
     public async Task Watermark_DoesNotChangeDimensions()
     {
-        await using MagickNetImagePipeline pipeline = CreatePipeline();
+        await using MagickNetImagePipeline pipeline = await CreatePipelineAsync();
         ReadOnlyMemory<byte> watermark = CreateWatermarkBytes();
 
         ImageResult result = await pipeline
@@ -118,7 +133,7 @@ public sealed class MagickNetImagePipelineWatermarkTests
     [Fact]
     public async Task Watermark_AfterResize_WorksCorrectly()
     {
-        await using MagickNetImagePipeline pipeline = CreatePipeline();
+        await using MagickNetImagePipeline pipeline = await CreatePipelineAsync();
         ReadOnlyMemory<byte> watermark = CreateWatermarkBytes();
 
         ImageResult result = await pipeline

--- a/tests/Granit.Imaging.MagickNet.Tests/Internal/MagickNetImageProcessorTests.cs
+++ b/tests/Granit.Imaging.MagickNet.Tests/Internal/MagickNetImageProcessorTests.cs
@@ -33,13 +33,13 @@ public sealed class MagickNetImageProcessorTests
     }
 
     [Fact]
-    public void Load_FromStream_ReturnsPipelineWithCorrectSourceFormat()
+    public async Task LoadAsync_FromStream_ReturnsPipelineWithCorrectSourceFormat()
     {
         // Arrange
-        using Stream stream = GetTestImageStream();
+        await using Stream stream = GetTestImageStream();
 
         // Act
-        IImagePipeline pipeline = _processor.Load(stream);
+        IImagePipeline pipeline = await _processor.LoadAsync(stream, TestContext.Current.CancellationToken);
 
         // Assert
         pipeline.SourceFormat.ShouldBe(ImageFormat.Png);
@@ -86,16 +86,128 @@ public sealed class MagickNetImageProcessorTests
     }
 
     [Fact]
-    public async Task Load_FromStream_PipelineIsDisposable()
+    public async Task LoadAsync_FromStream_PipelineIsDisposable()
     {
         // Arrange
         await using Stream stream = GetTestImageStream();
 
         // Act
-        IImagePipeline pipeline = _processor.Load(stream);
+        IImagePipeline pipeline = await _processor.LoadAsync(stream, TestContext.Current.CancellationToken);
 
         // Assert
         Func<Task> act = () => pipeline.DisposeAsync().AsTask();
         await Should.NotThrowAsync(act);
+    }
+
+    [Fact]
+    public async Task LoadAsync_NonSeekableStream_BuffersAndDecodes()
+    {
+        await using Stream inner = GetTestImageStream();
+        await using NonSeekableStream stream = new(inner);
+
+        await using IImagePipeline pipeline = await _processor.LoadAsync(stream, TestContext.Current.CancellationToken);
+
+        pipeline.SourceFormat.ShouldBe(ImageFormat.Png);
+        pipeline.SourceSize.Width.ShouldBe(100);
+    }
+
+    [Fact]
+    public async Task LoadAsync_SeekableStream_RestoresPositionAfterHeaderSniff()
+    {
+        await using Stream stream = GetTestImageStream();
+
+        await using IImagePipeline pipeline = await _processor.LoadAsync(stream, TestContext.Current.CancellationToken);
+
+        // The whole stream was consumed by the decode, not left at the 12-byte header mark.
+        stream.Position.ShouldBe(stream.Length);
+        pipeline.SourceFormat.ShouldBe(ImageFormat.Png);
+    }
+
+    [Fact]
+    public async Task LoadAsync_StreamYieldingOneBytePerRead_StillPassesHeaderValidation()
+    {
+        // Regression: a single Read may legally return fewer than the requested bytes even
+        // mid-stream; the header sniff must use ReadAtLeast semantics, not one Read call.
+        await using Stream inner = GetTestImageStream();
+        await using OneBytePerReadStream stream = new(inner);
+
+        await using IImagePipeline pipeline = await _processor.LoadAsync(stream, TestContext.Current.CancellationToken);
+
+        pipeline.SourceFormat.ShouldBe(ImageFormat.Png);
+    }
+
+    [Fact]
+    public async Task LoadAsync_OversizedInput_Throws()
+    {
+        MagickNetImageProcessor processor = new(
+            CreateTestMetrics(),
+            Microsoft.Extensions.Options.Options.Create(new ImagingMagickNetOptions { MaxInputBytes = 16 }));
+        await using Stream stream = GetTestImageStream();
+
+        await Should.ThrowAsync<InvalidOperationException>(
+            () => processor.LoadAsync(stream, TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task LoadAsync_UnknownFormat_ThrowsUnsupportedImageFormat()
+    {
+        await using MemoryStream stream = new("%PDF-1.7 not an image"u8.ToArray());
+
+        await Should.ThrowAsync<UnsupportedImageFormatException>(
+            () => _processor.LoadAsync(stream, TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task LoadAsync_CancelledToken_Throws()
+    {
+        await using Stream inner = GetTestImageStream();
+        await using NonSeekableStream stream = new(inner);
+        using CancellationTokenSource cts = new();
+        await cts.CancelAsync();
+
+        await Should.ThrowAsync<OperationCanceledException>(
+            () => _processor.LoadAsync(stream, cts.Token));
+    }
+
+    /// <summary>Wraps a stream and reports it as non-seekable (network-stream shape).</summary>
+    private sealed class NonSeekableStream(Stream inner) : Stream
+    {
+        public override bool CanRead => inner.CanRead;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => throw new NotSupportedException();
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        public override int Read(byte[] buffer, int offset, int count) => inner.Read(buffer, offset, count);
+        public override void Flush() { }
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
+
+    /// <summary>Seekable stream that returns at most one byte per Read call.</summary>
+    private sealed class OneBytePerReadStream(Stream inner) : Stream
+    {
+        public override bool CanRead => inner.CanRead;
+        public override bool CanSeek => true;
+        public override bool CanWrite => false;
+        public override long Length => inner.Length;
+        public override long Position
+        {
+            get => inner.Position;
+            set => inner.Position = value;
+        }
+
+        public override int Read(byte[] buffer, int offset, int count) =>
+            inner.Read(buffer, offset, Math.Min(count, 1));
+
+        public override void Flush() { }
+        public override long Seek(long offset, SeekOrigin origin) => inner.Seek(offset, origin);
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
     }
 }


### PR DESCRIPTION
## Summary

PR 3 shipped of the Imaging/AI redesign series (after #3077; independent of #3079). Vague Imaging-2 of the plan.

- **`LoadAsync(Stream, CancellationToken)` replaces `Load(Stream)`.** Reading the source is I/O — the old sync path did a blocking `CopyTo` on non-seekable streams. Non-seekable sources now buffer via `CopyToAsync`; seekable ones decode via `MagickImage.ReadAsync`. `Load(ReadOnlyMemory<byte>)` and `Identify` deliberately stay synchronous (pure CPU; a `Task` wrapper would be dishonest). Verified: zero production consumers of `Load(Stream)` existed outside the MagickNet implementation — the only interface consumer (`TesseractOcrExtractor`) calls `Identify` only.
- **Header-sniff correctness (audit finding):** the magic-byte validation used a single `Read`, which may legally return fewer than 12 bytes and rejected valid images on short first chunks — now `ReadAtLeast`/`ReadAtLeastAsync`, with a regression test using a 1-byte-per-read stream.
- **`ImageFormatDetector` gets direct tests at last** — it is the security control keeping SVG/MSL/PDF/EPS away from the native ImageMagick decoder, and was only covered incidentally. Table-driven: 10 accepted headers (incl. GIF87a/89a, TIFF LE/BE, AVIF `avif`+`avis` brands), 9 rejections (SVG, XML prolog, PDF, EPS, MSL, MVG, RIFF+`WAVE`, `ftyp`+`mp42`, all-zero), truncated-header and empty-span cases.
- **Pipeline hardening:** watermark opacity validated against `[0, 1]` (documented on `IImagePipeline`); `ToResultAsync` encodes via `ToByteArray(format)` — one managed copy instead of `MemoryStream` + `ToArray()`.
- **`ImagingAIOptionsValidator`:** `Imaging:AI` `TimeoutSeconds` outside `[1, 300]` now fails at startup (`ValidateOnStart`) instead of throwing `ArgumentOutOfRangeException` at first call.

## Breaking changes

| Before | After |
| --- | --- |
| `processor.Load(stream)` | `await processor.LoadAsync(stream)` |
| Watermark opacity unchecked | Outside `[0, 1]` throws `ArgumentOutOfRangeException` |
| Bad `Imaging:AI:TimeoutSeconds` threw at first call | Fails at host startup |

## Tests

New: `ImageFormatDetectorTests` (21 vectors), `LoadAsync` suite (non-seekable shim, position restored after sniff, 1-byte-per-read regression, oversized input, unknown format, cancellation), opacity-range tests, `ImagingAIOptionsValidatorTests`.

Verified: `Granit.Imaging.Tests` 37 ✅, `Granit.Imaging.MagickNet.Tests` 127 ✅, `Granit.Imaging.AI.Tests` 25 ✅, `Granit.TextExtraction.Ocr.Tesseract.Tests` 20 ✅, architecture shard 262 ✅, `dotnet format` clean (api-data).

🤖 Generated with [Claude Code](https://claude.com/claude-code)