### PR TITLE
feat(ai)!: multimodal StructuredCompletionRequest (binary attachments)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -6363,7 +6363,7 @@
       "kind": "record",
       "project": "Granit.AI",
       "file": "src/Granit.AI/StructuredCompletionRequest.cs",
-      "line": 12,
+      "line": 16,
       "members": []
     },
     {

--- a/src/Granit.AI/Internal/DefaultStructuredCompletion.cs
+++ b/src/Granit.AI/Internal/DefaultStructuredCompletion.cs
@@ -42,6 +42,12 @@ internal sealed partial class DefaultStructuredCompletion(
     {
         ArgumentNullException.ThrowIfNull(request);
 
+        if (string.IsNullOrWhiteSpace(request.Content) && request.Attachments is not { Count: > 0 })
+        {
+            throw new ArgumentException(
+                "The request must carry Content, at least one attachment, or both.", nameof(request));
+        }
+
         string workspaceName = request.WorkspaceName ?? aiOptions.Value.DefaultWorkspace;
 
         AIWorkspace? workspace = await workspaceProvider
@@ -98,9 +104,17 @@ internal sealed partial class DefaultStructuredCompletion(
                 .CreateAsync(workspaceName, linkedCts.Token)
                 .ConfigureAwait(false);
 
+            // Text prompt first (instruction + sanitized envelope), then the binary parts —
+            // the pattern vision-capable providers expect for multimodal user messages.
+            List<AIContent> parts = [new TextContent(BuildPrompt<T>(request, schemaSupported))];
+            if (request.Attachments is { Count: > 0 })
+            {
+                parts.AddRange(request.Attachments);
+            }
+
             var messages = new List<ChatMessage>
             {
-                new(ChatRole.User, BuildPrompt<T>(request, schemaSupported)),
+                new(ChatRole.User, parts),
             };
 
             ChatOptions? chatOptions = schemaSupported
@@ -214,7 +228,10 @@ internal sealed partial class DefaultStructuredCompletion(
             builder.AppendUserDataMap("Context", request.Context);
         }
 
-        builder.AppendUserTextBlock(request.ContentLabel ?? "Document", request.Content);
+        if (!string.IsNullOrWhiteSpace(request.Content))
+        {
+            builder.AppendUserTextBlock(request.ContentLabel ?? "Document", request.Content);
+        }
 
         return builder.Build();
     }

--- a/src/Granit.AI/StructuredCompletionRequest.cs
+++ b/src/Granit.AI/StructuredCompletionRequest.cs
@@ -1,3 +1,5 @@
+using Microsoft.Extensions.AI;
+
 namespace Granit.AI;
 
 /// <summary>
@@ -7,7 +9,9 @@ namespace Granit.AI;
 /// Separates the developer-controlled task <see cref="Instruction"/> from the untrusted
 /// <see cref="Content"/> (and optional <see cref="Context"/>) so the implementation can
 /// sanitize and delimit everything that originates outside the application — the
-/// framework's first line of defence against OWASP LLM01 prompt injection.
+/// framework's first line of defence against OWASP LLM01 prompt injection. Binary
+/// <see cref="Attachments"/> enable multimodal requests (image analysis, vision OCR);
+/// at least one of <see cref="Content"/> or <see cref="Attachments"/> must be supplied.
 /// </remarks>
 public sealed record StructuredCompletionRequest
 {
@@ -23,10 +27,11 @@ public sealed record StructuredCompletionRequest
     public string? Instruction { get; init; }
 
     /// <summary>
-    /// The untrusted text to analyze. Sanitized and wrapped in a <c>&lt;data&gt;</c> block
-    /// by the implementation before it reaches the model.
+    /// The untrusted text to analyze, or <c>null</c> for attachment-only (e.g. image-only)
+    /// requests. Sanitized and wrapped in a <c>&lt;data&gt;</c> block by the implementation
+    /// before it reaches the model.
     /// </summary>
-    public required string Content { get; init; }
+    public string? Content { get; init; }
 
     /// <summary>
     /// Developer-controlled label for the <see cref="Content"/> block. Defaults to
@@ -40,6 +45,19 @@ public sealed record StructuredCompletionRequest
     /// treated as untrusted.
     /// </summary>
     public IReadOnlyList<KeyValuePair<string, string?>>? Context { get; init; }
+
+    /// <summary>
+    /// Optional binary parts (images, …) appended to the user message after the prompt,
+    /// enabling multimodal structured completion against a vision-capable model.
+    /// </summary>
+    /// <remarks>
+    /// TRUSTED-BY-CALLER: unlike <see cref="Content"/>, binary parts cannot flow through the
+    /// text sanitization envelope — the caller owns size caps and provenance checks (e.g.
+    /// <c>Granit.Imaging.AI</c> enforces <c>MaxImageBytes</c> and a content-type allowlist).
+    /// Constrained to <see cref="DataContent"/> so untrusted text can never be smuggled past
+    /// the <c>&lt;data&gt;</c> envelope as a raw message part.
+    /// </remarks>
+    public IReadOnlyList<DataContent>? Attachments { get; init; }
 
     /// <summary>
     /// Workspace to run against. When <c>null</c>, the configured default workspace is used.

--- a/tests/Granit.AI.Tests/StructuredCompletion/DefaultStructuredCompletionTests.cs
+++ b/tests/Granit.AI.Tests/StructuredCompletion/DefaultStructuredCompletionTests.cs
@@ -215,6 +215,61 @@ public sealed class DefaultStructuredCompletionTests
     }
 
     [Fact]
+    public async Task CompleteAsync_WithAttachments_AppendsThemAfterThePromptText()
+    {
+        List<ChatMessage>? messages = null;
+        _chatClient
+            .GetResponseAsync(
+                Arg.Do<IEnumerable<ChatMessage>>(m => messages = m.ToList()),
+                Arg.Any<ChatOptions?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new ChatResponse(new ChatMessage(ChatRole.Assistant, """{"title":"H"}"""))
+            {
+                FinishReason = ChatFinishReason.Stop,
+            });
+
+        DataContent image = new(new byte[] { 0x89, 0x50, 0x4E, 0x47 }, "image/png");
+        await _sut.CompleteAsync<SeoExtraction>(
+            new StructuredCompletionRequest { Content = "Body.", Attachments = [image] },
+            TestContext.Current.CancellationToken);
+
+        messages.ShouldNotBeNull();
+        ChatMessage message = messages.Single();
+        message.Contents.Count.ShouldBe(2);
+        message.Contents[0].ShouldBeOfType<TextContent>();
+        message.Contents[1].ShouldBeSameAs(image);
+        // The sanitization envelope still wraps the text part.
+        ((TextContent)message.Contents[0]).Text.ShouldContain("<data>");
+    }
+
+    [Fact]
+    public async Task CompleteAsync_AttachmentOnly_SucceedsWithoutContent()
+    {
+        RespondWith(new ChatResponse(new ChatMessage(ChatRole.Assistant, """{"title":"H"}"""))
+        {
+            FinishReason = ChatFinishReason.Stop,
+        });
+
+        StructuredCompletionResult<SeoExtraction> result = await _sut.CompleteAsync<SeoExtraction>(
+            new StructuredCompletionRequest
+            {
+                Instruction = "Describe the image.",
+                Attachments = [new DataContent(new byte[] { 0x89, 0x50, 0x4E, 0x47 }, "image/png")],
+            },
+            TestContext.Current.CancellationToken);
+
+        result.Status.ShouldBe(StructuredCompletionStatus.Succeeded);
+        result.Value!.Title.ShouldBe("H");
+    }
+
+    [Fact]
+    public async Task CompleteAsync_NoContentAndNoAttachments_ThrowsArgumentException() =>
+        await Should.ThrowAsync<ArgumentException>(
+            () => _sut.CompleteAsync<SeoExtraction>(
+                new StructuredCompletionRequest { Instruction = "Do something." },
+                TestContext.Current.CancellationToken));
+
+    [Fact]
     public async Task CompleteAsync_WithUsage_SurfacesUsage()
     {
         // The usage record itself is stamped by the factory-applied middleware, not here.


### PR DESCRIPTION
## Summary

PR 4 shipped of the Imaging/AI redesign series (after #3079). Extends the ADR-064 structured-output primitive to multimodal requests.

- `StructuredCompletionRequest` gains `IReadOnlyList<DataContent>? Attachments`; `Content` becomes `string?` (image-only requests need no dummy text).
- `DefaultStructuredCompletion` builds the user message as `[TextContent(prompt), ..attachments]` — the exact pattern already used by `LlmImageTextExtractor`. The `PromptBuilder` sanitization envelope is untouched for text; the attachment type is **constrained to `DataContent`** so untrusted text can never bypass the `<data>` envelope as a raw message part. Attachments are documented **trusted-by-caller** (size caps/provenance are the caller's job — `Granit.Imaging.AI` will enforce `MaxImageBytes` in the next PR).
- Neither `Content` nor `Attachments` → `ArgumentException` (programming error, not a status).
- This is the follow-up the `StructuredCompletionBypassTests` exemption for `LlmImageAnalyzer` explicitly anticipates ("Revisit if a multimodal primitive lands") — the analyzer migrates in the next PR, which also removes that exemption.

## Breaking changes

`Content` is no longer `required` — source-compatible for all 19 existing callers (verified: full `ai` shard compiles and passes).

## Tests

New: attachments appended after the prompt text (envelope asserted on the text part), attachment-only request succeeds, both-empty throws. Verified: `Granit.AI.Tests` 94 ✅, full **ai shard** green (~600 tests across 23 projects), architecture shard 262 ✅, `dotnet format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)