### PR TITLE
refactor(identity)!: replica-safe federated upsert + relocate UserCacheStats (Vague 4c)

### DIFF
--- a/src/Granit.Identity.Federated.EntityFrameworkCore/Extensions/IdentityFederatedEntityFrameworkCoreHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Identity.Federated.EntityFrameworkCore/Extensions/IdentityFederatedEntityFrameworkCoreHostApplicationBuilderExtensions.cs
@@ -25,7 +25,7 @@ public static class IdentityFederatedEntityFrameworkCoreHostApplicationBuilderEx
     /// <list type="bullet">
     ///   <item><see cref="CachedUserLookupService"/> — replaces the default <c>NullUserLookupService</c>.</item>
     ///   <item><see cref="EfCoreUserCacheStore"/> — implements <c>IUserCacheStore</c>.</item>
-    ///   <item><see cref="EfCoreUserCacheStats"/> — implements <c>IUserCacheStats</c>.</item>
+    ///   <item><c>UserCacheStats</c> — the default <c>IUserCacheStats</c> implementation.</item>
     ///   <item><see cref="FederatedUserCacheEraserAdapter"/> — implements <c>IFederatedUserCacheEraser</c>.</item>
     ///   <item><see cref="IdentityFederatedDbContext"/> — registered as <c>IDbContextFactory&lt;T&gt;</c> for thread-safe usage in Wolverine handlers.</item>
     /// </list>
@@ -50,7 +50,7 @@ public static class IdentityFederatedEntityFrameworkCoreHostApplicationBuilderEx
         builder.Services.AddGranitDbContext<IdentityFederatedDbContext>(configure);
 
         builder.Services.Replace(ServiceDescriptor.Scoped<IUserLookupService, CachedUserLookupService>());
-        builder.Services.Replace(ServiceDescriptor.Scoped<IUserCacheStats, EfCoreUserCacheStats>());
+        builder.Services.Replace(ServiceDescriptor.Scoped<IUserCacheStats, UserCacheStats>());
         builder.Services.TryAddScoped<IUserCacheStore, EfCoreUserCacheStore>();
         // The single joint-hydration write path (ADR-051), shared by the cache-aside service,
         // the provider webhook handler, and the login-time sync middleware.

--- a/src/Granit.Identity.Federated.EntityFrameworkCore/GranitIdentityFederatedEntityFrameworkCoreModule.cs
+++ b/src/Granit.Identity.Federated.EntityFrameworkCore/GranitIdentityFederatedEntityFrameworkCoreModule.cs
@@ -6,7 +6,7 @@ namespace Granit.Identity.Federated.EntityFrameworkCore;
 /// <summary>
 /// Granit module for EF Core identity user cache persistence. Owns the dedicated
 /// <c>IdentityFederatedDbContext</c> and replaces the default null stores with
-/// <c>EfCoreUserCacheStore</c> / <c>EfCoreUserCacheStats</c>.
+/// <c>EfCoreUserCacheStore</c> / <c>UserCacheStats</c>.
 /// </summary>
 /// <remarks>
 /// <para>

--- a/src/Granit.Identity.Federated.EntityFrameworkCore/Internal/EfCoreUserCacheStore.cs
+++ b/src/Granit.Identity.Federated.EntityFrameworkCore/Internal/EfCoreUserCacheStore.cs
@@ -158,37 +158,59 @@ internal sealed class EfCoreUserCacheStore(
 
     // -- Write --
 
-    public async Task UpsertAsync(FederatedIdentity entry, CancellationToken cancellationToken = default)
+    public async Task<Guid> UpsertAsync(FederatedIdentity entry, CancellationToken cancellationToken = default)
     {
         // Keep EmailHash in sync with Email so admin search finds the row. Callers
         // may pre-compute this (CachedUserLookupService does), but the store also
         // recomputes defensively so direct consumers of UpsertAsync stay correct.
         entry.EmailHash = hasher.ComputeEmailHash(entry.Email);
 
-        await using IdentityFederatedDbContext db = await contextFactory
-            .CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
-
-        FederatedIdentity? existing = await db.FederatedIdentities
-            .FirstOrDefaultAsync(
-                e => e.TenantId == entry.TenantId && e.ExternalUserId == entry.ExternalUserId,
-                cancellationToken).ConfigureAwait(false);
-
-        if (existing is null)
+        // Upsert with one retry: two concurrent first-logins of the same (TenantId, ExternalUserId)
+        // — e.g. the same user hitting two pods — both miss the existing row and both insert,
+        // tripping the unique index. On that conflict, re-read and update the row the winner
+        // created instead of surfacing the DbUpdateException. Provider-agnostic (no ON CONFLICT).
+        // Returns the persisted row's Id so the caller can detect a lost insert race (persisted Id
+        // != entry.Id) and compensate — FederatedIdentityWriter deletes the orphaned canonical
+        // User it created for its losing insert. The second attempt's own DbUpdateException is not
+        // caught (filter is attempt == 0), so a genuine failure still surfaces and bounds the loop.
+        for (int attempt = 0; attempt <= 1; attempt++)
         {
-            db.FederatedIdentities.Add(entry);
-        }
-        else
-        {
-            existing.Username = entry.Username;
-            existing.Email = entry.Email;
-            existing.EmailHash = entry.EmailHash;
-            existing.FirstName = entry.FirstName;
-            existing.LastName = entry.LastName;
-            existing.Enabled = entry.Enabled;
-            existing.LastSyncedAt = entry.LastSyncedAt;
+            await using IdentityFederatedDbContext db = await contextFactory
+                .CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+
+            FederatedIdentity? existing = await db.FederatedIdentities
+                .FirstOrDefaultAsync(
+                    e => e.TenantId == entry.TenantId && e.ExternalUserId == entry.ExternalUserId,
+                    cancellationToken).ConfigureAwait(false);
+
+            if (existing is null)
+            {
+                db.FederatedIdentities.Add(entry);
+            }
+            else
+            {
+                existing.Username = entry.Username;
+                existing.Email = entry.Email;
+                existing.EmailHash = entry.EmailHash;
+                existing.FirstName = entry.FirstName;
+                existing.LastName = entry.LastName;
+                existing.Enabled = entry.Enabled;
+                existing.LastSyncedAt = entry.LastSyncedAt;
+            }
+
+            try
+            {
+                await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+                return existing?.Id ?? entry.Id;
+            }
+            catch (DbUpdateException) when (attempt == 0)
+            {
+                // Lost an insert race; loop once to re-read and update the winner's row.
+            }
         }
 
-        await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        // Unreachable: attempt 1 either returns or rethrows its own DbUpdateException.
+        throw new InvalidOperationException("UpsertAsync retry loop exited without persisting.");
     }
 
     public async Task UpsertManyAsync(

--- a/src/Granit.Identity.Federated/Internal/FederatedIdentityWriter.cs
+++ b/src/Granit.Identity.Federated/Internal/FederatedIdentityWriter.cs
@@ -79,14 +79,24 @@ internal sealed class FederatedIdentityWriter(
 
         await userDirectoryWriter.CreateAsync(canonical, cancellationToken).ConfigureAwait(false);
 
+        Guid persistedId;
         try
         {
-            await store.UpsertAsync(newEntry, cancellationToken).ConfigureAwait(false);
+            persistedId = await store.UpsertAsync(newEntry, cancellationToken).ConfigureAwait(false);
         }
         catch
         {
+            // Genuine store failure — the canonical User we just created would orphan; remove it.
             await userDirectoryWriter.DeleteAsync(newEntry.Id, cancellationToken).ConfigureAwait(false);
             throw;
+        }
+
+        if (persistedId != newEntry.Id)
+        {
+            // Lost a benign insert race: a concurrent write already created the row for this key
+            // (under the winner's own User), so our canonical User is orphaned — remove it. The
+            // winner's row now carries our data (the store's retry updated it), so no throw needed.
+            await userDirectoryWriter.DeleteAsync(newEntry.Id, cancellationToken).ConfigureAwait(false);
         }
 
         return newEntry;

--- a/src/Granit.Identity.Federated/Internal/IUserCacheStore.cs
+++ b/src/Granit.Identity.Federated/Internal/IUserCacheStore.cs
@@ -44,8 +44,13 @@ internal interface IUserCacheStore
 
     // -- Write --
 
-    /// <summary>Inserts or updates a single cache entry (matched by TenantId + ExternalUserId).</summary>
-    Task UpsertAsync(FederatedIdentity entry, CancellationToken cancellationToken = default);
+    /// <summary>
+    /// Inserts or updates a single cache entry (matched by TenantId + ExternalUserId) and returns
+    /// the persisted row's <c>Id</c>. When a concurrent insert wins the race for the same key, the
+    /// returned Id is the winner's — different from <paramref name="entry"/>.<c>Id</c> — so the
+    /// caller can compensate for any resources it pre-created against its own (losing) Id.
+    /// </summary>
+    Task<Guid> UpsertAsync(FederatedIdentity entry, CancellationToken cancellationToken = default);
 
     /// <summary>Inserts or updates multiple cache entries in batch.</summary>
     Task UpsertManyAsync(IReadOnlyList<FederatedIdentity> entries, CancellationToken cancellationToken = default);

--- a/src/Granit.Identity.Federated/Internal/UserCacheStats.cs
+++ b/src/Granit.Identity.Federated/Internal/UserCacheStats.cs
@@ -1,15 +1,14 @@
-using Granit.Identity.Federated.Internal;
 using Granit.Identity.Federated.Options;
 using Granit.MultiTenancy;
 using Microsoft.Extensions.Options;
 
-namespace Granit.Identity.Federated.EntityFrameworkCore.Internal;
+namespace Granit.Identity.Federated.Internal;
 
 /// <summary>
-/// EF Core implementation of <see cref="IUserCacheStats"/>.
-/// Delegates to <see cref="IUserCacheStore"/> for all queries.
+/// Default <see cref="IUserCacheStats"/> implementation: tenant-scoped counts and sync range
+/// derived by delegating to <see cref="IUserCacheStore"/> — no EF Core types of its own.
 /// </summary>
-internal sealed class EfCoreUserCacheStats(
+internal sealed class UserCacheStats(
     IUserCacheStore store,
     ICurrentTenant currentTenant,
     TimeProvider timeProvider,

--- a/tests/Granit.Identity.Federated.EntityFrameworkCore.Tests/EfCoreUserCacheStoreTests.cs
+++ b/tests/Granit.Identity.Federated.EntityFrameworkCore.Tests/EfCoreUserCacheStoreTests.cs
@@ -91,13 +91,15 @@ public sealed class EfCoreUserCacheStoreTests : IDisposable
     }
 
     [Fact]
-    public async Task UpsertAsync_InsertsNewEntry()
+    public async Task UpsertAsync_InsertsNewEntry_AndReturnsItsId()
     {
         EfCoreUserCacheStore store = CreateStore();
         FederatedIdentity entry = CreateEntry();
 
-        await store.UpsertAsync(entry, TestContext.Current.CancellationToken);
+        Guid persistedId = await store.UpsertAsync(entry, TestContext.Current.CancellationToken);
 
+        // A clean insert returns our own Id — the writer reads this to know no race happened.
+        persistedId.ShouldBe(entry.Id);
         FederatedIdentity? found = await store.FindByExternalIdAsync(
             "user-1", null, TestContext.Current.CancellationToken);
         found.ShouldNotBeNull();
@@ -105,15 +107,20 @@ public sealed class EfCoreUserCacheStoreTests : IDisposable
     }
 
     [Fact]
-    public async Task UpsertAsync_UpdatesExistingEntry()
+    public async Task UpsertAsync_UpdatesExistingEntry_AndReturnsExistingId()
     {
         EfCoreUserCacheStore store = CreateStore();
         FederatedIdentity entry = CreateEntry();
         await store.UpsertAsync(entry, TestContext.Current.CancellationToken);
 
+        // A second upsert for the same (tenant, external id) but a DIFFERENT row Id must resolve
+        // onto the existing row and return the EXISTING Id — the signal the writer uses to detect a
+        // lost insert race and compensate its orphaned canonical User.
         FederatedIdentity updated = CreateEntry(username: "jdoe-updated", email: "updated@test.com");
-        await store.UpsertAsync(updated, TestContext.Current.CancellationToken);
+        Guid persistedId = await store.UpsertAsync(updated, TestContext.Current.CancellationToken);
 
+        persistedId.ShouldBe(entry.Id);
+        persistedId.ShouldNotBe(updated.Id);
         FederatedIdentity? found = await store.FindByExternalIdAsync(
             "user-1", null, TestContext.Current.CancellationToken);
         found.ShouldNotBeNull();

--- a/tests/Granit.Identity.Federated.EntityFrameworkCore.Tests/IdentityEfCoreDiRegistrationTests.cs
+++ b/tests/Granit.Identity.Federated.EntityFrameworkCore.Tests/IdentityEfCoreDiRegistrationTests.cs
@@ -39,7 +39,7 @@ public sealed class IdentityEfCoreDiRegistrationTests
         lookupService.ShouldBeOfType<CachedUserLookupService>();
 
         IUserCacheStats stats = provider.GetRequiredService<IUserCacheStats>();
-        stats.ShouldBeOfType<EfCoreUserCacheStats>();
+        stats.ShouldBeOfType<UserCacheStats>();
 
         IUserCacheStore store = provider.GetRequiredService<IUserCacheStore>();
         store.ShouldBeOfType<EfCoreUserCacheStore>();

--- a/tests/Granit.Identity.Federated.Tests/Internal/FederatedIdentityWriterTests.cs
+++ b/tests/Granit.Identity.Federated.Tests/Internal/FederatedIdentityWriterTests.cs
@@ -37,6 +37,9 @@ public sealed class FederatedIdentityWriterTests
         _tenant.IsAvailable.Returns(true);
         _tenant.Id.Returns(Guid.NewGuid());
         _timeProvider.GetUtcNow().Returns(DateTimeOffset.UtcNow);
+        // Default: the store persists our row and returns our own Id (no insert race).
+        _store.UpsertAsync(Arg.Any<FederatedIdentity>(), Arg.Any<CancellationToken>())
+            .Returns(ci => ci.Arg<FederatedIdentity>().Id);
     }
 
     [Fact]
@@ -90,14 +93,47 @@ public sealed class FederatedIdentityWriterTests
 
         FederatedIdentityWriter writer = CreateWriter();
 
-        // The canonical User is created first; if the cache insert throws, the freshly-created
-        // user must be hard-deleted so the directory does not orphan it. The exception surfaces.
+        // The canonical User is created first; if the cache insert throws (a genuine store
+        // failure), the freshly-created user must be hard-deleted and the exception surfaces.
         await Should.ThrowAsync<InvalidOperationException>(() =>
             writer.WriteAsync(CreateUser(), existing: null, TestContext.Current.CancellationToken));
 
         await _userDirectoryWriter.Received(1).CreateAsync(
             Arg.Is<User>(u => u.Id == generatedId), Arg.Any<CancellationToken>());
         await _userDirectoryWriter.Received(1).DeleteAsync(generatedId, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task WriteAsync_CompensatesUserDelete_WithoutThrowing_OnBenignInsertRace()
+    {
+        // A concurrent first-login won the insert race: the store resolved the conflict by
+        // updating the winner's row (which points at the winner's own User) and returns the
+        // winner's Id — different from ours. Our canonical User is now orphaned; the writer must
+        // delete it silently (no throw — the row exists and carries our data).
+        var ourId = Guid.NewGuid();
+        var winnerId = Guid.NewGuid();
+        _guidGenerator.Create().Returns(ourId);
+        _store.UpsertAsync(Arg.Any<FederatedIdentity>(), Arg.Any<CancellationToken>())
+            .Returns(winnerId);
+
+        FederatedIdentityWriter writer = CreateWriter();
+        await writer.WriteAsync(CreateUser(), existing: null, TestContext.Current.CancellationToken);
+
+        await _userDirectoryWriter.Received(1).CreateAsync(
+            Arg.Is<User>(u => u.Id == ourId), Arg.Any<CancellationToken>());
+        await _userDirectoryWriter.Received(1).DeleteAsync(ourId, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task WriteAsync_DoesNotCompensate_OnSuccessfulInsert()
+    {
+        var generatedId = Guid.NewGuid();
+        _guidGenerator.Create().Returns(generatedId);
+
+        FederatedIdentityWriter writer = CreateWriter();
+        await writer.WriteAsync(CreateUser(), existing: null, TestContext.Current.CancellationToken);
+
+        await _userDirectoryWriter.DidNotReceiveWithAnyArgs().DeleteAsync(default, TestContext.Current.CancellationToken);
     }
 
     [Fact]

--- a/tests/Granit.Identity.Federated.Tests/Internal/UserCacheStatsTests.cs
+++ b/tests/Granit.Identity.Federated.Tests/Internal/UserCacheStatsTests.cs
@@ -1,25 +1,23 @@
-using Granit.Identity.Federated.EntityFrameworkCore.Internal;
 using Granit.Identity.Federated.Internal;
 using Granit.Identity.Federated.Options;
 using Granit.MultiTenancy;
-using Granit.Testing.Fakes;
 using NSubstitute;
 using Shouldly;
 using Xunit;
 
-namespace Granit.Identity.Federated.EntityFrameworkCore.Tests;
+namespace Granit.Identity.Federated.Tests.Internal;
 
-public sealed class EfCoreUserCacheStatsTests
+public sealed class UserCacheStatsTests
 {
     private readonly IUserCacheStore _store = Substitute.For<IUserCacheStore>();
     private readonly ICurrentTenant _currentTenant = Substitute.For<ICurrentTenant>();
-    private readonly FakeTimeProvider _timeProvider = new();
-    private readonly EfCoreUserCacheStats _stats;
+    private readonly TimeProvider _timeProvider = Substitute.For<TimeProvider>();
+    private readonly UserCacheStats _stats;
 
-    public EfCoreUserCacheStatsTests()
+    public UserCacheStatsTests()
     {
         UserCacheOptions options = new() { StalenessThreshold = TimeSpan.FromHours(24) };
-        _stats = new EfCoreUserCacheStats(
+        _stats = new UserCacheStats(
             _store,
             _currentTenant,
             _timeProvider,
@@ -56,7 +54,7 @@ public sealed class EfCoreUserCacheStatsTests
     public async Task GetStaleCountAsync_ComputesThreshold()
     {
         DateTimeOffset now = new(2026, 3, 21, 12, 0, 0, TimeSpan.Zero);
-        _timeProvider.SetUtcNow(now);
+        _timeProvider.GetUtcNow().Returns(now);
         _currentTenant.IsAvailable.Returns(false);
 
         DateTimeOffset expectedThreshold = now - TimeSpan.FromHours(24);


### PR DESCRIPTION
## Context

Vague 4c of the **Granit.Identity\* overhaul** ([EPIC #3057](https://github.com/granit-fx/granit-dotnet/issues/3057), [FEATURE #3062](https://github.com/granit-fx/granit-dotnet/issues/3062)) — the cleanups deferred out of the write-path unification ([#3080](https://github.com/granit-fx/granit-dotnet/pull/3080)).

## What changed

- **Replica-safe upsert.** `IUserCacheStore.UpsertAsync` now returns the persisted row's `Id` and resolves the find-then-add race with one retry (re-read + update the winner's row on a unique `(TenantId, ExternalUserId)` conflict) instead of surfacing a `DbUpdateException` on concurrent first-logins across pods. `FederatedIdentityWriter` reads the returned Id: on a **lost insert race** the winner's row already carries our data under the winner's canonical `User`, so the writer **silently deletes the orphaned `User`** it created for its losing insert (no throw); a **genuine store failure** still throws and compensates. Provider-agnostic (no `ON CONFLICT`); matches the session-store retry pattern.
- **`EfCoreUserCacheStats` → base module.** It had no EF Core usage (delegates entirely to `IUserCacheStore`), so it moves to `Granit.Identity.Federated` and is renamed **`UserCacheStats`** (the `EfCore` prefix was a misnomer — audit ARCHITECTURE finding). DI registration and test move with it.

## Not done — audit false positive

The planned `IdentityFederatedDbContext` `ICurrentTenant?` ctor rider was **reverted**: the reference `IdentityDbContext` (which also owns an `IMultiTenant` entity) injects a **non-null** `ICurrentTenant` because the `GranitDbContext` base requires one. `IdentityFederatedDbContext` already matches that convention, so the finding doesn't apply.

## Testing

- New cover: `UpsertAsync` returns its own Id on insert and the **existing** Id on a same-key/different-Id update (the signal the writer's compensation reads); the writer compensates **without throwing** on a benign race and **does not** compensate on a clean insert.
- **Architecture suite green (262/262)**.
- `Granit.Identity.Federated.Tests` 64/64, `.EntityFrameworkCore.Tests` 22/22 (the 4 stats tests moved to the base test project). `dotnet format` clean. **No lock changes.**

This completes G5 (the federated write path) across Vagues 4a/4b/4c.

## Breaking

- `IUserCacheStore.UpsertAsync` return type `Task` → `Task<Guid>` (internal contract; the only production caller is `FederatedIdentityWriter`). Pre-1.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)