### PR TITLE
feat(imaging-ai)!: rebuild LlmImageAnalyzer on IStructuredCompletion; MaxImageBytes

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -33762,6 +33762,12 @@
           "kind": "property",
           "signature": "string? WorkspaceName",
           "returnType": "string?"
+        },
+        {
+          "name": "MaxImageBytes",
+          "kind": "property",
+          "signature": "long MaxImageBytes",
+          "returnType": "long"
         }
       ]
     },

--- a/src/Granit.Imaging.AI/Internal/LlmAnalysisResponse.cs
+++ b/src/Granit.Imaging.AI/Internal/LlmAnalysisResponse.cs
@@ -1,0 +1,12 @@
+namespace Granit.Imaging.AI.Internal;
+
+/// <summary>
+/// Wire shape of the LLM image-analysis response, produced and deserialized by the
+/// structured-output primitive (camelCase, case-insensitive). Sanitized into the public
+/// <see cref="ImageAnalysis"/> by <see cref="LlmImageAnalyzer"/>.
+/// </summary>
+internal sealed record LlmAnalysisResponse(
+    string? Description,
+    IReadOnlyList<string>? DetectedObjects,
+    IReadOnlyList<string>? Tags,
+    string? SuggestedAltText);

--- a/src/Granit.Imaging.AI/Internal/LlmImageAnalyzer.cs
+++ b/src/Granit.Imaging.AI/Internal/LlmImageAnalyzer.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics;
-using System.Text.Json;
 using System.Text.RegularExpressions;
 using Granit.AI;
 using Granit.Imaging.AI.Diagnostics;
@@ -11,30 +10,23 @@ using Microsoft.Extensions.Options;
 namespace Granit.Imaging.AI.Internal;
 
 /// <summary>
-/// Multimodal LLM-based implementation of <see cref="IAIImageAnalyzer"/>.
-/// Sends image bytes as a <see cref="DataContent"/> message to a vision-capable model.
+/// Multimodal implementation of <see cref="IAIImageAnalyzer"/> riding the ADR-064
+/// structured-output primitive: schema pinning, fence-strip fallback, PII-safe failure
+/// mapping, quota, and usage stamping all come from <see cref="IStructuredCompletion"/>.
+/// The model output is still treated as untrusted and sanitized before it reaches callers.
 /// </summary>
 internal sealed partial class LlmImageAnalyzer(
-    IAIChatClientFactory chatClientFactory,
+    IStructuredCompletion structuredCompletion,
     IOptions<ImagingAIOptions> options,
     ImagingAIMetrics metrics,
     ILogger<LlmImageAnalyzer> logger) : IAIImageAnalyzer
 {
-    private const string AnalysisPrompt = """
-        Analyze this image and return a JSON object with the following structure:
-        {
-          "description": "A detailed natural-language description of the image content",
-          "detectedObjects": ["list", "of", "objects", "in", "the", "image"],
-          "tags": ["semantic", "tags", "for", "classification"],
-          "suggestedAltText": "Concise alt text for accessibility (WCAG 2.1)"
-        }
-        Return ONLY the JSON object, no markdown fences, no explanation.
-        """;
-
-    private static readonly JsonSerializerOptions JsonOptions = new()
-    {
-        PropertyNameCaseInsensitive = true,
-    };
+    // Task instruction only — the output shape is pinned by the primitive's JSON schema
+    // (provider-enforced when the model supports structured output, in-prompt otherwise).
+    private const string AnalysisInstruction =
+        "Analyze the attached image. Produce a detailed natural-language description of its "
+        + "content, the list of objects it contains, semantic tags for classification and "
+        + "search, and a concise suggested alt text for accessibility (WCAG 2.1).";
 
     private static readonly HashSet<string> AllowedContentTypes =
         ["image/jpeg", "image/png", "image/webp", "image/avif", "image/gif", "image/bmp", "image/tiff"];
@@ -48,6 +40,18 @@ internal sealed partial class LlmImageAnalyzer(
         ArgumentNullException.ThrowIfNull(contentType);
 
         ImagingAIOptions opts = options.Value;
+
+        // First statement, before any DataContent is built: the image arrives already
+        // materialized (the byte source owns the original allocation guard), but failing
+        // here avoids the ~1.33x base64 expansion, the provider serialization, and a
+        // wasted round-trip.
+        if (opts.MaxImageBytes > 0 && imageData.Length > opts.MaxImageBytes)
+        {
+            throw new ArgumentException(
+                $"Image size ({imageData.Length} bytes) exceeds the configured MaxImageBytes ({opts.MaxImageBytes}).",
+                nameof(imageData));
+        }
+
         string normalizedContentType = NormalizeContentType(contentType);
         long startTimestamp = Stopwatch.GetTimestamp();
 
@@ -59,28 +63,23 @@ internal sealed partial class LlmImageAnalyzer(
 
         try
         {
-            // CreateAsync builds a fresh client per call (no cache) — dispose
-            // deterministically so the HttpMessageHandler doesn't linger until GC.
-            using IChatClient client = await chatClientFactory
-                .CreateAsync(opts.WorkspaceName, cancellationToken)
-                .ConfigureAwait(false);
-
-            var message = new ChatMessage(ChatRole.User,
-            [
-                new TextContent(AnalysisPrompt),
-                new DataContent(imageData, contentType),
-            ]);
-
+            // Two timeouts stack here: this one (Imaging:AI TimeoutSeconds) and the
+            // primitive's StructuredCompletionOptions.TimeoutSeconds — the lower wins.
             using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
             timeoutCts.CancelAfter(TimeSpan.FromSeconds(opts.TimeoutSeconds));
 
-            ChatResponse response = await client
-                .GetResponseAsync([message], cancellationToken: timeoutCts.Token)
+            StructuredCompletionResult<LlmAnalysisResponse> completion = await structuredCompletion
+                .CompleteAsync<LlmAnalysisResponse>(
+                    new StructuredCompletionRequest
+                    {
+                        Instruction = AnalysisInstruction,
+                        Attachments = [new DataContent(imageData, contentType)],
+                        WorkspaceName = opts.WorkspaceName,
+                    },
+                    timeoutCts.Token)
                 .ConfigureAwait(false);
 
-            string json = response.Text ?? throw new InvalidOperationException("The AI model returned an empty response.");
-
-            ImageAnalysis result = Deserialize(json);
+            ImageAnalysis result = MapResult(completion);
 
             metrics.RecordAnalysisCompleted(tenantId: null, normalizedContentType);
             metrics.RecordAnalysisDuration(tenantId: null, normalizedContentType, Stopwatch.GetElapsedTime(startTimestamp));
@@ -99,33 +98,26 @@ internal sealed partial class LlmImageAnalyzer(
     private static string NormalizeContentType(string contentType) =>
         AllowedContentTypes.Contains(contentType) ? contentType : "other";
 
-    private static ImageAnalysis Deserialize(string json)
-    {
-        // Strip markdown fences if the model wraps the JSON despite instructions
-        ReadOnlySpan<char> trimmed = json.AsSpan().Trim();
-        if (trimmed.StartsWith("```"))
+    // Preserves the analyzer's exception-based contract over the primitive's status codes;
+    // ErrorMessage is PII-safe by the primitive's contract (never echoes model output).
+    private static ImageAnalysis MapResult(StructuredCompletionResult<LlmAnalysisResponse> completion) =>
+        completion.Status switch
         {
-            int firstNewline = trimmed.IndexOf('\n');
-            if (firstNewline >= 0)
-            {
-                trimmed = trimmed[(firstNewline + 1)..];
-            }
+            StructuredCompletionStatus.Succeeded => Sanitize(completion.Value!),
+            StructuredCompletionStatus.ModelRefused =>
+                throw new InvalidOperationException("The AI model returned an empty response."),
+            StructuredCompletionStatus.SchemaViolation =>
+                throw new InvalidOperationException("Failed to parse the AI model response as JSON."),
+            _ => throw new InvalidOperationException(
+                completion.ErrorMessage ?? "The AI request failed due to a transport or provider error."),
+        };
 
-            if (trimmed.EndsWith("```"))
-            {
-                trimmed = trimmed[..^3].TrimEnd();
-            }
-        }
-
-        LlmAnalysisResponse? parsed = JsonSerializer.Deserialize<LlmAnalysisResponse>(trimmed, JsonOptions)
-            ?? throw new InvalidOperationException("Failed to parse the AI model response as JSON.");
-
-        return new ImageAnalysis(
+    private static ImageAnalysis Sanitize(LlmAnalysisResponse parsed) =>
+        new(
             SanitizeText(parsed.Description),
             SanitizeList(parsed.DetectedObjects),
             SanitizeList(parsed.Tags),
             parsed.SuggestedAltText is not null ? SanitizeText(parsed.SuggestedAltText, 500) : null);
-    }
 
     private static string SanitizeText(string? value, int maxLength = 2000)
     {
@@ -163,13 +155,4 @@ internal sealed partial class LlmImageAnalyzer(
 
     [LoggerMessage(Level = LogLevel.Information, Message = "AI image analysis completed (objects={ObjectCount}, tags={TagCount})")]
     private partial void LogAnalysisCompleted(int objectCount, int tagCount);
-
-    /// <summary>
-    /// Internal DTO for deserializing the LLM JSON response.
-    /// </summary>
-    private sealed record LlmAnalysisResponse(
-        string? Description,
-        IReadOnlyList<string>? DetectedObjects,
-        IReadOnlyList<string>? Tags,
-        string? SuggestedAltText);
 }

--- a/src/Granit.Imaging.AI/Options/ImagingAIOptions.cs
+++ b/src/Granit.Imaging.AI/Options/ImagingAIOptions.cs
@@ -24,5 +24,21 @@ public sealed class ImagingAIOptions
     /// <summary>
     /// Timeout in seconds for a single image analysis request.
     /// </summary>
+    /// <remarks>
+    /// The analysis path also runs under the structured-completion primitive's own
+    /// <c>StructuredCompletionOptions.TimeoutSeconds</c> — the lower of the two wins.
+    /// </remarks>
     public int TimeoutSeconds { get; set; } = 15;
+
+    /// <summary>
+    /// Maximum image size in bytes accepted by the AI analysis/extraction paths.
+    /// Default: 10 MB. Set to <c>0</c> to disable the guard.
+    /// </summary>
+    /// <remarks>
+    /// This is a fail-fast guard, not an allocation guard: the image reaches this module
+    /// already materialized in memory (the byte source — HTTP limits, BlobStorage
+    /// <c>MaxInputBytes</c> — owns that). Failing here avoids the ~1.33x base64 expansion,
+    /// the provider serialization, and a wasted round-trip to the model.
+    /// </remarks>
+    public long MaxImageBytes { get; set; } = 10 * 1024 * 1024;
 }

--- a/src/Granit.Imaging.AI/Options/ImagingAIOptionsValidator.cs
+++ b/src/Granit.Imaging.AI/Options/ImagingAIOptionsValidator.cs
@@ -18,6 +18,12 @@ internal sealed class ImagingAIOptionsValidator : IValidateOptions<ImagingAIOpti
                 $"{nameof(options.TimeoutSeconds)} must be between 1 and {MaxTimeoutSeconds} seconds.");
         }
 
+        if (options.MaxImageBytes < 0)
+        {
+            return ValidateOptionsResult.Fail(
+                $"{nameof(options.MaxImageBytes)} must be >= 0 (0 = disabled).");
+        }
+
         return ValidateOptionsResult.Success;
     }
 }

--- a/tests/Granit.ArchitectureTests/StructuredCompletionBypassTests.cs
+++ b/tests/Granit.ArchitectureTests/StructuredCompletionBypassTests.cs
@@ -32,11 +32,6 @@ public sealed partial class StructuredCompletionBypassTests
         // The IStructuredCompletion implementation itself — it owns GetResponseAsync + Deserialize<T>
         // precisely so every other .AI module does not have to (ADR-064).
         "Granit.AI/Internal/DefaultStructuredCompletion.cs",
-
-        // Multimodal vision: the image travels as MEAI DataContent (raw bytes), which the text-only
-        // structured-completion primitive cannot carry. This analyzer legitimately calls
-        // GetResponseAsync + Deserialize<T>. Revisit if a multimodal primitive lands (ADR-064 follow-up).
-        "Granit.Imaging.AI/Internal/LlmImageAnalyzer.cs",
     };
 
     [Fact]

--- a/tests/Granit.Imaging.AI.Tests/ImagingAIOptionsValidatorTests.cs
+++ b/tests/Granit.Imaging.AI.Tests/ImagingAIOptionsValidatorTests.cs
@@ -25,4 +25,14 @@ public sealed class ImagingAIOptionsValidatorTests
     public void Boundary_timeouts_pass(int timeoutSeconds) =>
         _validator.Validate(null, new ImagingAIOptions { TimeoutSeconds = timeoutSeconds })
             .Succeeded.ShouldBeTrue();
+
+    [Fact]
+    public void Negative_MaxImageBytes_fails() =>
+        _validator.Validate(null, new ImagingAIOptions { MaxImageBytes = -1 })
+            .Failed.ShouldBeTrue();
+
+    [Fact]
+    public void Zero_MaxImageBytes_means_disabled_and_passes() =>
+        _validator.Validate(null, new ImagingAIOptions { MaxImageBytes = 0 })
+            .Succeeded.ShouldBeTrue();
 }

--- a/tests/Granit.Imaging.AI.Tests/ImagingAIServiceRegistrationTests.cs
+++ b/tests/Granit.Imaging.AI.Tests/ImagingAIServiceRegistrationTests.cs
@@ -29,6 +29,7 @@ public sealed class ImagingAIServiceRegistrationTests
         // Minimal stand-in for Granit.AI: the scoped contracts the analyzer and the
         // vision text-extractor capture.
         builder.Services.TryAddScoped(_ => Substitute.For<IAIChatClientFactory>());
+        builder.Services.TryAddScoped(_ => Substitute.For<IStructuredCompletion>());
         builder.Services.TryAddScoped(_ => Substitute.For<IAIWorkspaceProvider>());
         builder.Services.TryAddScoped(_ => Substitute.For<IAIWorkspaceCapabilityResolver>());
 

--- a/tests/Granit.Imaging.AI.Tests/LlmAnalysisResponseSchemaTests.cs
+++ b/tests/Granit.Imaging.AI.Tests/LlmAnalysisResponseSchemaTests.cs
@@ -1,0 +1,50 @@
+using System.Text.Json;
+using Granit.Imaging.AI.Internal;
+using Microsoft.Extensions.AI;
+using Shouldly;
+
+namespace Granit.Imaging.AI.Tests;
+
+/// <summary>
+/// Locks the wire contract between <see cref="LlmAnalysisResponse"/> and the
+/// structured-completion primitive: camelCase/case-insensitive deserialization
+/// (the primitive's serializer settings) and JSON-schema generation must both work.
+/// </summary>
+public sealed class LlmAnalysisResponseSchemaTests
+{
+    private static readonly JsonSerializerOptions PrimitiveSerializerOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+    };
+
+    [Fact]
+    public void Deserializes_camelCase_json_like_the_primitive()
+    {
+        const string json = """
+            {
+                "description": "A red car",
+                "detectedObjects": ["car"],
+                "tags": ["outdoor"],
+                "suggestedAltText": "Red car"
+            }
+            """;
+
+        LlmAnalysisResponse? parsed = JsonSerializer.Deserialize<LlmAnalysisResponse>(json, PrimitiveSerializerOptions);
+
+        parsed.ShouldNotBeNull();
+        parsed.Description.ShouldBe("A red car");
+        parsed.DetectedObjects.ShouldBe(["car"]);
+        parsed.Tags.ShouldBe(["outdoor"]);
+        parsed.SuggestedAltText.ShouldBe("Red car");
+    }
+
+    [Fact]
+    public void Json_schema_generation_succeeds()
+    {
+        JsonElement schema = AIJsonUtilities.CreateJsonSchema(typeof(LlmAnalysisResponse));
+
+        schema.ValueKind.ShouldBe(JsonValueKind.Object);
+        schema.GetProperty("properties").TryGetProperty("description", out _).ShouldBeTrue();
+    }
+}

--- a/tests/Granit.Imaging.AI.Tests/LlmImageAnalyzerTests.cs
+++ b/tests/Granit.Imaging.AI.Tests/LlmImageAnalyzerTests.cs
@@ -13,8 +13,7 @@ namespace Granit.Imaging.AI.Tests;
 
 public sealed class LlmImageAnalyzerTests
 {
-    private readonly IAIChatClientFactory _chatClientFactory = Substitute.For<IAIChatClientFactory>();
-    private readonly IChatClient _chatClient = Substitute.For<IChatClient>();
+    private readonly IStructuredCompletion _structuredCompletion = Substitute.For<IStructuredCompletion>();
     private readonly ImagingAIMetrics _metrics = CreateTestMetrics();
     private readonly IOptions<ImagingAIOptions> _options = Microsoft.Extensions.Options.Options.Create(new ImagingAIOptions
     {
@@ -31,28 +30,31 @@ public sealed class LlmImageAnalyzerTests
 
     private static readonly ReadOnlyMemory<byte> TestImage = new byte[] { 0x89, 0x50, 0x4E, 0x47 };
 
-    public LlmImageAnalyzerTests()
-    {
-        _chatClientFactory.CreateAsync("vision", Arg.Any<CancellationToken>()).Returns(_chatClient);
-    }
+    private LlmImageAnalyzer CreateAnalyzer(ImagingAIOptions? options = null) =>
+        new(_structuredCompletion,
+            options is null ? _options : Microsoft.Extensions.Options.Options.Create(options),
+            _metrics,
+            NullLogger<LlmImageAnalyzer>.Instance);
+
+    private void SetupCompletion(StructuredCompletionResult<LlmAnalysisResponse> result) =>
+        _structuredCompletion
+            .CompleteAsync<LlmAnalysisResponse>(Arg.Any<StructuredCompletionRequest>(), Arg.Any<CancellationToken>())
+            .Returns(result);
+
+    private static StructuredCompletionResult<LlmAnalysisResponse> Succeeded(LlmAnalysisResponse value) =>
+        new() { Status = StructuredCompletionStatus.Succeeded, Value = value };
 
     [Fact]
-    public async Task AnalyzeAsync_ValidResponse_ReturnsImageAnalysis()
+    public async Task AnalyzeAsync_Succeeded_ReturnsSanitizedImageAnalysis()
     {
-        const string json = """
-            {
-                "description": "A red car parked on a street",
-                "detectedObjects": ["car", "street", "building"],
-                "tags": ["outdoor", "urban", "daytime"],
-                "suggestedAltText": "Red car parked on urban street"
-            }
-            """;
+        SetupCompletion(Succeeded(new LlmAnalysisResponse(
+            "A red car parked on a street",
+            ["car", "street", "building"],
+            ["outdoor", "urban", "daytime"],
+            "Red car parked on urban street")));
 
-        SetupChatResponse(json);
-
-        LlmImageAnalyzer analyzer = CreateAnalyzer();
-
-        ImageAnalysis result = await analyzer.AnalyzeAsync(TestImage, "image/png", TestContext.Current.CancellationToken);
+        ImageAnalysis result = await CreateAnalyzer()
+            .AnalyzeAsync(TestImage, "image/png", TestContext.Current.CancellationToken);
 
         result.Description.ShouldBe("A red car parked on a street");
         result.DetectedObjects.ShouldBe(["car", "street", "building"]);
@@ -61,129 +63,124 @@ public sealed class LlmImageAnalyzerTests
     }
 
     [Fact]
-    public async Task AnalyzeAsync_ResponseWithMarkdownFences_ParsesCorrectly()
+    public async Task AnalyzeAsync_SendsImageAsAttachmentWithConfiguredWorkspace()
     {
-        const string json = """
-            ```json
-            {
-                "description": "A cat sitting on a windowsill",
-                "detectedObjects": ["cat", "window"],
-                "tags": ["indoor", "pet"],
-                "suggestedAltText": "Cat on windowsill"
-            }
-            ```
-            """;
+        StructuredCompletionRequest? captured = null;
+        _structuredCompletion
+            .CompleteAsync<LlmAnalysisResponse>(
+                Arg.Do<StructuredCompletionRequest>(r => captured = r),
+                Arg.Any<CancellationToken>())
+            .Returns(Succeeded(new LlmAnalysisResponse("d", [], [], null)));
 
-        SetupChatResponse(json);
+        await CreateAnalyzer().AnalyzeAsync(TestImage, "image/webp", TestContext.Current.CancellationToken);
 
-        LlmImageAnalyzer analyzer = CreateAnalyzer();
-
-        ImageAnalysis result = await analyzer.AnalyzeAsync(TestImage, "image/jpeg", TestContext.Current.CancellationToken);
-
-        result.Description.ShouldBe("A cat sitting on a windowsill");
-        result.DetectedObjects.Count.ShouldBe(2);
+        captured.ShouldNotBeNull();
+        captured.WorkspaceName.ShouldBe("vision");
+        captured.Instruction.ShouldNotBeNullOrWhiteSpace();
+        // Schema pinning is the primitive's job — the instruction must not hand-roll a JSON shape.
+        captured.Instruction.ShouldNotContain("JSON");
+        DataContent attachment = captured.Attachments.ShouldHaveSingleItem();
+        attachment.MediaType.ShouldBe("image/webp");
+        attachment.Data.Span.SequenceEqual(TestImage.Span).ShouldBeTrue();
     }
 
     [Fact]
-    public async Task AnalyzeAsync_NullAltText_ReturnsNullSuggestedAltText()
+    public async Task AnalyzeAsync_SanitizesModelOutput()
     {
-        const string json = """
-            {
-                "description": "Abstract art",
-                "detectedObjects": [],
-                "tags": ["abstract"],
-                "suggestedAltText": null
-            }
-            """;
+        SetupCompletion(Succeeded(new LlmAnalysisResponse(
+            "desc\u0001with\u0002control chars",
+            ["ok", "\u0003", new string('x', 500)],
+            null,
+            new string('y', 900))));
 
-        SetupChatResponse(json);
+        ImageAnalysis result = await CreateAnalyzer()
+            .AnalyzeAsync(TestImage, "image/png", TestContext.Current.CancellationToken);
 
-        LlmImageAnalyzer analyzer = CreateAnalyzer();
+        result.Description.ShouldBe("descwithcontrol chars");
+        result.DetectedObjects.Count.ShouldBe(2); // control-char-only entry dropped
+        result.DetectedObjects[1].Length.ShouldBe(200); // item length cap
+        result.Tags.ShouldBeEmpty();
+        result.SuggestedAltText!.Length.ShouldBe(500); // alt text cap
+    }
+
+    [Fact]
+    public async Task AnalyzeAsync_ModelRefused_ThrowsInvalidOperation()
+    {
+        SetupCompletion(new StructuredCompletionResult<LlmAnalysisResponse>
+        {
+            Status = StructuredCompletionStatus.ModelRefused,
+        });
+
+        InvalidOperationException ex = await Should.ThrowAsync<InvalidOperationException>(
+            () => CreateAnalyzer().AnalyzeAsync(TestImage, "image/png", TestContext.Current.CancellationToken));
+
+        ex.Message.ShouldBe("The AI model returned an empty response.");
+    }
+
+    [Fact]
+    public async Task AnalyzeAsync_SchemaViolation_ThrowsInvalidOperation()
+    {
+        SetupCompletion(new StructuredCompletionResult<LlmAnalysisResponse>
+        {
+            Status = StructuredCompletionStatus.SchemaViolation,
+        });
+
+        InvalidOperationException ex = await Should.ThrowAsync<InvalidOperationException>(
+            () => CreateAnalyzer().AnalyzeAsync(TestImage, "image/png", TestContext.Current.CancellationToken));
+
+        ex.Message.ShouldBe("Failed to parse the AI model response as JSON.");
+    }
+
+    [Fact]
+    public async Task AnalyzeAsync_TransportFailure_ThrowsWithPiiSafeMessage()
+    {
+        SetupCompletion(new StructuredCompletionResult<LlmAnalysisResponse>
+        {
+            Status = StructuredCompletionStatus.TransportFailure,
+            ErrorMessage = "The AI request timed out after 30 seconds.",
+        });
+
+        InvalidOperationException ex = await Should.ThrowAsync<InvalidOperationException>(
+            () => CreateAnalyzer().AnalyzeAsync(TestImage, "image/png", TestContext.Current.CancellationToken));
+
+        ex.Message.ShouldBe("The AI request timed out after 30 seconds.");
+    }
+
+    [Fact]
+    public async Task AnalyzeAsync_OversizedImage_FailsFastWithoutCallingThePrimitive()
+    {
+        LlmImageAnalyzer analyzer = CreateAnalyzer(new ImagingAIOptions
+        {
+            WorkspaceName = "vision",
+            TimeoutSeconds = 30,
+            MaxImageBytes = 2,
+        });
+
+        await Should.ThrowAsync<ArgumentException>(
+            () => analyzer.AnalyzeAsync(TestImage, "image/png", TestContext.Current.CancellationToken));
+
+        await _structuredCompletion.DidNotReceive().CompleteAsync<LlmAnalysisResponse>(
+            Arg.Any<StructuredCompletionRequest>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task AnalyzeAsync_ZeroMaxImageBytes_DisablesTheGuard()
+    {
+        SetupCompletion(Succeeded(new LlmAnalysisResponse("d", [], [], null)));
+        LlmImageAnalyzer analyzer = CreateAnalyzer(new ImagingAIOptions
+        {
+            WorkspaceName = "vision",
+            TimeoutSeconds = 30,
+            MaxImageBytes = 0,
+        });
 
         ImageAnalysis result = await analyzer.AnalyzeAsync(TestImage, "image/png", TestContext.Current.CancellationToken);
 
-        result.SuggestedAltText.ShouldBeNull();
-        result.DetectedObjects.ShouldBeEmpty();
+        result.ShouldNotBeNull();
     }
 
     [Fact]
-    public async Task AnalyzeAsync_InvalidJsonResponse_ThrowsJsonException()
-    {
-        SetupChatResponse("not valid json");
-
-        LlmImageAnalyzer analyzer = CreateAnalyzer();
-
-        await Should.ThrowAsync<System.Text.Json.JsonException>(
-            () => analyzer.AnalyzeAsync(TestImage, "image/png", TestContext.Current.CancellationToken));
-    }
-
-    [Fact]
-    public async Task AnalyzeAsync_NullContentType_ThrowsArgumentNullException()
-    {
-        LlmImageAnalyzer analyzer = CreateAnalyzer();
-
+    public async Task AnalyzeAsync_NullContentType_ThrowsArgumentNullException() =>
         await Should.ThrowAsync<ArgumentNullException>(
-            () => analyzer.AnalyzeAsync(TestImage, null!, TestContext.Current.CancellationToken));
-    }
-
-    [Fact]
-    public async Task AnalyzeAsync_UsesConfiguredWorkspaceName()
-    {
-        const string json = """
-            {
-                "description": "Test",
-                "detectedObjects": [],
-                "tags": [],
-                "suggestedAltText": null
-            }
-            """;
-
-        SetupChatResponse(json);
-
-        LlmImageAnalyzer analyzer = CreateAnalyzer();
-
-        await analyzer.AnalyzeAsync(TestImage, "image/png", TestContext.Current.CancellationToken);
-
-        await _chatClientFactory.Received(1).CreateAsync("vision", Arg.Any<CancellationToken>());
-    }
-
-    [Fact]
-    public async Task AnalyzeAsync_SendsImageDataAsChatMessage()
-    {
-        const string json = """
-            {
-                "description": "Test image",
-                "detectedObjects": [],
-                "tags": [],
-                "suggestedAltText": null
-            }
-            """;
-
-        SetupChatResponse(json);
-
-        LlmImageAnalyzer analyzer = CreateAnalyzer();
-
-        await analyzer.AnalyzeAsync(TestImage, "image/webp", TestContext.Current.CancellationToken);
-
-        await _chatClient.Received(1).GetResponseAsync(
-            Arg.Is<IEnumerable<ChatMessage>>(msgs =>
-                msgs.Any(m => m.Role == ChatRole.User &&
-                    m.Contents.OfType<DataContent>().Any(dc => dc.MediaType == "image/webp") &&
-                    m.Contents.OfType<TextContent>().Any())),
-            Arg.Any<ChatOptions>(),
-            Arg.Any<CancellationToken>());
-    }
-
-    private LlmImageAnalyzer CreateAnalyzer() =>
-        new(_chatClientFactory, _options, _metrics, NullLogger<LlmImageAnalyzer>.Instance);
-
-    private void SetupChatResponse(string? text)
-    {
-        ChatResponse response = new([new ChatMessage(ChatRole.Assistant, text)]);
-
-        _chatClient.GetResponseAsync(
-            Arg.Any<IEnumerable<ChatMessage>>(),
-            Arg.Any<ChatOptions>(),
-            Arg.Any<CancellationToken>()).Returns(response);
-    }
+            () => CreateAnalyzer().AnalyzeAsync(TestImage, null!, TestContext.Current.CancellationToken));
 }


### PR DESCRIPTION
## Summary

PR 6 shipped of the Imaging/AI redesign series (after #3083). Closes the audit's ARCHITECTURE finding #1 end-to-end: the one AI caller that had forgotten usage stamping now rides the full primitive stack.

- **`LlmImageAnalyzer` on `IStructuredCompletion`**: schema pinning (provider-enforced via `ForJsonSchema`, in-prompt fallback + fence-strip otherwise), PII-safe failure mapping, quota, and usage stamping (#3079) all come from the primitive. **Deleted**: hand-rolled JSON-shape prompt, manual fence stripping, `JsonSerializerOptions`, manual deserialize. **Kept**: output sanitization (control-char strip, length caps — model output stays untrusted), metrics, logging, activity. Public contract (`IAIImageAnalyzer`, `ImageAnalysis`) unchanged.
- **ADR-064 ratchet**: the `StructuredCompletionBypassTests` exemption for this file — whose comment literally says *"Revisit if a multimodal primitive lands (ADR-064 follow-up)"* — is removed in the same commit. Architecture shard green proves the analyzer no longer bypasses.
- **`ImagingAIOptions.MaxImageBytes`** (10 MB default, 0 = disabled): fail-fast **first statement**, before any `DataContent` is built — the image arrives already materialized (allocation guards belong to the byte source), but failing here avoids the ~1.33× base64 expansion and a wasted round-trip. Validator extended (`>= 0`).
- Status → exception mapping preserves the current messages; note the assumed normalization: malformed model JSON now throws `InvalidOperationException` instead of `JsonException`.
- Note: the same `MaxImageBytes` guard on `LlmImageTextExtractor` ships with the tenant/telemetry PR — adding it here would conflict with the in-flight #3085 which edits that file.

## Tests

`LlmImageAnalyzerTests` rewritten against `Substitute.For<IStructuredCompletion>()`: request shape (single `DataContent` + media type + workspace, instruction free of JSON-shape text), sanitization (control chars, list/alt-text caps), all three failure statuses, **fail-fast MaxImageBytes (primitive never called)**, zero-disables-guard. New `LlmAnalysisResponseSchemaTests` locks the camelCase wire contract + `AIJsonUtilities.CreateJsonSchema` generation.

Verified: `Granit.Imaging.AI.Tests` 31 ✅, architecture shard 262 ✅ (bypass ratchet), `dotnet format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)