### PR TITLE
feat(imaging): tenant-aware metrics and activity instrumentation

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -33673,7 +33673,7 @@
       "kind": "class",
       "project": "Granit.Imaging.AI",
       "file": "src/Granit.Imaging.AI/Extensions/ImagingAIHostApplicationBuilderExtensions.cs",
-      "line": 17,
+      "line": 18,
       "members": [
         {
           "name": "AddGranitImagingAI",

--- a/src/Granit.Imaging.AI/Diagnostics/ImagingAIActivitySource.cs
+++ b/src/Granit.Imaging.AI/Diagnostics/ImagingAIActivitySource.cs
@@ -10,4 +10,11 @@ internal static class ImagingAIActivitySource
 
     /// <summary>Shared activity source instance.</summary>
     internal static readonly ActivitySource Source = new(Name);
+
+    internal const string AnalyzeOperation = "imaging.ai.analyze";
+    internal const string ExtractTextOperation = "imaging.ai.extract_text";
+
+    internal const string TagContentType = "imaging.ai.content_type";
+    internal const string TagImageSizeBytes = "imaging.ai.image_size_bytes";
+    internal const string TagWorkspace = "imaging.ai.workspace";
 }

--- a/src/Granit.Imaging.AI/Extensions/ImagingAIHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Imaging.AI/Extensions/ImagingAIHostApplicationBuilderExtensions.cs
@@ -3,6 +3,7 @@ using Granit.Diagnostics;
 using Granit.Imaging.AI.Diagnostics;
 using Granit.Imaging.AI.Internal;
 using Granit.Imaging.AI.Options;
+using Granit.MultiTenancy;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
@@ -38,6 +39,8 @@ public static class ImagingAIHostApplicationBuilderExtensions
         builder.Services.TryAddEnumerable(
             ServiceDescriptor.Singleton<IValidateOptions<ImagingAIOptions>, ImagingAIOptionsValidator>());
 
+        // Soft multi-tenancy dependency: real implementation comes from Granit.MultiTenancy when present.
+        builder.Services.TryAddSingleton<ICurrentTenant>(NullTenantContext.Instance);
         builder.Services.TryAddSingleton<ImagingAIMetrics>();
         // Scoped because LlmImageAnalyzer depends on IAIChatClientFactory (scoped).
         // The analyzer carries no singleton-justifying state.

--- a/src/Granit.Imaging.AI/Internal/LlmImageAnalyzer.cs
+++ b/src/Granit.Imaging.AI/Internal/LlmImageAnalyzer.cs
@@ -3,6 +3,7 @@ using System.Text.RegularExpressions;
 using Granit.AI;
 using Granit.Imaging.AI.Diagnostics;
 using Granit.Imaging.AI.Options;
+using Granit.MultiTenancy;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -19,6 +20,7 @@ internal sealed partial class LlmImageAnalyzer(
     IStructuredCompletion structuredCompletion,
     IOptions<ImagingAIOptions> options,
     ImagingAIMetrics metrics,
+    ICurrentTenant currentTenant,
     ILogger<LlmImageAnalyzer> logger) : IAIImageAnalyzer
 {
     // Task instruction only — the output shape is pinned by the primitive's JSON schema
@@ -53,11 +55,13 @@ internal sealed partial class LlmImageAnalyzer(
         }
 
         string normalizedContentType = NormalizeContentType(contentType);
+        string? tenantId = currentTenant.IsAvailable ? currentTenant.Id?.ToString() : null;
         long startTimestamp = Stopwatch.GetTimestamp();
 
-        using Activity? activity = ImagingAIActivitySource.Source.StartActivity("ImageAnalysis.Analyze");
-        activity?.SetTag("imaging.ai.content_type", normalizedContentType);
-        activity?.SetTag("imaging.ai.image_size_bytes", imageData.Length);
+        using Activity? activity = ImagingAIActivitySource.Source
+            .StartActivity(ImagingAIActivitySource.AnalyzeOperation);
+        activity?.SetTag(ImagingAIActivitySource.TagContentType, normalizedContentType);
+        activity?.SetTag(ImagingAIActivitySource.TagImageSizeBytes, imageData.Length);
 
         LogAnalysisStarted(normalizedContentType, imageData.Length);
 
@@ -81,8 +85,8 @@ internal sealed partial class LlmImageAnalyzer(
 
             ImageAnalysis result = MapResult(completion);
 
-            metrics.RecordAnalysisCompleted(tenantId: null, normalizedContentType);
-            metrics.RecordAnalysisDuration(tenantId: null, normalizedContentType, Stopwatch.GetElapsedTime(startTimestamp));
+            metrics.RecordAnalysisCompleted(tenantId, normalizedContentType);
+            metrics.RecordAnalysisDuration(tenantId, normalizedContentType, Stopwatch.GetElapsedTime(startTimestamp));
 
             LogAnalysisCompleted(result.DetectedObjects.Count, result.Tags.Count);
 
@@ -90,7 +94,7 @@ internal sealed partial class LlmImageAnalyzer(
         }
         catch
         {
-            metrics.RecordAnalysisFailure(tenantId: null, normalizedContentType);
+            metrics.RecordAnalysisFailure(tenantId, normalizedContentType);
             throw;
         }
     }

--- a/src/Granit.Imaging.AI/Internal/LlmImageTextExtractor.cs
+++ b/src/Granit.Imaging.AI/Internal/LlmImageTextExtractor.cs
@@ -1,6 +1,8 @@
+using System.Diagnostics;
 using Granit.AI;
 using Granit.AI.Vision;
 using Granit.AI.Workspaces;
+using Granit.Imaging.AI.Diagnostics;
 using Granit.Imaging.AI.Options;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging;
@@ -43,6 +45,17 @@ internal sealed partial class LlmImageTextExtractor(
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(contentType);
 
+        ImagingAIOptions opts = options.Value;
+
+        // First check, before any workspace resolution or DataContent: the caller degrades
+        // gracefully on null, and failing here avoids the ~1.33x base64 expansion and a
+        // wasted provider round-trip (the byte source owns the original allocation guard).
+        if (opts.MaxImageBytes > 0 && imageData.Length > opts.MaxImageBytes)
+        {
+            LogImageTooLarge(imageData.Length, opts.MaxImageBytes);
+            return null;
+        }
+
         AIWorkspace? workspace = await ResolveVisionWorkspaceAsync(cancellationToken).ConfigureAwait(false);
         if (workspace is null)
         {
@@ -50,7 +63,11 @@ internal sealed partial class LlmImageTextExtractor(
             return null;
         }
 
-        ImagingAIOptions opts = options.Value;
+        using Activity? activity = ImagingAIActivitySource.Source
+            .StartActivity(ImagingAIActivitySource.ExtractTextOperation);
+        activity?.SetTag(ImagingAIActivitySource.TagContentType, contentType);
+        activity?.SetTag(ImagingAIActivitySource.TagImageSizeBytes, imageData.Length);
+        activity?.SetTag(ImagingAIActivitySource.TagWorkspace, workspace.Key);
 
         using IChatClient client = await chatClientFactory
             .CreateAsync(workspace.Key, cancellationToken)
@@ -103,4 +120,8 @@ internal sealed partial class LlmImageTextExtractor(
     [LoggerMessage(Level = LogLevel.Debug,
         Message = "No vision-capable AI workspace is configured; extract_text_from_image is unavailable.")]
     private partial void LogNoVisionWorkspace();
+
+    [LoggerMessage(Level = LogLevel.Warning,
+        Message = "Image of {SizeBytes} bytes exceeds MaxImageBytes ({MaxImageBytes}); extraction skipped.")]
+    private partial void LogImageTooLarge(int sizeBytes, long maxImageBytes);
 }

--- a/src/Granit.Imaging.MagickNet/Diagnostics/ImagingMagickNetActivitySource.cs
+++ b/src/Granit.Imaging.MagickNet/Diagnostics/ImagingMagickNetActivitySource.cs
@@ -10,4 +10,14 @@ internal static class ImagingMagickNetActivitySource
 
     /// <summary>Shared activity source instance.</summary>
     internal static readonly ActivitySource Source = new(Name);
+
+    internal const string LoadOperation = "imaging.load";
+    internal const string IdentifyOperation = "imaging.identify";
+    internal const string EncodeOperation = "imaging.encode";
+
+    internal const string TagSourceFormat = "imaging.source_format";
+    internal const string TagOutputFormat = "imaging.output_format";
+    internal const string TagWidth = "imaging.width";
+    internal const string TagHeight = "imaging.height";
+    internal const string TagInputBytes = "imaging.input_bytes";
 }

--- a/src/Granit.Imaging.MagickNet/Internal/MagickNetImagePipeline.cs
+++ b/src/Granit.Imaging.MagickNet/Internal/MagickNetImagePipeline.cs
@@ -1,5 +1,7 @@
 using System.Diagnostics;
 using Granit.Imaging.Diagnostics;
+using Granit.Imaging.MagickNet.Diagnostics;
+using Granit.MultiTenancy;
 using ImageMagick;
 
 namespace Granit.Imaging.MagickNet.Internal;
@@ -12,14 +14,16 @@ internal sealed class MagickNetImagePipeline : IImagePipeline
 {
     private readonly MagickImage _image;
     private readonly ImagingMetrics _metrics;
+    private readonly ICurrentTenant _currentTenant;
     private readonly long _startTimestamp;
     private int? _quality;
     private ImageFormat? _targetFormat;
 
-    internal MagickNetImagePipeline(MagickImage image, ImagingMetrics metrics)
+    internal MagickNetImagePipeline(MagickImage image, ImagingMetrics metrics, ICurrentTenant currentTenant)
     {
         _image = image;
         _metrics = metrics;
+        _currentTenant = currentTenant;
         _startTimestamp = Stopwatch.GetTimestamp();
         SourceSize = new ImageSize((int)_image.Width, (int)_image.Height);
         SourceFormat = MagickFormatMapper.FromMagickFormat(_image.Format);
@@ -155,6 +159,7 @@ internal sealed class MagickNetImagePipeline : IImagePipeline
         ApplyOutputSettings();
 
         ImageFormat outputFormat = _targetFormat ?? SourceFormat;
+        using Activity? activity = StartEncodeActivity(outputFormat);
 
         // ToByteArray encodes straight from the native blob into a single managed array —
         // no intermediate MemoryStream + ToArray() double copy. Encoding is CPU-bound.
@@ -177,9 +182,21 @@ internal sealed class MagickNetImagePipeline : IImagePipeline
         ApplyOutputSettings();
 
         ImageFormat outputFormat = _targetFormat ?? SourceFormat;
+        using Activity? activity = StartEncodeActivity(outputFormat);
+
         await _image.WriteAsync(destination, MagickFormatMapper.ToMagickFormat(outputFormat), cancellationToken).ConfigureAwait(false);
 
         RecordMetrics(outputFormat);
+    }
+
+    private Activity? StartEncodeActivity(ImageFormat outputFormat)
+    {
+        Activity? activity = ImagingMagickNetActivitySource.Source
+            .StartActivity(ImagingMagickNetActivitySource.EncodeOperation);
+        activity?.SetTag(ImagingMagickNetActivitySource.TagOutputFormat, outputFormat.ToString());
+        activity?.SetTag(ImagingMagickNetActivitySource.TagWidth, (int)_image.Width);
+        activity?.SetTag(ImagingMagickNetActivitySource.TagHeight, (int)_image.Height);
+        return activity;
     }
 
     /// <inheritdoc/>
@@ -191,9 +208,13 @@ internal sealed class MagickNetImagePipeline : IImagePipeline
 
     private void RecordMetrics(ImageFormat outputFormat)
     {
+        // Read the ambient tenant at terminal-op time (ICurrentTenant is AsyncLocal-backed),
+        // so the metric carries the tenant of the request that ran the pipeline.
+        string? tenantId = _currentTenant.IsAvailable ? _currentTenant.Id?.ToString() : null;
+
         string formatName = outputFormat.ToString().ToLowerInvariant();
-        _metrics.RecordImageProcessed(tenantId: null, formatName);
-        _metrics.RecordProcessingDuration(tenantId: null, formatName, Stopwatch.GetElapsedTime(_startTimestamp));
+        _metrics.RecordImageProcessed(tenantId, formatName);
+        _metrics.RecordProcessingDuration(tenantId, formatName, Stopwatch.GetElapsedTime(_startTimestamp));
     }
 
     private void ApplyOutputSettings()

--- a/src/Granit.Imaging.MagickNet/Internal/MagickNetImageProcessor.cs
+++ b/src/Granit.Imaging.MagickNet/Internal/MagickNetImageProcessor.cs
@@ -1,6 +1,9 @@
+using System.Diagnostics;
 using Granit.Imaging.Diagnostics;
 using Granit.Imaging.Exceptions;
+using Granit.Imaging.MagickNet.Diagnostics;
 using Granit.Imaging.MagickNet.Options;
+using Granit.MultiTenancy;
 using ImageMagick;
 using Microsoft.Extensions.Options;
 
@@ -10,14 +13,23 @@ namespace Granit.Imaging.MagickNet.Internal;
 /// Magick.NET implementation of <see cref="IImageProcessor"/>.
 /// Stateless singleton that creates <see cref="MagickNetImagePipeline"/> instances.
 /// </summary>
+/// <remarks>
+/// <see cref="ICurrentTenant"/> is a singleton (AsyncLocal-backed), so injecting it here is
+/// lifetime-safe; the pipeline reads the ambient tenant at terminal-operation time so the
+/// metrics carry the tenant of the request that ran the pipeline.
+/// </remarks>
 internal sealed class MagickNetImageProcessor(
     ImagingMetrics metrics,
+    ICurrentTenant currentTenant,
     IOptions<ImagingMagickNetOptions> options) : IImageProcessor
 {
     /// <inheritdoc/>
     public async Task<IImagePipeline> LoadAsync(Stream source, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(source);
+
+        using Activity? activity = ImagingMagickNetActivitySource.Source
+            .StartActivity(ImagingMagickNetActivitySource.LoadOperation);
 
         if (!source.CanSeek)
         {
@@ -31,7 +43,7 @@ internal sealed class MagickNetImageProcessor(
                 ValidateFormat(buffer);
 
                 MagickImage bufferedImage = new(buffer);
-                return new MagickNetImagePipeline(bufferedImage, metrics);
+                return CreatePipeline(bufferedImage, buffer.Length, activity);
             }
         }
 
@@ -40,12 +52,15 @@ internal sealed class MagickNetImageProcessor(
 
         MagickImage image = new();
         await image.ReadAsync(source, cancellationToken).ConfigureAwait(false);
-        return new MagickNetImagePipeline(image, metrics);
+        return CreatePipeline(image, source.Length, activity);
     }
 
     /// <inheritdoc/>
     public IImagePipeline Load(ReadOnlyMemory<byte> source)
     {
+        using Activity? activity = ImagingMagickNetActivitySource.Source
+            .StartActivity(ImagingMagickNetActivitySource.LoadOperation);
+
         ValidateInputSize(source.Length);
 
         if (!ImageFormatDetector.IsSafeRasterFormat(source.Span))
@@ -54,12 +69,16 @@ internal sealed class MagickNetImageProcessor(
         }
 
         MagickImage image = new(source.Span);
-        return new MagickNetImagePipeline(image, metrics);
+        return CreatePipeline(image, source.Length, activity);
     }
 
     /// <inheritdoc/>
     public ImageInfo Identify(ReadOnlyMemory<byte> source)
     {
+        using Activity? activity = ImagingMagickNetActivitySource.Source
+            .StartActivity(ImagingMagickNetActivitySource.IdentifyOperation);
+        activity?.SetTag(ImagingMagickNetActivitySource.TagInputBytes, source.Length);
+
         // Header-only: deliberately NO size validation here. Identify never allocates a
         // decoded surface, so a large byte buffer is harmless — and callers rely on it
         // precisely to vet declared pixel dimensions BEFORE deciding whether to decode.
@@ -71,14 +90,31 @@ internal sealed class MagickNetImageProcessor(
         try
         {
             MagickImageInfo info = new(source.Span);
-            return new ImageInfo(
+            ImageInfo result = new(
                 new ImageSize((int)info.Width, (int)info.Height),
                 MagickFormatMapper.FromMagickFormat(info.Format));
+
+            activity?.SetTag(ImagingMagickNetActivitySource.TagSourceFormat, result.Format.ToString());
+            activity?.SetTag(ImagingMagickNetActivitySource.TagWidth, result.Size.Width);
+            activity?.SetTag(ImagingMagickNetActivitySource.TagHeight, result.Size.Height);
+            return result;
         }
         catch (MagickException ex)
         {
             throw new UnsupportedImageFormatException("unreadable", ex);
         }
+    }
+
+    private MagickNetImagePipeline CreatePipeline(MagickImage image, long inputBytes, Activity? activity)
+    {
+        MagickNetImagePipeline pipeline = new(image, metrics, currentTenant);
+
+        activity?.SetTag(ImagingMagickNetActivitySource.TagInputBytes, inputBytes);
+        activity?.SetTag(ImagingMagickNetActivitySource.TagSourceFormat, pipeline.SourceFormat.ToString());
+        activity?.SetTag(ImagingMagickNetActivitySource.TagWidth, pipeline.SourceSize.Width);
+        activity?.SetTag(ImagingMagickNetActivitySource.TagHeight, pipeline.SourceSize.Height);
+
+        return pipeline;
     }
 
     private void ValidateInputSize(long length)

--- a/tests/Granit.Imaging.AI.Tests/LlmImageAnalyzerTests.cs
+++ b/tests/Granit.Imaging.AI.Tests/LlmImageAnalyzerTests.cs
@@ -3,6 +3,7 @@ using Granit.AI;
 using Granit.Imaging.AI.Diagnostics;
 using Granit.Imaging.AI.Internal;
 using Granit.Imaging.AI.Options;
+using Granit.MultiTenancy;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
@@ -34,6 +35,7 @@ public sealed class LlmImageAnalyzerTests
         new(_structuredCompletion,
             options is null ? _options : Microsoft.Extensions.Options.Options.Create(options),
             _metrics,
+            NullTenantContext.Instance,
             NullLogger<LlmImageAnalyzer>.Instance);
 
     private void SetupCompletion(StructuredCompletionResult<LlmAnalysisResponse> result) =>

--- a/tests/Granit.Imaging.AI.Tests/LlmImageTextExtractorTests.cs
+++ b/tests/Granit.Imaging.AI.Tests/LlmImageTextExtractorTests.cs
@@ -35,10 +35,27 @@ public sealed class LlmImageTextExtractorTests
         _chatClientFactory.CreateAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(_chatClient);
     }
 
-    private LlmImageTextExtractor CreateExtractor(string? workspaceName) =>
+    private LlmImageTextExtractor CreateExtractor(string? workspaceName, long maxImageBytes = 10 * 1024 * 1024) =>
         new(_chatClientFactory, _workspaceProvider, _capabilityResolver,
-            MsOptions.Create(new ImagingAIOptions { WorkspaceName = workspaceName, TimeoutSeconds = 30 }),
+            MsOptions.Create(new ImagingAIOptions
+            {
+                WorkspaceName = workspaceName,
+                TimeoutSeconds = 30,
+                MaxImageBytes = maxImageBytes,
+            }),
             NullLogger<LlmImageTextExtractor>.Instance);
+
+    [Fact]
+    public async Task Returns_null_for_an_oversized_image_without_calling_the_provider()
+    {
+        // Graceful-degradation contract: too large -> null, provider never contacted.
+        LlmImageTextExtractor extractor = CreateExtractor("vision", maxImageBytes: 2);
+
+        ImageTextExtractionResult? result = await extractor.ExtractTextAsync(Image, "image/png", TestContext.Current.CancellationToken);
+
+        result.ShouldBeNull();
+        await _chatClientFactory.DidNotReceive().CreateAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
 
     [Fact]
     public async Task Uses_the_explicitly_configured_workspace()

--- a/tests/Granit.Imaging.MagickNet.Tests/Internal/ImagingTelemetryTests.cs
+++ b/tests/Granit.Imaging.MagickNet.Tests/Internal/ImagingTelemetryTests.cs
@@ -1,0 +1,114 @@
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using Granit.Imaging.Diagnostics;
+using Granit.Imaging.MagickNet.Internal;
+using Granit.Imaging.MagickNet.Options;
+using Granit.MultiTenancy;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Imaging.MagickNet.Tests.Internal;
+
+public sealed class ImagingTelemetryTests
+{
+    private static Stream GetTestImageStream() =>
+        typeof(ImagingTelemetryTests).Assembly
+            .GetManifestResourceStream("Granit.Imaging.MagickNet.Tests.TestAssets.test-image.png")!;
+
+    private static MagickNetImageProcessor CreateProcessor(ICurrentTenant tenant, out Meter meter)
+    {
+        Meter localMeter = new(ImagingMetrics.MeterName);
+        meter = localMeter;
+        IMeterFactory factory = Substitute.For<IMeterFactory>();
+        factory.Create(Arg.Any<MeterOptions>()).Returns(localMeter);
+        return new MagickNetImageProcessor(
+            new ImagingMetrics(factory),
+            tenant,
+            Microsoft.Extensions.Options.Options.Create(new ImagingMagickNetOptions()));
+    }
+
+    [Fact]
+    public async Task RecordMetrics_WithAvailableTenant_TagsTheRealTenantId()
+    {
+        var tenantId = Guid.NewGuid();
+        ICurrentTenant tenant = Substitute.For<ICurrentTenant>();
+        tenant.IsAvailable.Returns(true);
+        tenant.Id.Returns(tenantId);
+
+        string? observedTenantTag = await CaptureTenantTagAsync(tenant);
+
+        observedTenantTag.ShouldBe(tenantId.ToString());
+    }
+
+    [Fact]
+    public async Task RecordMetrics_WithoutTenant_CoalescesToGlobal()
+    {
+        string? observedTenantTag = await CaptureTenantTagAsync(NullTenantContext.Instance);
+
+        observedTenantTag.ShouldBe("global");
+    }
+
+    [Fact]
+    public async Task TerminalOperation_EmitsEncodeActivityWithOutputFormat()
+    {
+        List<Activity> activities = [];
+        using ActivityListener listener = new()
+        {
+            ShouldListenTo = source => source.Name == "Granit.Imaging.MagickNet",
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
+            ActivityStopped = activities.Add,
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        MagickNetImageProcessor processor = CreateProcessor(NullTenantContext.Instance, out Meter meter);
+        using (meter)
+        {
+            await using Stream stream = GetTestImageStream();
+            await using IImagePipeline pipeline = await processor.LoadAsync(stream, TestContext.Current.CancellationToken);
+            await pipeline.ConvertTo(ImageFormat.Jpeg).ToResultAsync(TestContext.Current.CancellationToken);
+        }
+
+        Activity load = activities.First(a => a.OperationName == "imaging.load");
+        load.GetTagItem("imaging.source_format").ShouldBe("Png");
+
+        Activity encode = activities.First(a => a.OperationName == "imaging.encode");
+        encode.GetTagItem("imaging.output_format").ShouldBe("Jpeg");
+        encode.GetTagItem("imaging.width").ShouldBe(100);
+    }
+
+    private static async Task<string?> CaptureTenantTagAsync(ICurrentTenant tenant)
+    {
+        MagickNetImageProcessor processor = CreateProcessor(tenant, out Meter meter);
+
+        string? observedTenantTag = null;
+        using MeterListener listener = new();
+        listener.InstrumentPublished = (instrument, l) =>
+        {
+            if (instrument.Meter == meter && instrument.Name == "granit.imaging.image.processed")
+            {
+                l.EnableMeasurementEvents(instrument);
+            }
+        };
+        listener.SetMeasurementEventCallback<long>((_, _, tags, _) =>
+        {
+            foreach (KeyValuePair<string, object?> tag in tags)
+            {
+                if (tag.Key == "tenant_id")
+                {
+                    observedTenantTag = tag.Value?.ToString();
+                }
+            }
+        });
+        listener.Start();
+
+        using (meter)
+        {
+            await using Stream stream = GetTestImageStream();
+            await using IImagePipeline pipeline = await processor.LoadAsync(stream, TestContext.Current.CancellationToken);
+            await pipeline.ToResultAsync(TestContext.Current.CancellationToken);
+        }
+
+        return observedTenantTag;
+    }
+}

--- a/tests/Granit.Imaging.MagickNet.Tests/Internal/MagickNetImagePipelineFormatConversionTests.cs
+++ b/tests/Granit.Imaging.MagickNet.Tests/Internal/MagickNetImagePipelineFormatConversionTests.cs
@@ -2,6 +2,7 @@ using System.Diagnostics.Metrics;
 using Granit.Imaging.Diagnostics;
 using Granit.Imaging.MagickNet.Internal;
 using Granit.Imaging.MagickNet.Options;
+using Granit.MultiTenancy;
 using NSubstitute;
 using Shouldly;
 using Xunit;
@@ -21,7 +22,7 @@ public sealed class MagickNetImagePipelineFormatConversionTests
     {
         Stream stream = typeof(MagickNetImagePipelineFormatConversionTests).Assembly
             .GetManifestResourceStream("Granit.Imaging.MagickNet.Tests.TestAssets.test-image.png")!;
-        MagickNetImageProcessor processor = new(CreateTestMetrics(), Microsoft.Extensions.Options.Options.Create(new ImagingMagickNetOptions()));
+        MagickNetImageProcessor processor = new(CreateTestMetrics(), NullTenantContext.Instance, Microsoft.Extensions.Options.Options.Create(new ImagingMagickNetOptions()));
         return (MagickNetImagePipeline)await processor.LoadAsync(stream);
     }
 

--- a/tests/Granit.Imaging.MagickNet.Tests/Internal/MagickNetImagePipelineTests.cs
+++ b/tests/Granit.Imaging.MagickNet.Tests/Internal/MagickNetImagePipelineTests.cs
@@ -2,6 +2,7 @@ using System.Diagnostics.Metrics;
 using Granit.Imaging.Diagnostics;
 using Granit.Imaging.MagickNet.Internal;
 using Granit.Imaging.MagickNet.Options;
+using Granit.MultiTenancy;
 using NSubstitute;
 using Shouldly;
 using Xunit;
@@ -21,7 +22,7 @@ public sealed class MagickNetImagePipelineTests
     {
         Stream stream = typeof(MagickNetImagePipelineTests).Assembly
             .GetManifestResourceStream("Granit.Imaging.MagickNet.Tests.TestAssets.test-image.png")!;
-        MagickNetImageProcessor processor = new(CreateTestMetrics(), Microsoft.Extensions.Options.Options.Create(new ImagingMagickNetOptions()));
+        MagickNetImageProcessor processor = new(CreateTestMetrics(), NullTenantContext.Instance, Microsoft.Extensions.Options.Options.Create(new ImagingMagickNetOptions()));
         return (MagickNetImagePipeline)await processor.LoadAsync(stream);
     }
 

--- a/tests/Granit.Imaging.MagickNet.Tests/Internal/MagickNetImagePipelineWatermarkTests.cs
+++ b/tests/Granit.Imaging.MagickNet.Tests/Internal/MagickNetImagePipelineWatermarkTests.cs
@@ -2,6 +2,7 @@ using System.Diagnostics.Metrics;
 using Granit.Imaging.Diagnostics;
 using Granit.Imaging.MagickNet.Internal;
 using Granit.Imaging.MagickNet.Options;
+using Granit.MultiTenancy;
 using ImageMagick;
 using NSubstitute;
 using Shouldly;
@@ -22,7 +23,7 @@ public sealed class MagickNetImagePipelineWatermarkTests
     {
         Stream stream = typeof(MagickNetImagePipelineWatermarkTests).Assembly
             .GetManifestResourceStream("Granit.Imaging.MagickNet.Tests.TestAssets.test-image.png")!;
-        MagickNetImageProcessor processor = new(CreateTestMetrics(), Microsoft.Extensions.Options.Options.Create(new ImagingMagickNetOptions()));
+        MagickNetImageProcessor processor = new(CreateTestMetrics(), NullTenantContext.Instance, Microsoft.Extensions.Options.Options.Create(new ImagingMagickNetOptions()));
         return (MagickNetImagePipeline)await processor.LoadAsync(stream);
     }
 

--- a/tests/Granit.Imaging.MagickNet.Tests/Internal/MagickNetImageProcessorTests.cs
+++ b/tests/Granit.Imaging.MagickNet.Tests/Internal/MagickNetImageProcessorTests.cs
@@ -3,6 +3,7 @@ using Granit.Imaging.Diagnostics;
 using Granit.Imaging.Exceptions;
 using Granit.Imaging.MagickNet.Internal;
 using Granit.Imaging.MagickNet.Options;
+using Granit.MultiTenancy;
 using NSubstitute;
 using Shouldly;
 using Xunit;
@@ -11,7 +12,7 @@ namespace Granit.Imaging.MagickNet.Tests.Internal;
 
 public sealed class MagickNetImageProcessorTests
 {
-    private readonly MagickNetImageProcessor _processor = new(CreateTestMetrics(), Microsoft.Extensions.Options.Options.Create(new ImagingMagickNetOptions()));
+    private readonly MagickNetImageProcessor _processor = new(CreateTestMetrics(), NullTenantContext.Instance, Microsoft.Extensions.Options.Options.Create(new ImagingMagickNetOptions()));
 
     private static ImagingMetrics CreateTestMetrics()
     {
@@ -141,6 +142,7 @@ public sealed class MagickNetImageProcessorTests
     {
         MagickNetImageProcessor processor = new(
             CreateTestMetrics(),
+            NullTenantContext.Instance,
             Microsoft.Extensions.Options.Options.Create(new ImagingMagickNetOptions { MaxInputBytes = 16 }));
         await using Stream stream = GetTestImageStream();
 


### PR DESCRIPTION
## Summary

**Final code PR of the Imaging/AI redesign series** (after #3085 + #3086). Closes the audit's CONVENTION findings #4 (tenant_id always "global") and #5 (dead ActivitySource).

- **Tenant-aware metrics**: `ICurrentTenant` is a singleton (AsyncLocal-backed) in this repo — verified during planning — so injecting it into the singleton `MagickNetImageProcessor` is lifetime-safe and needs no new `ProjectReference` (the type lives in Granit core). The pipeline reads the ambient tenant at terminal-op time (BlobStorage pattern: `IsAvailable ? Id?.ToString() : null`, `"global"` coalesce unchanged in the metrics class). Same wiring in `LlmImageAnalyzer`. Both registration extensions keep the `NullTenantContext.Instance` fallback for hosts without `Granit.MultiTenancy`.
- **Activities (S3 naming convention)**: the MagickNet `ActivitySource` was registered but never started a span — it now emits `imaging.load` / `imaging.identify` / `imaging.encode` with `imaging.source_format`, `imaging.output_format`, `imaging.width`, `imaging.height`, `imaging.input_bytes` tags. Imaging.AI aligns: `imaging.ai.analyze` (renamed from PascalCase `ImageAnalysis.Analyze`) and a **new** `imaging.ai.extract_text` span on the extractor (workspace, content type, size).
- **`MaxImageBytes` on `LlmImageTextExtractor`** (deferred from #3086 to avoid conflicting with the then-in-flight #3085): first check, before workspace resolution or `DataContent` — logs a warning and returns `null`, consistent with the tool's graceful-degradation contract.

## Breaking changes

Span rename `ImageAnalysis.Analyze` → `imaging.ai.analyze` (dashboards); imaging metrics now emit real per-tenant series instead of a single `"global"` one (cardinality bounded by the tenant table — same accepted trade-off as BlobStorage).

## Tests

New `ImagingTelemetryTests`: `MeterListener` proves the `tenant_id` tag carries the real tenant when available and `"global"` under `NullTenantContext`; `ActivityListener` proves `imaging.load`/`imaging.encode` spans with format/dimension tags. Extractor: oversized image → `null`, provider never contacted.

Verified: `Granit.Imaging.MagickNet.Tests` 130 ✅, `Granit.Imaging.AI.Tests` 34 ✅, architecture shard 262 ✅, `dotnet format` clean.

The remaining item of the redesign plan is the **granit-docs PR** (separate repo, handoff prompt in the PR conversation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)