### PR TITLE
fix(openiddict): drive idle-session revocation from durable last-activity (Phase 2D)

### DIFF
--- a/.github/shard-filters/integration.slnf
+++ b/.github/shard-filters/integration.slnf
@@ -64,6 +64,7 @@
       "src/Granit.MultiTenancy/Granit.MultiTenancy.csproj",
       "src/Granit.Observability/Granit.Observability.csproj",
       "src/Granit.OpenIddict.Abstractions/Granit.OpenIddict.Abstractions.csproj",
+      "src/Granit.OpenIddict.BackgroundJobs/Granit.OpenIddict.BackgroundJobs.csproj",
       "src/Granit.OpenIddict.Endpoints/Granit.OpenIddict.Endpoints.csproj",
       "src/Granit.OpenIddict.EntityFrameworkCore/Granit.OpenIddict.EntityFrameworkCore.csproj",
       "src/Granit.OpenIddict.Server/Granit.OpenIddict.Server.csproj",

--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -42835,7 +42835,7 @@
       "kind": "class",
       "project": "Granit.OpenIddict.BackgroundJobs",
       "file": "src/Granit.OpenIddict.BackgroundJobs/Services/IdleSessionEnforcementService.cs",
-      "line": 26,
+      "line": 22,
       "members": [
         {
           "name": "ExecuteAsync",
@@ -43996,6 +43996,12 @@
           "kind": "method",
           "signature": "GetActivitiesAsync(string userId, CancellationToken cancellationToken = default)",
           "returnType": "Task<IReadOnlyDictionary<string, DateTimeOffset>>"
+        },
+        {
+          "name": "GetIdleRefreshTokenIdsAsync",
+          "kind": "method",
+          "signature": "GetIdleRefreshTokenIdsAsync(DateTimeOffset idleSince, int max, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<string>>"
         }
       ]
     },

--- a/src/Granit.OpenIddict.Abstractions/Services/IUserSessionActivityStore.cs
+++ b/src/Granit.OpenIddict.Abstractions/Services/IUserSessionActivityStore.cs
@@ -36,4 +36,16 @@ public interface IUserSessionActivityStore
     /// <param name="cancellationToken">Cancellation token.</param>
     Task<IReadOnlyDictionary<string, DateTimeOffset>> GetActivitiesAsync(
         string userId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns the ids of valid refresh tokens whose session has been idle since before
+    /// <paramref name="idleSince"/> — using the last-activity timestamp, or the token's creation date
+    /// when the session was never touched (a session that never sent a heartbeat is idle from birth).
+    /// The idle-session job loads each and revokes it unless it is a remember-me session.
+    /// </summary>
+    /// <param name="idleSince">The cutoff; sessions with no activity at or after this are idle.</param>
+    /// <param name="max">Maximum number of ids to return in one sweep.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<IReadOnlyList<string>> GetIdleRefreshTokenIdsAsync(
+        DateTimeOffset idleSince, int max, CancellationToken cancellationToken = default);
 }

--- a/src/Granit.OpenIddict.BackgroundJobs/Services/IdleSessionEnforcementService.cs
+++ b/src/Granit.OpenIddict.BackgroundJobs/Services/IdleSessionEnforcementService.cs
@@ -1,37 +1,36 @@
-using Granit.Identity.Local.Services;
+using System.Collections.Immutable;
+using System.Text.Json;
+using Granit.OpenIddict.Services;
 using Granit.Settings.Services;
+using Granit.Timing;
 using Microsoft.Extensions.Logging;
 using OpenIddict.Abstractions;
-using ZiggyCreatures.Caching.Fusion;
 
 namespace Granit.OpenIddict.BackgroundJobs.Services;
 
 /// <summary>
-/// Scans active refresh tokens and checks whether the corresponding session cache entry
-/// has expired. If so, revokes the refresh token.
+/// Revokes refresh tokens whose session has been idle beyond the configured timeout, so an
+/// abandoned session cannot be resumed indefinitely. Remember-me sessions are exempt.
 /// </summary>
 /// <remarks>
-/// <para>
-/// <strong>Temporary safe-guard:</strong> revocation is intentionally disabled. The previous
-/// implementation probed a <see cref="IFusionCache"/> key <c>session:{subject}:{refreshTokenId}</c>
-/// that the heartbeat endpoint never wrote under the same identifier (it writes
-/// <c>session:{subject}:{accessTokenJti}</c>), so every refresh token looked idle and was
-/// revoked on the first run — a mass logout — and <c>remember_me</c> sessions (which the
-/// heartbeat deliberately never tracks) were revoked too. Until the correct mechanism ships
-/// (a persistent last-activity column on the token entry, replacing this three-party cache
-/// contract), the job scans and reports what it <em>would</em> revoke but does not revoke,
-/// favouring "no enforcement" over "log everyone out".
-/// </para>
+/// Idleness is measured from the durable last-activity the heartbeat stamps on the refresh token
+/// (<see cref="IUserSessionActivityStore"/>), falling back to the token's creation date for a session
+/// that never sent a heartbeat. This replaces the earlier three-party FusionCache contract whose keys
+/// never matched — which made every session look idle, so the job was disabled as a safe-guard against
+/// a mass logout.
 /// </remarks>
 public sealed partial class IdleSessionEnforcementService(
     IOpenIddictTokenManager tokenManager,
-    IFusionCache cache,
+    IUserSessionActivityStore activityStore,
     ISettingProvider settingProvider,
+    IClock clock,
     ILogger<IdleSessionEnforcementService> logger)
 {
+    private const int BatchSize = 1_000;
+
     public async Task ExecuteAsync(CancellationToken cancellationToken)
     {
-        // Read the idle session timeout setting (minutes, 0 = disabled)
+        // Idle session timeout in minutes (0 or unset = disabled).
         string? timeoutValue = await settingProvider
             .GetOrNullAsync(OpenIddictSettingNames.IdleSessionTimeout, cancellationToken)
             .ConfigureAwait(false);
@@ -44,55 +43,44 @@ public sealed partial class IdleSessionEnforcementService(
 
         Log.IdleSessionEnforcementStarted(logger, timeoutMinutes);
 
-        // SAFE-GUARD: the cache-key contract below is broken (the heartbeat writes
-        // session:{subject}:{accessTokenJti} while this scan probes
-        // session:{subject}:{refreshTokenId}), so every entry looks idle. We scan and count
-        // what the old logic WOULD have revoked, but do NOT revoke — a cache miss here is not
-        // trustworthy evidence of idleness. The real mechanism (persistent last-activity on the
-        // token entry) replaces this loop wholesale; see the class remarks.
-        const int pageSize = 1_000;
-        int wouldRevokeCount = 0;
-        int offset = 0;
-        bool hasMore;
+        DateTimeOffset idleSince = clock.Now - TimeSpan.FromMinutes(timeoutMinutes);
+        IReadOnlyList<string> idleIds = await activityStore
+            .GetIdleRefreshTokenIdsAsync(idleSince, BatchSize, cancellationToken).ConfigureAwait(false);
 
-        do
+        int revoked = 0;
+        int exempt = 0;
+        foreach (string tokenId in idleIds)
         {
-            int pageCount = 0;
-
-            await foreach (object token in tokenManager.ListAsync(pageSize, offset, cancellationToken))
+            object? token = await tokenManager.FindByIdAsync(tokenId, cancellationToken).ConfigureAwait(false);
+            if (token is null)
             {
-                pageCount++;
-
-                string? tokenType = await tokenManager.GetTypeAsync(token, cancellationToken).ConfigureAwait(false);
-                if (tokenType != global::OpenIddict.Abstractions.OpenIddictConstants.TokenTypeHints.RefreshToken)
-                {
-                    continue;
-                }
-
-                string? subject = await tokenManager.GetSubjectAsync(token, cancellationToken).ConfigureAwait(false);
-                string? tokenId = await tokenManager.GetIdAsync(token, cancellationToken).ConfigureAwait(false);
-                if (subject is null || tokenId is null)
-                {
-                    continue;
-                }
-
-                string cacheKey = $"session:{subject}:{tokenId}";
-                MaybeValue<UserSessionActivity> cachedEntry = await cache
-                    .TryGetAsync<UserSessionActivity>(cacheKey, token: cancellationToken).ConfigureAwait(false);
-
-                if (!cachedEntry.HasValue)
-                {
-                    // Would revoke under the old (broken) contract — counted only, never revoked.
-                    wouldRevokeCount++;
-                }
+                continue;
             }
 
-            offset += pageCount;
-            hasMore = pageCount == pageSize;
-        }
-        while (hasMore);
+            if (await IsRememberMeAsync(token, cancellationToken).ConfigureAwait(false))
+            {
+                // Persistent session — the user opted out of inactivity revocation.
+                exempt++;
+                continue;
+            }
 
-        Log.IdleSessionEnforcementDeferred(logger, wouldRevokeCount);
+            if (await tokenManager.TryRevokeAsync(token, cancellationToken).ConfigureAwait(false))
+            {
+                revoked++;
+            }
+        }
+
+        Log.IdleSessionEnforcementCompleted(logger, revoked, exempt);
+    }
+
+    private async Task<bool> IsRememberMeAsync(object token, CancellationToken cancellationToken)
+    {
+        ImmutableDictionary<string, JsonElement> properties = await tokenManager
+            .GetPropertiesAsync(token, cancellationToken).ConfigureAwait(false);
+
+        return properties.TryGetValue("remember_me", out JsonElement value)
+            && value.ValueKind == JsonValueKind.String
+            && value.GetString() is "true";
     }
 
     private static partial class Log
@@ -103,7 +91,8 @@ public sealed partial class IdleSessionEnforcementService(
         [LoggerMessage(Level = LogLevel.Debug, Message = "Idle session enforcement started (timeout = {TimeoutMinutes} min).")]
         public static partial void IdleSessionEnforcementStarted(ILogger logger, int timeoutMinutes);
 
-        [LoggerMessage(Level = LogLevel.Warning, Message = "Idle session enforcement is temporarily disabled (broken cache-key contract). Would have revoked {WouldRevokeCount} refresh token(s); none were revoked. Pending the persistent last-activity mechanism.")]
-        public static partial void IdleSessionEnforcementDeferred(ILogger logger, int wouldRevokeCount);
+        [LoggerMessage(Level = LogLevel.Information,
+            Message = "Idle session enforcement completed: revoked {Revoked} idle refresh token(s), exempted {Exempt} remember-me session(s).")]
+        public static partial void IdleSessionEnforcementCompleted(ILogger logger, int revoked, int exempt);
     }
 }

--- a/src/Granit.OpenIddict.Endpoints/Endpoints/ConnectAuthorizationEndpoints.cs
+++ b/src/Granit.OpenIddict.Endpoints/Endpoints/ConnectAuthorizationEndpoints.cs
@@ -152,6 +152,17 @@ internal static partial class ConnectAuthorizationEndpoints
                 context.RequestAborted)
             .ConfigureAwait(false);
 
+        // Propagate the persistent-login choice (the Identity cookie's IsPersistent, set at
+        // interactive login from "remember me") onto the token as a remember_me claim, so the
+        // idle-session job can exempt these sessions from inactivity revocation. The token endpoint
+        // preserves it across refreshes; the heartbeat reads it from the access token.
+        if (authenticateResult.Properties?.IsPersistent == true)
+        {
+            Claim rememberMe = new("remember_me", "true");
+            rememberMe.SetDestinations(OpenIddictConstants.Destinations.AccessToken);
+            principal.Identities.First().AddClaim(rememberMe);
+        }
+
         // Reuse or create an authorization for this subject + client + scopes.
         IOpenIddictAuthorizationManager authorizationManager = context.RequestServices
             .GetRequiredService<IOpenIddictAuthorizationManager>();

--- a/src/Granit.OpenIddict.Endpoints/Endpoints/ConnectTokenEndpoints.cs
+++ b/src/Granit.OpenIddict.Endpoints/Endpoints/ConnectTokenEndpoints.cs
@@ -187,6 +187,18 @@ internal static partial class ConnectTokenEndpoints
                 properties.Items["user_agent"] = userAgent;
             }
 
+            // Preserve the persistent-login choice across refreshes: the source principal (auth code
+            // or prior refresh token) carries remember_me. Re-stamp it as a claim (so the next refresh
+            // and the heartbeat still see it) and as a token property (so the idle-session job can
+            // exempt the session from inactivity revocation).
+            if (authenticateResult.Principal.GetClaim("remember_me") is "true")
+            {
+                Claim rememberMe = new("remember_me", "true");
+                rememberMe.SetDestinations(OpenIddictConstants.Destinations.AccessToken);
+                principal.Identities.First().AddClaim(rememberMe);
+                properties.Items["remember_me"] = "true";
+            }
+
             return Results.SignIn(principal, properties,
                 OpenIddictServerAspNetCoreDefaults.AuthenticationScheme);
         }

--- a/src/Granit.OpenIddict.EntityFrameworkCore/Internal/EfUserSessionActivityStore.cs
+++ b/src/Granit.OpenIddict.EntityFrameworkCore/Internal/EfUserSessionActivityStore.cs
@@ -59,5 +59,26 @@ internal sealed class EfUserSessionActivityStore(
         return rows.ToDictionary(r => r.SessionId.ToString(), r => r.LastActivityAt);
     }
 
+    /// <inheritdoc/>
+    public async Task<IReadOnlyList<string>> GetIdleRefreshTokenIdsAsync(
+        DateTimeOffset idleSince, int max, CancellationToken cancellationToken = default)
+    {
+        await using OpenIddictDbContext db = await dbFactory
+            .CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+
+        List<Guid> ids = await db.Set<GranitOpenIddictToken>()
+            .AsNoTracking()
+            .Where(t => t.Type == OpenIddictConstants.TokenTypeHints.RefreshToken
+                && t.Status == OpenIddictConstants.Statuses.Valid
+                && (t.LastActivityAt ?? t.CreationDate) < idleSince)
+            .OrderBy(t => t.LastActivityAt ?? t.CreationDate)
+            .Take(max)
+            .Select(t => t.Id)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return ids.ConvertAll(id => id.ToString());
+    }
+
     private readonly record struct ActivityRow(Guid SessionId, DateTimeOffset LastActivityAt);
 }

--- a/tests/Granit.OpenIddict.BackgroundJobs.Tests/Jobs/OpenIddictIdleSessionEnforcementHandlerTests.cs
+++ b/tests/Granit.OpenIddict.BackgroundJobs.Tests/Jobs/OpenIddictIdleSessionEnforcementHandlerTests.cs
@@ -1,107 +1,111 @@
+using System.Collections.Immutable;
+using System.Text.Json;
 using Granit.OpenIddict.BackgroundJobs.Services;
+using Granit.OpenIddict.Services;
 using Granit.Settings.Services;
+using Granit.Timing;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
 using OpenIddict.Abstractions;
-using Shouldly;
 using Xunit;
-using ZiggyCreatures.Caching.Fusion;
 
 namespace Granit.OpenIddict.BackgroundJobs.Tests.Jobs;
 
 public sealed class OpenIddictIdleSessionEnforcementHandlerTests
 {
+    private static readonly DateTimeOffset Now = new(2026, 1, 1, 12, 0, 0, TimeSpan.Zero);
+
     private readonly IOpenIddictTokenManager _tokenManager = Substitute.For<IOpenIddictTokenManager>();
-    private readonly IFusionCache _cache = Substitute.For<IFusionCache>();
+    private readonly IUserSessionActivityStore _activityStore = Substitute.For<IUserSessionActivityStore>();
     private readonly ISettingProvider _settingProvider = Substitute.For<ISettingProvider>();
+    private readonly IClock _clock = Substitute.For<IClock>();
+
+    public OpenIddictIdleSessionEnforcementHandlerTests() => _clock.Now.Returns(Now);
 
     private IdleSessionEnforcementService CreateService() =>
-        new(_tokenManager, _cache, _settingProvider,
+        new(_tokenManager, _activityStore, _settingProvider, _clock,
             NullLogger<IdleSessionEnforcementService>.Instance);
 
     [Fact]
-    public async Task ExecuteAsync_SettingNull_DoesNotCallTokenManager()
+    public async Task ExecuteAsync_TimeoutUnset_DoesNotQueryIdleSessions()
     {
         _settingProvider.GetOrNullAsync(OpenIddictSettingNames.IdleSessionTimeout, Arg.Any<CancellationToken>())
             .Returns((string?)null);
 
         await CreateService().ExecuteAsync(TestContext.Current.CancellationToken);
 
-        _tokenManager.DidNotReceive().ListAsync(
-            Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>());
+        await _activityStore.DidNotReceive().GetIdleRefreshTokenIdsAsync(
+            Arg.Any<DateTimeOffset>(), Arg.Any<int>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
-    public async Task ExecuteAsync_SettingZero_ReturnsEarly()
+    public async Task ExecuteAsync_TimeoutZero_ReturnsEarly()
     {
         _settingProvider.GetOrNullAsync(OpenIddictSettingNames.IdleSessionTimeout, Arg.Any<CancellationToken>())
             .Returns("0");
 
         await CreateService().ExecuteAsync(TestContext.Current.CancellationToken);
 
-        _tokenManager.DidNotReceive().ListAsync(
-            Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>());
+        await _activityStore.DidNotReceive().GetIdleRefreshTokenIdsAsync(
+            Arg.Any<DateTimeOffset>(), Arg.Any<int>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
-    public async Task ExecuteAsync_SettingNegative_ReturnsEarly()
+    public async Task ExecuteAsync_IdleSession_IsRevoked()
     {
-        _settingProvider.GetOrNullAsync(OpenIddictSettingNames.IdleSessionTimeout, Arg.Any<CancellationToken>())
-            .Returns("-5");
+        EnableWith(timeoutMinutes: 30);
+        object token = SetupIdleToken("idle-token", rememberMe: false);
 
         await CreateService().ExecuteAsync(TestContext.Current.CancellationToken);
 
-        _tokenManager.DidNotReceive().ListAsync(
-            Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>());
+        await _tokenManager.Received(1).TryRevokeAsync(token, Arg.Any<CancellationToken>());
     }
 
     [Fact]
-    public async Task ExecuteAsync_SettingEnabled_EmptyTokenList_DoesNotRevoke()
+    public async Task ExecuteAsync_RememberMeSession_IsExempt()
     {
+        EnableWith(timeoutMinutes: 30);
+        object token = SetupIdleToken("remember-token", rememberMe: true);
+
+        await CreateService().ExecuteAsync(TestContext.Current.CancellationToken);
+
+        await _tokenManager.DidNotReceive().TryRevokeAsync(token, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ComputesCutoffFromTimeout()
+    {
+        EnableWith(timeoutMinutes: 30);
+        _activityStore.GetIdleRefreshTokenIdsAsync(Arg.Any<DateTimeOffset>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns([]);
+
+        await CreateService().ExecuteAsync(TestContext.Current.CancellationToken);
+
+        await _activityStore.Received(1).GetIdleRefreshTokenIdsAsync(
+            Now.AddMinutes(-30), Arg.Any<int>(), Arg.Any<CancellationToken>());
+    }
+
+    private void EnableWith(int timeoutMinutes) =>
         _settingProvider.GetOrNullAsync(OpenIddictSettingNames.IdleSessionTimeout, Arg.Any<CancellationToken>())
-            .Returns("30");
+            .Returns(timeoutMinutes.ToString(System.Globalization.CultureInfo.InvariantCulture));
 
-        _tokenManager.ListAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
-            .Returns(EmptyAsync());
-
-        await Should.NotThrowAsync(() =>
-            CreateService().ExecuteAsync(TestContext.Current.CancellationToken));
-
-        await _tokenManager.DidNotReceive().TryRevokeAsync(
-            Arg.Any<object>(), Arg.Any<CancellationToken>());
-    }
-
-    [Fact]
-    public async Task ExecuteAsync_SettingEnabled_IdleRefreshToken_DoesNotRevoke()
+    private object SetupIdleToken(string tokenId, bool rememberMe)
     {
-        // Safe-guard: even when a refresh token has no session cache entry (which the broken
-        // key contract makes universal), the job must NOT revoke — otherwise every session is
-        // logged out on the first run.
         object token = new();
-        _settingProvider.GetOrNullAsync(OpenIddictSettingNames.IdleSessionTimeout, Arg.Any<CancellationToken>())
-            .Returns("30");
-        _tokenManager.ListAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
-            .Returns(SingleAsync(token));
-        _tokenManager.GetTypeAsync(token, Arg.Any<CancellationToken>())
-            .Returns(OpenIddictConstants.TokenTypeHints.RefreshToken);
-        _tokenManager.GetSubjectAsync(token, Arg.Any<CancellationToken>()).Returns("user-1");
-        _tokenManager.GetIdAsync(token, Arg.Any<CancellationToken>()).Returns("refresh-token-1");
+        _activityStore.GetIdleRefreshTokenIdsAsync(Arg.Any<DateTimeOffset>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns([tokenId]);
+        _tokenManager.FindByIdAsync(tokenId, Arg.Any<CancellationToken>())
+            .Returns(token);
 
-        await CreateService().ExecuteAsync(TestContext.Current.CancellationToken);
+        ImmutableDictionary<string, JsonElement> properties = rememberMe
+            ? ImmutableDictionary<string, JsonElement>.Empty.Add(
+                "remember_me", JsonDocument.Parse("\"true\"").RootElement)
+            : ImmutableDictionary<string, JsonElement>.Empty;
+        _tokenManager.GetPropertiesAsync(token, Arg.Any<CancellationToken>())
+            .Returns(properties);
 
-        await _tokenManager.DidNotReceive().TryRevokeAsync(
-            Arg.Any<object>(), Arg.Any<CancellationToken>());
-    }
-
-    private static async IAsyncEnumerable<object> EmptyAsync()
-    {
-        await Task.CompletedTask;
-        yield break;
-    }
-
-    private static async IAsyncEnumerable<object> SingleAsync(object item)
-    {
-        await Task.CompletedTask;
-        yield return item;
+        _tokenManager.TryRevokeAsync(token, Arg.Any<CancellationToken>())
+            .Returns(true);
+        return token;
     }
 }

--- a/tests/Granit.OpenIddict.Tests.Integration/Fixtures/OpenIddictTestApplication.cs
+++ b/tests/Granit.OpenIddict.Tests.Integration/Fixtures/OpenIddictTestApplication.cs
@@ -172,6 +172,10 @@ public sealed class OpenIddictTestApplication : IAsyncLifetime
         await _postgres.DisposeAsync();
     }
 
+    /// <summary>Gets the application's root service provider (for resolving managers/factories in tests).</summary>
+    internal IServiceProvider Services =>
+        _app?.Services ?? throw new InvalidOperationException("App not initialized.");
+
     /// <summary>Creates a raw <see cref="HttpClient"/> for the test server.</summary>
     public HttpClient CreateHttpClient() =>
         _app?.GetTestClient() ?? throw new InvalidOperationException("App not initialized.");

--- a/tests/Granit.OpenIddict.Tests.Integration/Granit.OpenIddict.Tests.Integration.csproj
+++ b/tests/Granit.OpenIddict.Tests.Integration/Granit.OpenIddict.Tests.Integration.csproj
@@ -28,6 +28,7 @@
     <ProjectReference Include="..\..\src\Granit.OpenIddict.Server\Granit.OpenIddict.Server.csproj" />
     <ProjectReference Include="..\..\src\Granit.OpenIddict.EntityFrameworkCore\Granit.OpenIddict.EntityFrameworkCore.csproj" />
     <ProjectReference Include="..\..\src\Granit.OpenIddict.Endpoints\Granit.OpenIddict.Endpoints.csproj" />
+    <ProjectReference Include="..\..\src\Granit.OpenIddict.BackgroundJobs\Granit.OpenIddict.BackgroundJobs.csproj" />
     <ProjectReference Include="..\..\src\Granit.Identity.Local.AspNetIdentity\Granit.Identity.Local.AspNetIdentity.csproj" />
     <ProjectReference Include="..\..\src\Granit.Identity.Local.Endpoints\Granit.Identity.Local.Endpoints.csproj" />
   </ItemGroup>

--- a/tests/Granit.OpenIddict.Tests.Integration/Jobs/IdleSessionEnforcementServiceTests.cs
+++ b/tests/Granit.OpenIddict.Tests.Integration/Jobs/IdleSessionEnforcementServiceTests.cs
@@ -1,0 +1,109 @@
+using Granit.OpenIddict.BackgroundJobs.Services;
+using Granit.OpenIddict.EntityFrameworkCore.Entities;
+using Granit.OpenIddict.EntityFrameworkCore.Internal;
+using Granit.OpenIddict.Tests.Integration.Fixtures;
+using Granit.Settings.Services;
+using Granit.Timing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using OpenIddict.Abstractions;
+using Shouldly;
+using Xunit;
+
+#pragma warning disable EF1001 // OpenIddictDbContext / EfUserSessionActivityStore are internal — accessible via InternalsVisibleTo
+
+namespace Granit.OpenIddict.Tests.Integration.Jobs;
+
+/// <summary>
+/// End-to-end validation of the idle-session job against real PostgreSQL and a real
+/// <see cref="IOpenIddictTokenManager"/>: an idle refresh token is revoked, a remember-me session is
+/// exempt, and an active session survives. This exercises the full path the unit tests mock —
+/// the SQL idle query, the manager's <c>remember_me</c> property read, and <c>TryRevokeAsync</c>.
+/// </summary>
+[Collection("openiddict-integration")]
+public sealed class IdleSessionEnforcementServiceTests(OpenIddictTestApplication app)
+{
+    private const int TimeoutMinutes = 30;
+    private static readonly DateTimeOffset Now = DateTimeOffset.UnixEpoch.AddYears(56);
+    private static readonly DateTimeOffset Idle = Now.AddMinutes(-(TimeoutMinutes + 5));
+    private static readonly DateTimeOffset Recent = Now.AddMinutes(-1);
+
+    [Fact]
+    public async Task ExecuteAsync_RevokesIdle_ExemptsRememberMe_KeepsActive()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+
+        Guid idleId = await SeedRefreshTokenAsync(Idle, rememberMe: false, ct);
+        Guid rememberId = await SeedRefreshTokenAsync(Idle, rememberMe: true, ct);
+        Guid activeId = await SeedRefreshTokenAsync(Recent, rememberMe: false, ct);
+
+        await CreateService().ExecuteAsync(ct);
+
+        (await StatusAsync(idleId, ct)).ShouldBe(OpenIddictConstants.Statuses.Revoked);
+        (await StatusAsync(rememberId, ct)).ShouldBe(OpenIddictConstants.Statuses.Valid);
+        (await StatusAsync(activeId, ct)).ShouldBe(OpenIddictConstants.Statuses.Valid);
+    }
+
+    private IdleSessionEnforcementService CreateService()
+    {
+        IOpenIddictTokenManager tokenManager =
+            app.Services.GetRequiredService<IOpenIddictTokenManager>();
+
+        ISettingProvider settingProvider = Substitute.For<ISettingProvider>();
+        settingProvider.GetOrNullAsync(OpenIddictSettingNames.IdleSessionTimeout, Arg.Any<CancellationToken>())
+            .Returns(TimeoutMinutes.ToString(System.Globalization.CultureInfo.InvariantCulture));
+
+        IClock clock = Substitute.For<IClock>();
+        clock.Now.Returns(Now);
+
+        return new IdleSessionEnforcementService(
+            tokenManager, new EfUserSessionActivityStore(DbFactory), settingProvider, clock,
+            NullLogger<IdleSessionEnforcementService>.Instance);
+    }
+
+    private async Task<Guid> SeedRefreshTokenAsync(
+        DateTimeOffset lastActivityAt, bool rememberMe, CancellationToken ct)
+    {
+        var authId = Guid.NewGuid();
+        var tokenId = Guid.NewGuid();
+
+        await using OpenIddictDbContext db = await DbFactory.CreateDbContextAsync(ct);
+        GranitOpenIddictAuthorization authorization = new()
+        {
+            Id = authId,
+            Subject = $"idle-user-{tokenId:N}",
+            Status = OpenIddictConstants.Statuses.Valid,
+            Type = OpenIddictConstants.AuthorizationTypes.Permanent,
+        };
+        GranitOpenIddictToken token = new()
+        {
+            Id = tokenId,
+            Subject = authorization.Subject,
+            Type = OpenIddictConstants.TokenTypeHints.RefreshToken,
+            Status = OpenIddictConstants.Statuses.Valid,
+            Authorization = authorization,
+            LastActivityAt = lastActivityAt,
+            Properties = rememberMe ? "{\"remember_me\":\"true\"}" : null,
+        };
+        db.Add(authorization);
+        db.Add(token);
+        await db.SaveChangesAsync(ct);
+        return tokenId;
+    }
+
+    private async Task<string?> StatusAsync(Guid tokenId, CancellationToken ct)
+    {
+        await using OpenIddictDbContext db = await DbFactory.CreateDbContextAsync(ct);
+        return await db.Set<GranitOpenIddictToken>()
+            .Where(t => t.Id == tokenId)
+            .Select(t => t.Status)
+            .SingleAsync(ct);
+    }
+
+    private IDbContextFactory<OpenIddictDbContext> DbFactory =>
+        app.Services.GetRequiredService<IDbContextFactory<OpenIddictDbContext>>();
+}
+
+#pragma warning restore EF1001

--- a/tests/Granit.OpenIddict.Tests.Integration/packages.lock.json
+++ b/tests/Granit.OpenIddict.Tests.Integration/packages.lock.json
@@ -700,6 +700,17 @@
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
+      "granit.backgroundjobs": {
+        "type": "Project",
+        "dependencies": {
+          "Cronos": "[0.13.*, )",
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
       "granit.caching": {
         "type": "Project",
         "dependencies": {
@@ -933,6 +944,16 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.openiddict.backgroundjobs": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.BackgroundJobs": "[0.1.0-dev, )",
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.OpenIddict": "[0.1.0-dev, )",
+          "Granit.Settings": "[0.1.0-dev, )",
+          "OpenIddict": "[7.*, )"
+        }
+      },
       "granit.openiddict.endpoints": {
         "type": "Project",
         "dependencies": {
@@ -1068,6 +1089,12 @@
         "dependencies": {
           "Asp.Versioning.Mvc": "10.0.0"
         }
+      },
+      "Cronos": {
+        "type": "CentralTransitive",
+        "requested": "[0.13.*, )",
+        "resolved": "0.13.0",
+        "contentHash": "Nkve+Yi0+ol3ntSBRHeW0ka9cJQ8vndSUvvkXqF9LVqwpoqWueyxu/HS275r98RDOmF7/mzRnZW5XXUBXob+TA=="
       },
       "Fido2.AspNet": {
         "type": "CentralTransitive",


### PR DESCRIPTION
## Context

Part of the `Granit.OpenIddict*` refonte (Phase 2D — idle sessions).

The idle-session job read session activity from a three-party FusionCache contract whose keys never matched what the heartbeat wrote, so **every** session looked idle. The job had been disabled as a safe-guard against a mass logout. This wires it to the durable last-activity already stamped on the refresh token.

## Changes

- **`IUserSessionActivityStore.GetIdleRefreshTokenIdsAsync`** — valid refresh tokens whose `LastActivityAt` (or `CreationDate` for a never-touched session) predates the cutoff. Implemented as a SQL query in the EF store.
- **`IdleSessionEnforcementService`** rewritten: queries the store, honours the configured `IdleSessionTimeout` setting (`0`/unset disables it), and revokes each hit **unless** it is a remember-me session (read from the token's `remember_me` property).
- **`remember_me` propagation** — the authorize endpoint stamps a `remember_me` claim from the Identity cookie's `IsPersistent`; the token endpoint preserves it across refreshes as both a claim and a token property, so the job can exempt persistent sessions from inactivity revocation.

## Tests

- Job unit tests rewritten for the new contract (timeout unset/zero → no query; idle → revoked; remember-me → exempt; cutoff computed from timeout). 15/15.
- Postgres e2e (`Granit.OpenIddict.Tests.Integration`) seeding idle / remember-me / active refresh tokens; asserts only the idle non-remember-me one is revoked.

## Verification

- BackgroundJobs unit 15/15 · Integration 36/37 (1 skipped) · Architecture 262/262 + 19/19
- `dotnet format --verify-no-changes` clean · locked-mode restore consistent (OpenIddict stays pinned 7.5.0; only the new `Granit.OpenIddict.BackgroundJobs` project ref added to the integration lock)

🤖 Generated with [Claude Code](https://claude.com/claude-code)