### PR TITLE
feat(openiddict): guarantee the external-login registration event via a reconciliation safety-net (Phase 2C)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -42732,6 +42732,31 @@
       "members": []
     },
     {
+      "name": "OpenIddictRegistrationEtoDispatchHandler",
+      "fqn": "Granit.OpenIddict.BackgroundJobs.Jobs.OpenIddictRegistrationEtoDispatchHandler",
+      "kind": "class",
+      "project": "Granit.OpenIddict.BackgroundJobs",
+      "file": "src/Granit.OpenIddict.BackgroundJobs/Jobs/OpenIddictRegistrationEtoDispatchHandler.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "HandleAsync",
+          "kind": "method",
+          "signature": "HandleAsync(OpenIddictRegistrationEtoDispatchJob _, IRegistrationEtoReconciler reconciler, CancellationToken cancellationToken)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "OpenIddictRegistrationEtoDispatchJob",
+      "fqn": "Granit.OpenIddict.BackgroundJobs.Jobs.OpenIddictRegistrationEtoDispatchJob",
+      "kind": "record",
+      "project": "Granit.OpenIddict.BackgroundJobs",
+      "file": "src/Granit.OpenIddict.BackgroundJobs/Jobs/OpenIddictRegistrationEtoDispatchJob.cs",
+      "line": 16,
+      "members": []
+    },
+    {
       "name": "OpenIddictTokenCleanupHandler",
       "fqn": "Granit.OpenIddict.BackgroundJobs.Jobs.OpenIddictTokenCleanupHandler",
       "kind": "class",
@@ -43859,6 +43884,44 @@
       ]
     },
     {
+      "name": "IPendingRegistrationStore",
+      "fqn": "Granit.OpenIddict.Services.IPendingRegistrationStore",
+      "kind": "interface",
+      "project": "Granit.OpenIddict.Abstractions",
+      "file": "src/Granit.OpenIddict.Abstractions/Services/IPendingRegistrationStore.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "GetPendingAsync",
+          "kind": "method",
+          "signature": "GetPendingAsync(int max, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<PendingRegistration>>"
+        },
+        {
+          "name": "MarkDispatchedAsync",
+          "kind": "method",
+          "signature": "MarkDispatchedAsync(Guid userId, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "IRegistrationEtoReconciler",
+      "fqn": "Granit.OpenIddict.Services.IRegistrationEtoReconciler",
+      "kind": "interface",
+      "project": "Granit.OpenIddict.Abstractions",
+      "file": "src/Granit.OpenIddict.Abstractions/Services/IRegistrationEtoReconciler.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "ReconcileAsync",
+          "kind": "method",
+          "signature": "ReconcileAsync(CancellationToken cancellationToken)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
       "name": "ISigningKeyStore",
       "fqn": "Granit.OpenIddict.Services.ISigningKeyStore",
       "kind": "interface",
@@ -43948,6 +44011,15 @@
       "project": "Granit.OpenIddict.Abstractions",
       "file": "src/Granit.OpenIddict.Abstractions/Services/IPendingAccountDeletionStore.cs",
       "line": 33,
+      "members": []
+    },
+    {
+      "name": "PendingRegistration",
+      "fqn": "Granit.OpenIddict.Services.PendingRegistration",
+      "kind": "record",
+      "project": "Granit.OpenIddict.Abstractions",
+      "file": "src/Granit.OpenIddict.Abstractions/Services/IPendingRegistrationStore.cs",
+      "line": 32,
       "members": []
     },
     {

--- a/src/Granit.Identity.Local.AspNetIdentity/Internal/AspNetExternalLoginService.cs
+++ b/src/Granit.Identity.Local.AspNetIdentity/Internal/AspNetExternalLoginService.cs
@@ -4,6 +4,7 @@ using Granit.Events;
 using Granit.Identity.Local.Domain;
 using Granit.Identity.Local.Events;
 using Granit.Identity.Local.Services;
+using Granit.Timing;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Options;
 using GranitExternalLoginInfo = Granit.Identity.Local.Services.ExternalLoginInfo;
@@ -18,6 +19,7 @@ internal sealed class AspNetExternalLoginService(
     UserManager<LocalIdentity> userManager,
     ExternalClaimsMapper claimsMapper,
     IDistributedEventBus eventBus,
+    IClock clock,
     IOptions<ExternalAuthOptions> externalAuthOptions) : IExternalLoginService
 {
     /// <inheritdoc/>
@@ -142,7 +144,9 @@ internal sealed class AspNetExternalLoginService(
                 provider, providerKey, props.Email, props.FirstName, props.LastName, props.UserName));
         }
 
-        // 3b. Sufficient data → create and link.
+        // 3b. Sufficient data → create and link. Stamp the registration-event intent in the creation
+        //     commit so the reconciler can recover the UserRegisteredEto if the inline publish below
+        //     is lost to a crash (the OpenIddict DbContext is not in the Wolverine outbox).
         LocalIdentity newUser = new()
         {
             UserName = props.Email ?? props.UserName ?? providerKey,
@@ -150,6 +154,7 @@ internal sealed class AspNetExternalLoginService(
             FirstName = props.FirstName,
             LastName = props.LastName,
             EmailConfirmed = true, // External provider already verified
+            RegistrationEventPendingSince = clock.Now,
         };
 
         IdentityResult createResult = await userManager.CreateAsync(newUser).ConfigureAwait(false);
@@ -164,9 +169,14 @@ internal sealed class AspNetExternalLoginService(
             new UserLoginInfo(provider, providerKey, provider))
             .ConfigureAwait(false);
 
+        // Fast path: publish inline, then clear the pending marker so the reconciler skips it. A crash
+        // before the clear leaves the marker set and the sweep re-publishes (at-least-once).
         await eventBus.PublishAsync(
             new UserRegisteredEto(newUser.Id, newUser.TenantId),
             cancellationToken).ConfigureAwait(false);
+
+        newUser.RegistrationEventPendingSince = null;
+        await userManager.UpdateAsync(newUser).ConfigureAwait(false);
 
         return ProcessCallbackResult.Created(newUser.Id);
     }

--- a/src/Granit.Identity.Local.Endpoints/Endpoints/AccountExternalLoginEndpoints.cs
+++ b/src/Granit.Identity.Local.Endpoints/Endpoints/AccountExternalLoginEndpoints.cs
@@ -13,6 +13,7 @@ using Granit.Identity.Local.Events;
 using Granit.Identity.Local.Services;
 using Granit.MultiTenancy;
 using Granit.Settings.Services;
+using Granit.Timing;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.DataProtection;
@@ -455,6 +456,7 @@ internal static partial class AccountExternalLoginEndpoints
         [FromServices] SignInManager<LocalIdentity> signInManager,
         [FromServices] IEmailConfirmationService emailConfirmation,
         [FromServices] IDistributedEventBus eventBus,
+        [FromServices] IClock clock,
         CancellationToken cancellationToken)
     {
         // Master account-creation gate (per-tenant).
@@ -520,6 +522,9 @@ internal static partial class AccountExternalLoginEndpoints
             FirstName = request.FirstName ?? payload.FirstName,
             LastName = request.LastName ?? payload.LastName,
             EmailConfirmed = emailVerified,
+            // Durable registration-event intent, cleared after the inline publish below (see the
+            // reconciler for the crash-recovery path).
+            RegistrationEventPendingSince = clock.Now,
         };
 
         IdentityResult createResult = await userManager.CreateAsync(newUser).ConfigureAwait(false);
@@ -563,6 +568,9 @@ internal static partial class AccountExternalLoginEndpoints
 
         await eventBus.PublishAsync(
             new UserRegisteredEto(newUser.Id, newUser.TenantId), cancellationToken).ConfigureAwait(false);
+
+        newUser.RegistrationEventPendingSince = null;
+        await userManager.UpdateAsync(newUser).ConfigureAwait(false);
 
         return TypedResults.Ok(new AccountLoginResponse(Succeeded: true));
     }

--- a/src/Granit.Identity.Local/Domain/LocalIdentity.cs
+++ b/src/Granit.Identity.Local/Domain/LocalIdentity.cs
@@ -85,6 +85,17 @@ public class LocalIdentity
     /// </summary>
     public DateTimeOffset? DeletionEventDispatchedAt { get; set; }
 
+    /// <summary>
+    /// Gets or sets the UTC timestamp at which this account's registration was recorded as owing a
+    /// <c>UserRegisteredEto</c>. Set atomically with the creation of a self-registered account (today,
+    /// the external-provider registration flow) and cleared once the event is published. <see
+    /// langword="null"/> for accounts created by other means (admin/seed) or whose event was already
+    /// dispatched — the reconciliation job sweeps the non-null stragglers and publishes idempotently,
+    /// so the registration side effects (default role, welcome) survive a crash between the account
+    /// creation and the inline publish.
+    /// </summary>
+    public DateTimeOffset? RegistrationEventPendingSince { get; set; }
+
     /// <summary>Gets or sets a JSON column for custom extensible attributes.</summary>
     public string? CustomAttributesJson { get; set; }
 

--- a/src/Granit.OpenIddict.Abstractions/Services/IPendingRegistrationStore.cs
+++ b/src/Granit.OpenIddict.Abstractions/Services/IPendingRegistrationStore.cs
@@ -1,0 +1,32 @@
+namespace Granit.OpenIddict.Services;
+
+/// <summary>
+/// Reads accounts that owe a <c>UserRegisteredEto</c> whose event has not yet been dispatched, and
+/// marks them dispatched — the durable state the reconciliation job uses to guarantee the
+/// registration side effects (default-role assignment, welcome notification) are published
+/// eventually, even if the process crashes between the account creation and the inline publish.
+/// </summary>
+public interface IPendingRegistrationStore
+{
+    /// <summary>
+    /// Returns accounts with a non-null <c>RegistrationEventPendingSince</c>, across every tenant (the
+    /// sweep runs in host context, so the multi-tenant filter is bypassed for this read). Soft-deleted
+    /// accounts are excluded — a registration event for a since-deleted account is moot.
+    /// </summary>
+    /// <param name="max">Maximum number of pending registrations to return in one sweep.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<IReadOnlyList<PendingRegistration>> GetPendingAsync(
+        int max, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Clears <c>RegistrationEventPendingSince</c> on the account so the registration is not re-published.
+    /// </summary>
+    /// <param name="userId">The user whose registration event was dispatched.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task MarkDispatchedAsync(Guid userId, CancellationToken cancellationToken = default);
+}
+
+/// <summary>An account awaiting registration-event dispatch.</summary>
+/// <param name="UserId">The registered user's identifier.</param>
+/// <param name="TenantId">The owning tenant, or <see langword="null"/> for a global user.</param>
+public sealed record PendingRegistration(Guid UserId, Guid? TenantId);

--- a/src/Granit.OpenIddict.Abstractions/Services/IRegistrationEtoReconciler.cs
+++ b/src/Granit.OpenIddict.Abstractions/Services/IRegistrationEtoReconciler.cs
@@ -1,0 +1,13 @@
+namespace Granit.OpenIddict.Services;
+
+/// <summary>
+/// Publishes the <c>UserRegisteredEto</c> for accounts whose registration event has not yet been
+/// dispatched. Driven by a recurring background job so the registration side effects survive a crash
+/// between the account creation and the inline publish.
+/// </summary>
+public interface IRegistrationEtoReconciler
+{
+    /// <summary>Publishes pending registration events and marks them dispatched.</summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task ReconcileAsync(CancellationToken cancellationToken);
+}

--- a/src/Granit.OpenIddict.BackgroundJobs/Jobs/OpenIddictRegistrationEtoDispatchHandler.cs
+++ b/src/Granit.OpenIddict.BackgroundJobs/Jobs/OpenIddictRegistrationEtoDispatchHandler.cs
@@ -1,0 +1,16 @@
+using Granit.OpenIddict.Services;
+
+namespace Granit.OpenIddict.BackgroundJobs.Jobs;
+
+/// <summary>
+/// Handler for <see cref="OpenIddictRegistrationEtoDispatchJob"/>. Delegates to
+/// <see cref="IRegistrationEtoReconciler"/> to publish pending registration events.
+/// </summary>
+public class OpenIddictRegistrationEtoDispatchHandler
+{
+    public static Task HandleAsync(
+        OpenIddictRegistrationEtoDispatchJob _,
+        IRegistrationEtoReconciler reconciler,
+        CancellationToken cancellationToken) =>
+        reconciler.ReconcileAsync(cancellationToken);
+}

--- a/src/Granit.OpenIddict.BackgroundJobs/Jobs/OpenIddictRegistrationEtoDispatchJob.cs
+++ b/src/Granit.OpenIddict.BackgroundJobs/Jobs/OpenIddictRegistrationEtoDispatchJob.cs
@@ -1,0 +1,16 @@
+using Granit.BackgroundJobs;
+
+namespace Granit.OpenIddict.BackgroundJobs.Jobs;
+
+/// <summary>
+/// Recurring job that publishes the <c>UserRegisteredEto</c> for any account whose registration
+/// event has not yet been dispatched.
+/// </summary>
+/// <remarks>
+/// Runs every five minutes. The registration flow publishes the event inline for immediate side
+/// effects but records the intent durably (the OpenIddict DbContext is not enrolled in the Wolverine
+/// outbox); this job reconciles the durable stragglers into published events at-least-once when the
+/// inline publish was lost to a crash.
+/// </remarks>
+[RecurringJob("*/5 * * * *", "openiddict-registration-eto-dispatch")]
+public sealed record OpenIddictRegistrationEtoDispatchJob : IBackgroundJob;

--- a/src/Granit.OpenIddict.EntityFrameworkCore/GranitOpenIddictEntityFrameworkCoreModule.cs
+++ b/src/Granit.OpenIddict.EntityFrameworkCore/GranitOpenIddictEntityFrameworkCoreModule.cs
@@ -41,6 +41,7 @@ public sealed class GranitOpenIddictEntityFrameworkCoreModule : GranitModule
         context.Services.TryAddScoped<ILocalIdentityGroupStore, OpenIddictGroupStore>();
         context.Services.TryAddScoped<ISigningKeyStore, EfSigningKeyStore>();
         context.Services.TryAddScoped<IPendingAccountDeletionStore, EfPendingAccountDeletionStore>();
+        context.Services.TryAddScoped<IPendingRegistrationStore, EfPendingRegistrationStore>();
         context.Services.TryAddScoped<IUserSessionActivityStore, EfUserSessionActivityStore>();
 
         // LocalIdentity implements IHasMetadata — apps can extend user properties

--- a/src/Granit.OpenIddict.EntityFrameworkCore/Internal/EfPendingRegistrationStore.cs
+++ b/src/Granit.OpenIddict.EntityFrameworkCore/Internal/EfPendingRegistrationStore.cs
@@ -1,0 +1,53 @@
+using Granit.Identity.Local.Domain;
+using Granit.OpenIddict.Services;
+using Granit.Persistence.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
+
+namespace Granit.OpenIddict.EntityFrameworkCore.Internal;
+
+/// <summary>
+/// EF Core implementation of <see cref="IPendingRegistrationStore"/> over the consolidated
+/// <see cref="OpenIddictDbContext"/>.
+/// </summary>
+/// <remarks>
+/// The reconciliation sweep runs in host context with no active tenant, so it ignores the
+/// multi-tenant filter to see every tenant's pending registrations. The soft-delete filter is left
+/// active — a registration event for a since-deleted account is moot, so a soft-deleted row is
+/// correctly hidden.
+/// </remarks>
+internal sealed class EfPendingRegistrationStore(
+    IDbContextFactory<OpenIddictDbContext> dbFactory) : IPendingRegistrationStore
+{
+    /// <inheritdoc/>
+    public async Task<IReadOnlyList<PendingRegistration>> GetPendingAsync(
+        int max, CancellationToken cancellationToken = default)
+    {
+        await using OpenIddictDbContext db = await dbFactory
+            .CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+
+        return await db.Set<LocalIdentity>()
+            .IgnoreQueryFilters([GranitFilterNames.MultiTenant])
+            .AsNoTracking()
+            .Where(u => u.RegistrationEventPendingSince != null)
+            .OrderBy(u => u.RegistrationEventPendingSince)
+            .Take(max)
+            .Select(u => new PendingRegistration(u.Id, u.TenantId))
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    /// <inheritdoc/>
+    public async Task MarkDispatchedAsync(Guid userId, CancellationToken cancellationToken = default)
+    {
+        await using OpenIddictDbContext db = await dbFactory
+            .CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+
+        await db.Set<LocalIdentity>()
+            .IgnoreQueryFilters([GranitFilterNames.MultiTenant])
+            .Where(u => u.Id == userId)
+            .ExecuteUpdateAsync(
+                s => s.SetProperty(u => u.RegistrationEventPendingSince, (DateTimeOffset?)null),
+                cancellationToken)
+            .ConfigureAwait(false);
+    }
+}

--- a/src/Granit.OpenIddict/GranitOpenIddictModule.cs
+++ b/src/Granit.OpenIddict/GranitOpenIddictModule.cs
@@ -79,6 +79,7 @@ public sealed class GranitOpenIddictModule : GranitModule
         context.Services.TryAddScoped<ITotpService, DefaultTotpService>();
         context.Services.TryAddScoped<IAccountDeletionService, Internal.AspNetAccountDeletionService>();
         context.Services.TryAddScoped<IAccountDeletionEtoReconciler, Internal.AccountDeletionEtoReconciler>();
+        context.Services.TryAddScoped<IRegistrationEtoReconciler, Internal.RegistrationEtoReconciler>();
         context.Services.TryAddScoped<IImpersonationService, Internal.AspNetImpersonationService>();
         context.Services.TryAddScoped<IKeyRotationService, Internal.KeyRotationService>();
 

--- a/src/Granit.OpenIddict/Internal/RegistrationEtoReconciler.cs
+++ b/src/Granit.OpenIddict/Internal/RegistrationEtoReconciler.cs
@@ -1,0 +1,63 @@
+using Granit.Events;
+using Granit.Identity.Local.Events;
+using Granit.OpenIddict.Services;
+using Microsoft.Extensions.Logging;
+
+namespace Granit.OpenIddict.Internal;
+
+/// <summary>
+/// Publishes the <see cref="UserRegisteredEto"/> for every account that still owes a registration
+/// event, then clears the pending marker.
+/// </summary>
+/// <remarks>
+/// The registration flow publishes the event inline for immediate side effects (default-role
+/// assignment, welcome notification) but records the intent durably first — the OpenIddict DbContext
+/// is not enrolled in the Wolverine outbox, so an inline publish after the account-creation commit
+/// could be lost to a crash before it reaches the durable outbox. This reconciler (driven by a
+/// recurring job) closes that gap: the <c>RegistrationEventPendingSince</c> marker is the durable
+/// intent, and the event is published at-least-once from it. Consumers of
+/// <see cref="UserRegisteredEto"/> are idempotent, so a rare re-publish (crash between the inline
+/// publish and the clear) is safe.
+/// </remarks>
+internal sealed partial class RegistrationEtoReconciler(
+    IPendingRegistrationStore store,
+    IDistributedEventBus eventBus,
+    ILogger<RegistrationEtoReconciler> logger) : IRegistrationEtoReconciler
+{
+    private const int BatchSize = 500;
+
+    public async Task ReconcileAsync(CancellationToken cancellationToken)
+    {
+        IReadOnlyList<PendingRegistration> pending = await store
+            .GetPendingAsync(BatchSize, cancellationToken).ConfigureAwait(false);
+
+        if (pending.Count == 0)
+        {
+            return;
+        }
+
+        LogReconciling(logger, pending.Count);
+
+        foreach (PendingRegistration registration in pending)
+        {
+            // Publish before marking: if the process dies between the two, the next sweep re-publishes
+            // (at-least-once). Marking first would risk dropping the event entirely.
+            await eventBus.PublishAsync(
+                new UserRegisteredEto(registration.UserId, registration.TenantId), cancellationToken)
+                .ConfigureAwait(false);
+
+            await store.MarkDispatchedAsync(registration.UserId, cancellationToken)
+                .ConfigureAwait(false);
+
+            LogDispatched(logger, registration.UserId);
+        }
+    }
+
+    [LoggerMessage(Level = LogLevel.Information,
+        Message = "Reconciling {Count} pending registration event(s).")]
+    private static partial void LogReconciling(ILogger logger, int count);
+
+    [LoggerMessage(Level = LogLevel.Debug,
+        Message = "Dispatched UserRegisteredEto for user {UserId}.")]
+    private static partial void LogDispatched(ILogger logger, Guid userId);
+}

--- a/tests/Granit.Identity.Local.AspNetIdentity.Tests/AspNetExternalLoginServiceTests.cs
+++ b/tests/Granit.Identity.Local.AspNetIdentity.Tests/AspNetExternalLoginServiceTests.cs
@@ -5,6 +5,7 @@ using Granit.Identity.Local.AspNetIdentity.Internal;
 using Granit.Identity.Local.Domain;
 using Granit.Identity.Local.Events;
 using Granit.Identity.Local.Services;
+using Granit.Timing;
 using Microsoft.AspNetCore.Identity;
 using NSubstitute;
 using Shouldly;
@@ -30,10 +31,14 @@ public sealed class AspNetExternalLoginServiceTests
         // keep the happy path creating directly.
         _userManager.Options = new IdentityOptions();
 
+        IClock clock = Substitute.For<IClock>();
+        clock.Now.Returns(DateTimeOffset.UnixEpoch);
+
         _sut = new AspNetExternalLoginService(
             _userManager,
             _claimsMapper,
             _eventBus,
+            clock,
             Microsoft.Extensions.Options.Options.Create(_externalAuthOptions));
     }
 

--- a/tests/Granit.Identity.Local.Endpoints.Tests/Integration/AccountEndpointsTestServer.cs
+++ b/tests/Granit.Identity.Local.Endpoints.Tests/Integration/AccountEndpointsTestServer.cs
@@ -14,6 +14,7 @@ using Granit.Identity.Local.Endpoints.Permissions;
 using Granit.Identity.Local.Services;
 using Granit.MultiTenancy;
 using Granit.Settings.Services;
+using Granit.Timing;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Identity;
@@ -184,6 +185,9 @@ internal sealed class AccountEndpointsTestServer : IAsyncDisposable
         TimeProvider timeProvider = Substitute.For<TimeProvider>();
         timeProvider.GetUtcNow().Returns(FixedNow);
 
+        IClock clock = Substitute.For<IClock>();
+        clock.Now.Returns(FixedNow);
+
         // ASP.NET Identity mocks — SignInManager requires UserManager which requires IUserStore
         IUserStore<LocalIdentity> userStore = Substitute.For<IUserStore<LocalIdentity>>();
         UserManager<LocalIdentity> userManager = Substitute.For<UserManager<LocalIdentity>>(
@@ -249,6 +253,7 @@ internal sealed class AccountEndpointsTestServer : IAsyncDisposable
         builder.Services.AddSingleton(settingProvider);
         builder.Services.AddScoped<IdentityLocalConfigProvider>();
         builder.Services.AddSingleton(timeProvider);
+        builder.Services.AddSingleton(clock);
         builder.Services.AddSingleton(signInManager);
         builder.Services.AddSingleton(userManager);
         builder.Services.AddSingleton(currentTenant);

--- a/tests/Granit.OpenIddict.Tests.Integration/Persistence/PendingRegistrationStoreTests.cs
+++ b/tests/Granit.OpenIddict.Tests.Integration/Persistence/PendingRegistrationStoreTests.cs
@@ -1,0 +1,103 @@
+using Granit.Identity.Local.Domain;
+using Granit.MultiTenancy;
+using Granit.OpenIddict.EntityFrameworkCore.Internal;
+using Granit.OpenIddict.Services;
+using Granit.OpenIddict.Tests.Integration.Fixtures;
+using Microsoft.EntityFrameworkCore;
+using Shouldly;
+using Xunit;
+
+#pragma warning disable EF1001 // EfPendingRegistrationStore / OpenIddictDbContext are internal — accessible via InternalsVisibleTo
+
+namespace Granit.OpenIddict.Tests.Integration.Persistence;
+
+/// <summary>
+/// Validates that <see cref="EfPendingRegistrationStore"/> finds accounts with a pending registration
+/// event across every tenant, excludes soft-deleted and already-cleared accounts, and stops returning
+/// an account once marked. Needs real PostgreSQL: the query bypasses the multi-tenant filter while
+/// keeping the soft-delete filter, and marking uses a bulk <c>ExecuteUpdate</c> — neither is
+/// faithfully exercised by mocks.
+/// </summary>
+public sealed class PendingRegistrationStoreTests : IAsyncLifetime
+{
+    private static readonly Guid TenantA = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    private static readonly DateTimeOffset PendingSince = DateTimeOffset.UnixEpoch;
+
+    private readonly PostgresFixture _postgres = new();
+    private Factory? _factory;
+
+    private EfPendingRegistrationStore Store => new(_factory!);
+
+    public async ValueTask InitializeAsync()
+    {
+        await _postgres.InitializeAsync();
+
+        DbContextOptions<OpenIddictDbContext> options =
+            new DbContextOptionsBuilder<OpenIddictDbContext>()
+                .UseNpgsql(_postgres.ConnectionString)
+                .Options;
+        _factory = new Factory(options);
+
+        await using OpenIddictDbContext db = _factory.CreateDbContext();
+        await db.Database.EnsureCreatedAsync(TestContext.Current.CancellationToken);
+    }
+
+    public async ValueTask DisposeAsync() => await _postgres.DisposeAsync();
+
+    [Fact]
+    public async Task GetPending_ReturnsPending_AcrossTenants_ExcludingDeletedAndCleared()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+        Guid globalPending = await SeedAsync(tenantId: null, pending: true, deleted: false, ct);
+        Guid tenantPending = await SeedAsync(tenantId: TenantA, pending: true, deleted: false, ct);
+        await SeedAsync(tenantId: null, pending: false, deleted: false, ct);   // already dispatched/other means
+        await SeedAsync(tenantId: TenantA, pending: true, deleted: true, ct);  // pending but soft-deleted → moot
+
+        IReadOnlyList<PendingRegistration> pending = await Store.GetPendingAsync(100, ct);
+
+        pending.Select(p => p.UserId).ShouldBe([globalPending, tenantPending], ignoreOrder: true);
+        pending.Single(p => p.UserId == tenantPending).TenantId.ShouldBe(TenantA);
+        pending.Single(p => p.UserId == globalPending).TenantId.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task MarkDispatched_ExcludesFromNextSweep()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+        Guid userId = await SeedAsync(tenantId: TenantA, pending: true, deleted: false, ct);
+
+        (await Store.GetPendingAsync(100, ct)).ShouldContain(p => p.UserId == userId);
+
+        await Store.MarkDispatchedAsync(userId, ct);
+
+        (await Store.GetPendingAsync(100, ct)).ShouldNotContain(p => p.UserId == userId);
+    }
+
+    private async Task<Guid> SeedAsync(Guid? tenantId, bool pending, bool deleted, CancellationToken ct)
+    {
+        var id = Guid.NewGuid();
+        await using OpenIddictDbContext db = _factory!.CreateDbContext();
+        db.Set<LocalIdentity>().Add(new LocalIdentity
+        {
+            Id = id,
+            UserName = id.ToString("N"),
+            NormalizedUserName = id.ToString("N").ToUpperInvariant(),
+            Email = $"{id:N}@example.com",
+            SecurityStamp = Guid.NewGuid().ToString("N"),
+            TenantId = tenantId,
+            IsDeleted = deleted,
+            DeletedAt = deleted ? PendingSince : null,
+            RegistrationEventPendingSince = pending ? PendingSince : null,
+        });
+        await db.SaveChangesAsync(ct);
+        return id;
+    }
+
+    private sealed class Factory(DbContextOptions<OpenIddictDbContext> options)
+        : IDbContextFactory<OpenIddictDbContext>
+    {
+        public OpenIddictDbContext CreateDbContext() => new(options, NullTenantContext.Instance);
+    }
+}
+
+#pragma warning restore EF1001

--- a/tests/Granit.OpenIddict.Tests/Internal/RegistrationEtoReconcilerTests.cs
+++ b/tests/Granit.OpenIddict.Tests/Internal/RegistrationEtoReconcilerTests.cs
@@ -1,0 +1,60 @@
+using Granit.Events;
+using Granit.Identity.Local.Events;
+using Granit.OpenIddict.Internal;
+using Granit.OpenIddict.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Xunit;
+
+namespace Granit.OpenIddict.Tests.Internal;
+
+/// <summary>
+/// The reconciler publishes a <see cref="UserRegisteredEto"/> for every pending registration and
+/// marks each dispatched — publishing before marking so a crash between the two re-publishes
+/// (at-least-once) rather than dropping the registration side effects.
+/// </summary>
+public sealed class RegistrationEtoReconcilerTests
+{
+    [Fact]
+    public async Task ReconcileAsync_PublishesAndMarksEachPending()
+    {
+        PendingRegistration tenantUser = new(Guid.NewGuid(), Guid.NewGuid());
+        PendingRegistration globalUser = new(Guid.NewGuid(), null);
+
+        IPendingRegistrationStore store = Substitute.For<IPendingRegistrationStore>();
+        store.GetPendingAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns([tenantUser, globalUser]);
+        IDistributedEventBus bus = Substitute.For<IDistributedEventBus>();
+
+        RegistrationEtoReconciler reconciler = new(
+            store, bus, NullLogger<RegistrationEtoReconciler>.Instance);
+
+        await reconciler.ReconcileAsync(TestContext.Current.CancellationToken);
+
+        await bus.Received(1).PublishAsync(
+            Arg.Is<UserRegisteredEto>(e => e.UserId == tenantUser.UserId && e.TenantId == tenantUser.TenantId),
+            Arg.Any<CancellationToken>());
+        await bus.Received(1).PublishAsync(
+            Arg.Is<UserRegisteredEto>(e => e.UserId == globalUser.UserId && e.TenantId == null),
+            Arg.Any<CancellationToken>());
+        await store.Received(1).MarkDispatchedAsync(tenantUser.UserId, Arg.Any<CancellationToken>());
+        await store.Received(1).MarkDispatchedAsync(globalUser.UserId, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ReconcileAsync_NoPending_PublishesNothing()
+    {
+        IPendingRegistrationStore store = Substitute.For<IPendingRegistrationStore>();
+        store.GetPendingAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns([]);
+        IDistributedEventBus bus = Substitute.For<IDistributedEventBus>();
+
+        RegistrationEtoReconciler reconciler = new(
+            store, bus, NullLogger<RegistrationEtoReconciler>.Instance);
+
+        await reconciler.ReconcileAsync(TestContext.Current.CancellationToken);
+
+        await bus.DidNotReceive().PublishAsync(Arg.Any<UserRegisteredEto>(), Arg.Any<CancellationToken>());
+        await store.DidNotReceive().MarkDispatchedAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+    }
+}


### PR DESCRIPTION
## Context

Continues Phase 2C of the `Granit.OpenIddict*` refonte. #3076 made the account-deletion erasure event durable via a reconciliation sweep and deferred the external-login and impersonation Etos to a follow-up. This is the external-login half.

`UserRegisteredEto` for an external-provider registration was published inline, after the `UserManager` commit. The OpenIddict DbContext is not enrolled in the Wolverine outbox, so a crash between the account-creation commit and the publish dropped the event — the registration side effects (**default-role assignment**, **welcome notification**) never ran.

## Approach — inline publish + durable reconciliation safety-net

Chosen over pure reconciliation so the happy path keeps its immediate role/welcome, with the sweep as an at-least-once backstop.

- **`LocalIdentity.RegistrationEventPendingSince`** — stamped in the account-creation commit by the two external-login registration paths (`AspNetExternalLoginService` auto-create and the external-registration completion endpoint) and cleared after the inline publish. The marker is the durable intent; a crash before the clear leaves it set.
- **`IRegistrationEtoReconciler`** (base) re-publishes for each account that still owes an event, then clears the marker — publish-before-clear (at-least-once; consumers are idempotent).
- **`IPendingRegistrationStore` + EF impl** read pending accounts across every tenant (ignores the MultiTenant filter) while keeping the SoftDelete filter active — a registration event for a since-deleted account is moot. Clearing uses a bulk `ExecuteUpdate`.
- **`OpenIddictRegistrationEtoDispatchJob`** (`[RecurringJob]`, every 5 min) drives the reconciler.

## Scope note

Only the two **external-login** paths are wired — they create `LocalIdentity` via `UserManager` directly, so the marker can be set atomically with creation. **Self-registration** creates through the provider-agnostic `IIdentityProvider` abstraction (shared with admin user-write, which must *not* emit the event), so making it durable needs a separate design — it follows separately, along with the impersonation Eto (routed via the durable audit pipeline).

## Verification

- Base 277/277 · EFCore 42/42 · AspNetIdentity 185/185 · endpoints 195/195 · OpenIddict integration green (incl. new Postgres store test) · architecture 262/262 + 19/19 · format clean.

## Migration

Hosts must add a migration for the new `RegistrationEventPendingSince` column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)