### PR TITLE
fix(openapi): regenerate OpenApi.Generator lock for Federated deps (CI unblock)

### DIFF
--- a/src/Granit.OpenApi.Generator/packages.lock.json
+++ b/src/Granit.OpenApi.Generator/packages.lock.json
@@ -913,11 +913,13 @@
       "granit.identity.federated": {
         "type": "Project",
         "dependencies": {
+          "Granit.Authorization": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Identity": "[0.1.0-dev, )",
           "Granit.Localization": "[0.1.0-dev, )",
+          "Granit.Persistence": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },


### PR DESCRIPTION
## CI unblock — `src-only` shard NU1004

A clean locked-mode restore of the `src-only` shard fails:

```
Granit.OpenApi.Generator.csproj : error NU1004: The project references granit.identity.federated
whose dependencies has changed. The packages lock file is inconsistent with the project dependencies...
```

### Root cause

`Granit.OpenApi.Generator` composes contracts via a **wildcard** reference
(`<ProjectReference Include="..\Granit.*.Endpoints\...">`), so its `packages.lock.json`
records the transitive closure of every `.Endpoints` package — including
`granit.identity.federated` (via `Granit.Identity.Federated.Endpoints`).

**Vague 5 (#3090)** added `Granit.Authorization` and `Granit.Persistence` to the base
`Granit.Identity.Federated` module, but the generator's lock was not regenerated at the
time (its wildcard edge sits in the `src-only` shard, outside that PR's regeneration sweep —
the same latent-miss class as the #3087 hotfix). The drift only surfaces on a fresh
clean-cache locked restore.

### Fix

Force-evaluate **only** `src/Granit.OpenApi.Generator/packages.lock.json` — adds the two
missing federated transitive deps (`Granit.Authorization`, `Granit.Persistence`). Unrelated
OpenIddict `7.5.0→7.6.0` lock drift pulled in by the evaluation was reverted. Verified: a
`--locked-mode` restore of the generator is now clean and the project builds `--no-restore`.

Scanned every other `packages.lock.json` with a `granit.identity.federated` block — none
were stale, so this is the only affected lock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)