### PR TITLE
fix(tests): narrow nullable Content before ShouldContain in AI test suites

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -29092,7 +29092,7 @@
       "kind": "class",
       "project": "Granit.Identity.Federated.Cognito",
       "file": "src/Granit.Identity.Federated.Cognito/Extensions/IdentityCognitoServiceCollectionExtensions.cs",
-      "line": 19,
+      "line": 20,
       "members": [
         {
           "name": "AddGranitIdentityCognito",
@@ -29177,6 +29177,22 @@
           "kind": "property",
           "signature": "OrphanedRolePolicy OrphanedRolePolicy",
           "returnType": "OrphanedRolePolicy"
+        }
+      ]
+    },
+    {
+      "name": "IdentityFederatedMetrics",
+      "fqn": "Granit.Identity.Federated.Diagnostics.IdentityFederatedMetrics",
+      "kind": "class",
+      "project": "Granit.Identity.Federated",
+      "file": "src/Granit.Identity.Federated/Diagnostics/IdentityFederatedMetrics.cs",
+      "line": 18,
+      "members": [
+        {
+          "name": "RecordProviderFailure",
+          "kind": "method",
+          "signature": "RecordProviderFailure(string providerName, string operation, IdentityProviderFailureCategory category, string? tenantId)",
+          "returnType": "void"
         }
       ]
     },
@@ -29312,7 +29328,7 @@
       "kind": "class",
       "project": "Granit.Identity.Federated.EntraId",
       "file": "src/Granit.Identity.Federated.EntraId/Extensions/IdentityEntraIdServiceCollectionExtensions.cs",
-      "line": 19,
+      "line": 20,
       "members": [
         {
           "name": "AddGranitIdentityEntraId",
@@ -29480,12 +29496,57 @@
       "members": []
     },
     {
+      "name": "IdentityProviderException",
+      "fqn": "Granit.Identity.Federated.Exceptions.IdentityProviderException",
+      "kind": "class",
+      "project": "Granit.Identity.Federated",
+      "file": "src/Granit.Identity.Federated/Exceptions/IdentityProviderException.cs",
+      "line": 30,
+      "members": []
+    },
+    {
+      "name": "IdentityProviderFailureCategory",
+      "fqn": "Granit.Identity.Federated.Exceptions.IdentityProviderFailureCategory",
+      "kind": "enum",
+      "project": "Granit.Identity.Federated",
+      "file": "src/Granit.Identity.Federated/Exceptions/IdentityProviderException.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "IdentityProviderNotFoundException",
+      "fqn": "Granit.Identity.Federated.Exceptions.IdentityProviderNotFoundException",
+      "kind": "class",
+      "project": "Granit.Identity.Federated",
+      "file": "src/Granit.Identity.Federated/Exceptions/IdentityProviderNotFoundException.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "IdentityProviderThrottledException",
+      "fqn": "Granit.Identity.Federated.Exceptions.IdentityProviderThrottledException",
+      "kind": "class",
+      "project": "Granit.Identity.Federated",
+      "file": "src/Granit.Identity.Federated/Exceptions/IdentityProviderThrottledException.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "IdentityProviderTransientException",
+      "fqn": "Granit.Identity.Federated.Exceptions.IdentityProviderTransientException",
+      "kind": "class",
+      "project": "Granit.Identity.Federated",
+      "file": "src/Granit.Identity.Federated/Exceptions/IdentityProviderTransientException.cs",
+      "line": 9,
+      "members": []
+    },
+    {
       "name": "IdentityProviderUnauthorizedException",
       "fqn": "Granit.Identity.Federated.Exceptions.IdentityProviderUnauthorizedException",
       "kind": "class",
       "project": "Granit.Identity.Federated",
       "file": "src/Granit.Identity.Federated/Exceptions/IdentityProviderUnauthorizedException.cs",
-      "line": 19,
+      "line": 21,
       "members": []
     },
     {
@@ -29505,6 +29566,15 @@
       ]
     },
     {
+      "name": "IdentityProviderDegradationExtensions",
+      "fqn": "Granit.Identity.Federated.Extensions.IdentityProviderDegradationExtensions",
+      "kind": "class",
+      "project": "Granit.Identity.Federated",
+      "file": "src/Granit.Identity.Federated/Extensions/IdentityProviderDegradationExtensions.cs",
+      "line": 13,
+      "members": []
+    },
+    {
       "name": "FederatedIdentityUser",
       "fqn": "Granit.Identity.Federated.FederatedIdentityUser",
       "kind": "record",
@@ -29519,7 +29589,7 @@
       "kind": "class",
       "project": "Granit.Identity.Federated.GoogleCloud",
       "file": "src/Granit.Identity.Federated.GoogleCloud/Extensions/IdentityGoogleCloudServiceCollectionExtensions.cs",
-      "line": 19,
+      "line": 20,
       "members": [
         {
           "name": "AddGranitIdentityGoogleCloud",
@@ -29579,7 +29649,7 @@
       "kind": "class",
       "project": "Granit.Identity.Federated",
       "file": "src/Granit.Identity.Federated/GranitIdentityFederatedModule.cs",
-      "line": 31,
+      "line": 32,
       "members": [
         {
           "name": "ConfigureServices",
@@ -29645,7 +29715,7 @@
       "kind": "class",
       "project": "Granit.Identity.Federated.Keycloak",
       "file": "src/Granit.Identity.Federated.Keycloak/Extensions/IdentityKeycloakServiceCollectionExtensions.cs",
-      "line": 19,
+      "line": 20,
       "members": [
         {
           "name": "AddGranitIdentityKeycloak",

--- a/tests/Granit.DataExchange.AI.Tests/AISemanticMappingServiceTests.cs
+++ b/tests/Granit.DataExchange.AI.Tests/AISemanticMappingServiceTests.cs
@@ -142,6 +142,7 @@ public sealed class AISemanticMappingServiceTests
         await CreateService().SuggestSemanticMappingsAsync(_headers, _targetFields, TestContext.Current.CancellationToken);
 
         captured.ShouldNotBeNull();
+        captured.Content.ShouldNotBeNull();
         // Untrusted source columns flow through the sanitized Content channel...
         captured.Content.ShouldContain("Email");
         captured.Content.ShouldContain("Phone Number");
@@ -168,6 +169,7 @@ public sealed class AISemanticMappingServiceTests
 
         result.Count.ShouldBe(1);
         captured.ShouldNotBeNull();
+        captured.Content.ShouldNotBeNull();
         captured.Content.ShouldNotContain("Sample data");
         captured.Content.ShouldNotContain("john@example.com");
     }
@@ -188,6 +190,7 @@ public sealed class AISemanticMappingServiceTests
 
         result.Count.ShouldBe(1);
         captured.ShouldNotBeNull();
+        captured.Content.ShouldNotBeNull();
         captured.Content.ShouldContain("Sample data");
         captured.Content.ShouldContain("john@example.com");
     }

--- a/tests/Granit.Notifications.AI.Tests/LlmChannelSelectorTests.cs
+++ b/tests/Granit.Notifications.AI.Tests/LlmChannelSelectorTests.cs
@@ -133,6 +133,7 @@ public sealed class LlmChannelSelectorTests
         captured.Instruction.ShouldContain("email");
         captured.Instruction.ShouldContain("push");
         // The notification context is the analyzed content.
+        captured.Content.ShouldNotBeNull();
         captured.Content.ShouldContain("order.completed");
         captured.Content.ShouldContain("Fatal");
     }

--- a/tests/Granit.Notifications.AI.Tests/LlmNotificationContentGeneratorTests.cs
+++ b/tests/Granit.Notifications.AI.Tests/LlmNotificationContentGeneratorTests.cs
@@ -108,6 +108,7 @@ public sealed class LlmNotificationContentGeneratorTests
 
         captured.ShouldNotBeNull();
         // Untrusted business data flows through the Content channel...
+        captured.Content.ShouldNotBeNull();
         captured.Content.ShouldContain("ORD-001");
         // ...the locale is developer-controlled instruction...
         captured.Instruction!.ShouldContain("fr");
@@ -129,6 +130,7 @@ public sealed class LlmNotificationContentGeneratorTests
         // GDPR: the payload may contain personal data — it must never reach the LLM
         // unless the host explicitly sets AllowPersonalDataInPrompts = true.
         captured.ShouldNotBeNull();
+        captured.Content.ShouldNotBeNull();
         captured.Content.ShouldBe("{}");
         captured.Content.ShouldNotContain("ORD-001");
     }

--- a/tests/Granit.Observability.AI.Tests/LlmLogAnalyzerTests.cs
+++ b/tests/Granit.Observability.AI.Tests/LlmLogAnalyzerTests.cs
@@ -134,6 +134,7 @@ public sealed class LlmLogAnalyzerTests : IDisposable
             [new LogEntry(DateTimeOffset.UtcNow, "Error", "boom happened", null)], TestContext.Current.CancellationToken);
 
         captured.ShouldNotBeNull();
+        captured.Content.ShouldNotBeNull();
         captured.Content.ShouldContain("boom happened");
         captured.WorkspaceName.ShouldBe("test-workspace");
     }

--- a/tests/Granit.Timeline.AI.Tests/LlmTimelineAnomalyDetectorTests.cs
+++ b/tests/Granit.Timeline.AI.Tests/LlmTimelineAnomalyDetectorTests.cs
@@ -144,6 +144,7 @@ public sealed class LlmTimelineAnomalyDetectorTests
         await CreateSut().DetectAnomaliesAsync("Ticket", TestEntityId, TestContext.Current.CancellationToken);
 
         captured.ShouldNotBeNull();
+        captured.Content.ShouldNotBeNull();
         captured.Content.ShouldContain("Did a thing");
         captured.Content.ShouldContain("User-abcdef12"); // pseudonymized author
         captured.Content.ShouldNotContain("Jane Doe");   // raw author name never sent


### PR DESCRIPTION
## Problem

CI build broke with **CS8604 (Possible null reference argument)** across several `*.AI.Tests` projects:

- `Granit.DataExchange.AI.Tests/AISemanticMappingServiceTests.cs` (146, 171, 191)
- `Granit.Timeline.AI.Tests/LlmTimelineAnomalyDetectorTests.cs` (147)
- `Granit.Observability.AI.Tests/LlmLogAnalyzerTests.cs` (137)

## Root cause

`StructuredCompletionRequest.Content` is `string?`. The tests assert on the captured request with `captured.Content.ShouldContain(...)` / `ShouldNotContain(...)`, whose `actual` parameter is **non-nullable** `string`. The preceding `captured.ShouldNotBeNull()` narrows `captured` — not its `Content` property — so the compiler flagged the argument as possibly null.

## Fix

Add `captured.Content.ShouldNotBeNull();` before the affected assertions to flow-narrow `Content`, matching the `.ShouldNotBeNull()` pattern the code already uses for the `Instruction` channel. `ShouldBe(...)` calls are left untouched (that overload accepts a nullable `actual`).

Also fixed the same latent defect preemptively in `Granit.Notifications.AI.Tests` (`LlmChannelSelectorTests`, `LlmNotificationContentGeneratorTests`) — not in the failing log but on the same code path in another shard.

## Verification

All four (now five) affected test projects build clean in Release:

- `Granit.DataExchange.AI.Tests` — Build succeeded
- `Granit.Timeline.AI.Tests` — Build succeeded
- `Granit.Observability.AI.Tests` — Build succeeded
- `Granit.Notifications.AI.Tests` — Build succeeded

🤖 Generated with [Claude Code](https://claude.com/claude-code)