### PR TITLE
refactor(identity)!: provider failure taxonomy + graceful-degradation decorator (Vague 6b-i)

### DIFF
--- a/src/Granit.Identity.Federated.Cognito/Extensions/IdentityCognitoServiceCollectionExtensions.cs
+++ b/src/Granit.Identity.Federated.Cognito/Extensions/IdentityCognitoServiceCollectionExtensions.cs
@@ -6,6 +6,7 @@ using Granit.Identity.Extensions;
 using Granit.Identity.Federated.Cognito.Internal;
 using Granit.Identity.Federated.Cognito.Options;
 using Granit.Identity.Federated.Cognito.Sync;
+using Granit.Identity.Federated.Extensions;
 using Granit.Identity.Federated.Sync;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -53,26 +54,26 @@ public static class IdentityCognitoServiceCollectionExtensions
         });
 
         services.AddIdentityProvider<CognitoIdentityProvider>();
+
+        // Wrap IIdentityProvider with graceful degradation; registers CognitoIdentityProvider by
+        // its concrete type so the facets the decorator does not carry (client-role, session,
+        // device) resolve the raw provider directly below.
+        services.DecorateIdentityProviderWithGracefulDegradation<CognitoIdentityProvider>();
         services.Replace(ServiceDescriptor.Scoped<IIdentityProviderCapabilities, CognitoIdentityProviderCapabilities>());
 
-        // Client-role capability (Phase 2). Forwards to the scoped IIdentityProvider so
-        // IIdentityProvider and IIdentityClientRoleManager resolve to the SAME scoped
-        // CognitoIdentityProvider instance — keeps internal state coherent across the
-        // two facets. See ADR-027.
-        services.TryAddScoped<IIdentityClientRoleManager>(sp =>
-            sp.GetRequiredService<IIdentityProvider>() as IIdentityClientRoleManager
-            ?? throw new InvalidOperationException(
-                "The registered IIdentityProvider does not implement IIdentityClientRoleManager — " +
-                "AddGranitIdentityCognito must be the last provider-registration call."));
+        // Client-role capability (Phase 2). Resolves the concrete CognitoIdentityProvider so this
+        // facet — which IIdentityProvider does not compose, and the decorator therefore does not
+        // implement — shares the SAME scoped instance. See ADR-027.
+        services.TryAddScoped<IIdentityClientRoleManager>(sp => sp.GetRequiredService<CognitoIdentityProvider>());
 
         // Session/device facets. Replace the Null defaults so the canonical /sessions and /devices
-        // endpoints surface Cognito data. Both forward to the SAME scoped IIdentityProvider instance
-        // (mirroring IIdentityClientRoleManager above) so every facet shares one CognitoIdentityProvider.
+        // endpoints surface Cognito data. Both resolve the concrete CognitoIdentityProvider (the
+        // decorator does not implement these facets), keeping every facet on one shared instance.
         // Registered at Federated precedence: a co-resident BFF wins the session facet deterministically.
         services.SetUserSessionProvider(
             UserSessionProviderPrecedence.Federated,
-            sessionFactory: sp => (IUserSessionProvider)sp.GetRequiredService<IIdentityProvider>(),
-            deviceFactory: sp => (IUserDeviceProvider)sp.GetRequiredService<IIdentityProvider>());
+            sessionFactory: sp => sp.GetRequiredService<CognitoIdentityProvider>(),
+            deviceFactory: sp => sp.GetRequiredService<CognitoIdentityProvider>());
 
         // Client-role sync pipeline — enumerates prefix-matching Cognito groups for each
         // tracked app-client id at host boot and upserts RoleMetadata rows.

--- a/src/Granit.Identity.Federated.EntraId/Extensions/IdentityEntraIdServiceCollectionExtensions.cs
+++ b/src/Granit.Identity.Federated.EntraId/Extensions/IdentityEntraIdServiceCollectionExtensions.cs
@@ -5,6 +5,7 @@ using Granit.Identity.Federated.EntraId.HealthChecks;
 using Granit.Identity.Federated.EntraId.Internal;
 using Granit.Identity.Federated.EntraId.Options;
 using Granit.Identity.Federated.EntraId.Sync;
+using Granit.Identity.Federated.Extensions;
 using Granit.Identity.Federated.Sync;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -59,26 +60,26 @@ public static class IdentityEntraIdServiceCollectionExtensions
         services.TryAddSingleton<EntraIdAdminTokenService>();
         services.TryAddScoped<IPasswordResetNotifier, NullPasswordResetNotifier>();
         services.AddIdentityProvider<EntraIdIdentityProvider>();
+
+        // Wrap IIdentityProvider with graceful degradation; registers EntraIdIdentityProvider by
+        // its concrete type so the facets the decorator does not carry (client-role, session,
+        // device) resolve the raw provider directly below.
+        services.DecorateIdentityProviderWithGracefulDegradation<EntraIdIdentityProvider>();
         services.Replace(ServiceDescriptor.Scoped<IIdentityProviderCapabilities, EntraIdIdentityProviderCapabilities>());
 
-        // Client-role capability (Phase 2). Forwards to the scoped IIdentityProvider so
-        // IIdentityProvider and IIdentityClientRoleManager resolve to the SAME scoped
-        // EntraIdIdentityProvider instance — avoids doubling Graph admin-token acquisition
-        // and keeps internal state coherent across the two facets.
-        services.TryAddScoped<IIdentityClientRoleManager>(sp =>
-            sp.GetRequiredService<IIdentityProvider>() as IIdentityClientRoleManager
-            ?? throw new InvalidOperationException(
-                "The registered IIdentityProvider does not implement IIdentityClientRoleManager — " +
-                "AddGranitIdentityEntraId must be the last provider-registration call."));
+        // Client-role capability (Phase 2). Resolves the concrete EntraIdIdentityProvider so this
+        // facet — which IIdentityProvider does not compose, and the decorator therefore does not
+        // implement — shares the SAME scoped instance, avoiding doubled Graph admin-token acquisition.
+        services.TryAddScoped<IIdentityClientRoleManager>(sp => sp.GetRequiredService<EntraIdIdentityProvider>());
 
-        // Session/device facets — forward to the scoped IIdentityProvider so the EntraId provider
-        // surfaces sessions and devices to IUserSessionManager, replacing the Null defaults from
-        // Granit.Identity.Abstractions. Same forwarding rationale as IIdentityClientRoleManager above.
+        // Session/device facets — resolve the concrete EntraIdIdentityProvider (the decorator does
+        // not implement these facets) so the EntraId provider surfaces sessions and devices to
+        // IUserSessionManager, replacing the Null defaults from Granit.Identity.Abstractions.
         // Registered at Federated precedence: a co-resident BFF wins the session facet deterministically.
         services.SetUserSessionProvider(
             UserSessionProviderPrecedence.Federated,
-            sessionFactory: sp => (IUserSessionProvider)sp.GetRequiredService<IIdentityProvider>(),
-            deviceFactory: sp => (IUserDeviceProvider)sp.GetRequiredService<IIdentityProvider>());
+            sessionFactory: sp => sp.GetRequiredService<EntraIdIdentityProvider>(),
+            deviceFactory: sp => sp.GetRequiredService<EntraIdIdentityProvider>());
 
         // Client-role sync pipeline — enumerates Entra ID App Roles for each tracked appId
         // at host boot and upserts RoleMetadata rows. See ADR-026 for details.

--- a/src/Granit.Identity.Federated.GoogleCloud/Extensions/IdentityGoogleCloudServiceCollectionExtensions.cs
+++ b/src/Granit.Identity.Federated.GoogleCloud/Extensions/IdentityGoogleCloudServiceCollectionExtensions.cs
@@ -3,6 +3,7 @@ using FirebaseAdmin.Auth;
 using Google.Apis.Auth.OAuth2;
 using Granit.Diagnostics;
 using Granit.Identity.Extensions;
+using Granit.Identity.Federated.Extensions;
 using Granit.Identity.Federated.GoogleCloud.HealthChecks;
 using Granit.Identity.Federated.GoogleCloud.Internal;
 using Granit.Identity.Federated.GoogleCloud.Options;
@@ -53,6 +54,10 @@ public static class IdentityGoogleCloudServiceCollectionExtensions
 
         services.TryAddSingleton<IFirebaseAuthTransport, FirebaseAuthTransport>();
         services.AddIdentityProvider<GoogleCloudIdentityProvider>();
+
+        // Wrap IIdentityProvider with graceful degradation (GoogleCloud exposes neither the
+        // client-role nor session/device facets, so no concrete-type forwarders are needed).
+        services.DecorateIdentityProviderWithGracefulDegradation<GoogleCloudIdentityProvider>();
         services.Replace(ServiceDescriptor.Scoped<IIdentityProviderCapabilities, GoogleCloudIdentityProviderCapabilities>());
 
         return services;

--- a/src/Granit.Identity.Federated.Keycloak/Extensions/IdentityKeycloakServiceCollectionExtensions.cs
+++ b/src/Granit.Identity.Federated.Keycloak/Extensions/IdentityKeycloakServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 using Granit.Diagnostics;
 using Granit.Http.Resilience.Extensions;
 using Granit.Identity.Extensions;
+using Granit.Identity.Federated.Extensions;
 using Granit.Identity.Federated.Keycloak.HealthChecks;
 using Granit.Identity.Federated.Keycloak.Internal;
 using Granit.Identity.Federated.Keycloak.Options;
@@ -70,28 +71,27 @@ public static class IdentityKeycloakServiceCollectionExtensions
         // RFC 8693 naked-impersonation flow is unbounded per target user.
         services.TryAddSingleton<ITokenExchangeRateLimiter, NullTokenExchangeRateLimiter>();
         services.AddIdentityProvider<KeycloakIdentityProvider>();
+
+        // Wrap IIdentityProvider with graceful degradation; registers KeycloakIdentityProvider by
+        // its concrete type so the facets the decorator does not carry (client-role, session,
+        // device) resolve the raw provider directly below.
+        services.DecorateIdentityProviderWithGracefulDegradation<KeycloakIdentityProvider>();
         services.Replace(ServiceDescriptor.Scoped<IIdentityProviderCapabilities, KeycloakIdentityProviderCapabilities>());
 
-        // Client-role capability (Phase 2). Forwards to the scoped IIdentityProvider so
-        // IIdentityProvider and IIdentityClientRoleManager resolve to the SAME scoped
-        // KeycloakIdentityProvider instance — avoids doubling the admin-token acquisition
-        // and keeps internal state coherent across the two facets.
-        services.TryAddScoped<IIdentityClientRoleManager>(sp =>
-            sp.GetRequiredService<IIdentityProvider>() as IIdentityClientRoleManager
-            ?? throw new InvalidOperationException(
-                "The registered IIdentityProvider does not implement IIdentityClientRoleManager — " +
-                "AddGranitIdentityKeycloak must be the last provider-registration call."));
+        // Client-role capability (Phase 2). Resolves the concrete KeycloakIdentityProvider so this
+        // facet — which IIdentityProvider does not compose, and the decorator therefore does not
+        // implement — shares the SAME scoped instance, avoiding doubled admin-token acquisition.
+        services.TryAddScoped<IIdentityClientRoleManager>(sp => sp.GetRequiredService<KeycloakIdentityProvider>());
 
         // Session/device facets. Replace the Null defaults (from the Identity Abstractions module)
         // so the canonical /sessions and /devices APIs surface Keycloak SSO sessions and devices —
-        // and revoke them via the Admin API. Both forward to the same scoped IIdentityProvider so
-        // every facet resolves to the SAME KeycloakIdentityProvider instance, sharing its admin-token
-        // acquisition (same instance-sharing rationale as IIdentityClientRoleManager above).
+        // and revoke them via the Admin API. Both resolve the concrete KeycloakIdentityProvider (the
+        // decorator does not implement these facets), sharing its admin-token acquisition.
         // Registered at Federated precedence: a co-resident BFF wins the session facet deterministically.
         services.SetUserSessionProvider(
             UserSessionProviderPrecedence.Federated,
-            sessionFactory: sp => (IUserSessionProvider)sp.GetRequiredService<IIdentityProvider>(),
-            deviceFactory: sp => (IUserDeviceProvider)sp.GetRequiredService<IIdentityProvider>());
+            sessionFactory: sp => sp.GetRequiredService<KeycloakIdentityProvider>(),
+            deviceFactory: sp => sp.GetRequiredService<KeycloakIdentityProvider>());
 
         // Client-role sync pipeline — enumerates Keycloak client roles for each tracked
         // clientId at host boot and upserts RoleMetadata rows. See ADR-025 for details.

--- a/src/Granit.Identity.Federated/Diagnostics/IdentityFederatedMetrics.cs
+++ b/src/Granit.Identity.Federated/Diagnostics/IdentityFederatedMetrics.cs
@@ -1,0 +1,58 @@
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using Granit.Identity.Federated.Exceptions;
+
+namespace Granit.Identity.Federated.Diagnostics;
+
+/// <summary>
+/// OpenTelemetry metrics for the federated identity providers.
+/// Meter: <c>Granit.Identity.Federated</c>.
+/// </summary>
+/// <remarks>
+/// Emitted by the graceful-degradation decorator so an operator can see the rate and
+/// classification of upstream provider failures (<c>unauthorized</c>, <c>throttled</c>,
+/// <c>transient</c>, <c>not_found</c>) that would otherwise be hidden behind a degraded
+/// empty result. Tags are <c>snake_case</c> and always include <c>tenant_id</c>
+/// (coalesced to <c>"global"</c>).
+/// </remarks>
+public sealed class IdentityFederatedMetrics(IMeterFactory meterFactory)
+{
+    /// <summary>The meter name for this module.</summary>
+    public const string MeterName = "Granit.Identity.Federated";
+
+    private const string TenantIdTag = "tenant_id";
+    private const string GlobalTenantId = "global";
+
+    private readonly Counter<long> _providerFailures = meterFactory.Create(MeterName).CreateCounter<long>(
+        "granit.identity.federated.provider.failures",
+        description: "Number of federated identity-provider operations that failed with a classified fault.");
+
+    /// <summary>
+    /// Records a classified provider failure observed by the graceful-degradation decorator.
+    /// </summary>
+    /// <param name="providerName">The provider that failed (e.g. <c>"keycloak"</c>).</param>
+    /// <param name="operation">The provider operation (e.g. <c>"get_users"</c>).</param>
+    /// <param name="category">The classified failure mode.</param>
+    /// <param name="tenantId">The current tenant id, or <see langword="null"/> for the host partition.</param>
+    public void RecordProviderFailure(
+        string providerName, string operation, IdentityProviderFailureCategory category, string? tenantId)
+    {
+        TagList tags = new()
+        {
+            { "provider", providerName },
+            { "operation", operation },
+            { "category", CategoryTag(category) },
+            { TenantIdTag, string.IsNullOrEmpty(tenantId) ? GlobalTenantId : tenantId },
+        };
+        _providerFailures.Add(1, tags);
+    }
+
+    private static string CategoryTag(IdentityProviderFailureCategory category) => category switch
+    {
+        IdentityProviderFailureCategory.Unauthorized => "unauthorized",
+        IdentityProviderFailureCategory.NotFound => "not_found",
+        IdentityProviderFailureCategory.Throttled => "throttled",
+        IdentityProviderFailureCategory.Transient => "transient",
+        _ => "unknown",
+    };
+}

--- a/src/Granit.Identity.Federated/Exceptions/IdentityProviderException.cs
+++ b/src/Granit.Identity.Federated/Exceptions/IdentityProviderException.cs
@@ -1,0 +1,53 @@
+namespace Granit.Identity.Federated.Exceptions;
+
+/// <summary>
+/// Classifies why a federated identity provider operation failed, so callers (and the
+/// graceful-degradation decorator) can react to the failure mode instead of treating every
+/// fault as an opaque empty result.
+/// </summary>
+public enum IdentityProviderFailureCategory
+{
+    /// <summary>The upstream API rejected the service-account credentials (401/403).</summary>
+    Unauthorized,
+
+    /// <summary>The targeted resource (user, client, group) does not exist upstream (404).</summary>
+    NotFound,
+
+    /// <summary>The upstream API rate-limited the request (429 / TooManyRequests).</summary>
+    Throttled,
+
+    /// <summary>A transient upstream fault (5xx, timeout, connection reset) — retry may succeed.</summary>
+    Transient,
+}
+
+/// <summary>
+/// Base type for the classified failures a federated identity provider raises. The concrete
+/// subtype and <see cref="Category"/> let the HTTP layer, health checks, and the
+/// graceful-degradation decorator distinguish "the user is gone" from "our IAM is broken"
+/// from "we are being throttled" — the distinction the providers previously collapsed into a
+/// silent empty result.
+/// </summary>
+public abstract class IdentityProviderException : Exception
+{
+    private protected IdentityProviderException(
+        IdentityProviderFailureCategory category,
+        string providerName,
+        string operation,
+        string message,
+        Exception? innerException)
+        : base(message, innerException)
+    {
+        Category = category;
+        ProviderName = providerName;
+        Operation = operation;
+    }
+
+    /// <summary>The classified failure mode.</summary>
+    public IdentityProviderFailureCategory Category { get; }
+
+    /// <summary>The provider that raised the failure (e.g. <c>"keycloak"</c>).</summary>
+    public string ProviderName { get; }
+
+    /// <summary>The operation that failed (e.g. <c>"get_users"</c>).</summary>
+    public string Operation { get; }
+}

--- a/src/Granit.Identity.Federated/Exceptions/IdentityProviderNotFoundException.cs
+++ b/src/Granit.Identity.Federated/Exceptions/IdentityProviderNotFoundException.cs
@@ -1,0 +1,19 @@
+namespace Granit.Identity.Federated.Exceptions;
+
+/// <summary>
+/// Thrown by a federated identity provider when the targeted resource (user, client, group)
+/// does not exist upstream (HTTP 404). Distinct from <see cref="IdentityProviderUnauthorizedException"/>
+/// (an IAM fault) so a genuinely absent user is not misread as an outage.
+/// </summary>
+public sealed class IdentityProviderNotFoundException : IdentityProviderException
+{
+    public IdentityProviderNotFoundException(string providerName, string operation, Exception? innerException = null)
+        : base(
+            IdentityProviderFailureCategory.NotFound,
+            providerName,
+            operation,
+            $"Identity provider '{providerName}' could not find the target of operation '{operation}'.",
+            innerException)
+    {
+    }
+}

--- a/src/Granit.Identity.Federated/Exceptions/IdentityProviderThrottledException.cs
+++ b/src/Granit.Identity.Federated/Exceptions/IdentityProviderThrottledException.cs
@@ -1,0 +1,24 @@
+namespace Granit.Identity.Federated.Exceptions;
+
+/// <summary>
+/// Thrown by a federated identity provider when the upstream API rate-limits the request
+/// (HTTP 429 / <c>TooManyRequests</c>). Carries the server-advertised <see cref="RetryAfter"/>
+/// when available so callers and background schedulers can back off intelligently.
+/// </summary>
+public sealed class IdentityProviderThrottledException : IdentityProviderException
+{
+    public IdentityProviderThrottledException(
+        string providerName, string operation, TimeSpan? retryAfter = null, Exception? innerException = null)
+        : base(
+            IdentityProviderFailureCategory.Throttled,
+            providerName,
+            operation,
+            $"Identity provider '{providerName}' throttled operation '{operation}'.",
+            innerException)
+    {
+        RetryAfter = retryAfter;
+    }
+
+    /// <summary>The server-advertised back-off delay, when the upstream supplied one.</summary>
+    public TimeSpan? RetryAfter { get; }
+}

--- a/src/Granit.Identity.Federated/Exceptions/IdentityProviderTransientException.cs
+++ b/src/Granit.Identity.Federated/Exceptions/IdentityProviderTransientException.cs
@@ -1,0 +1,20 @@
+namespace Granit.Identity.Federated.Exceptions;
+
+/// <summary>
+/// Thrown by a federated identity provider on a transient upstream fault (5xx, timeout,
+/// connection reset) — a failure that a retry might resolve, distinct from an authorization
+/// or not-found condition. The graceful-degradation decorator degrades read operations on
+/// this category (returns an empty/stale result) so a blip does not fail the whole request.
+/// </summary>
+public sealed class IdentityProviderTransientException : IdentityProviderException
+{
+    public IdentityProviderTransientException(string providerName, string operation, Exception? innerException = null)
+        : base(
+            IdentityProviderFailureCategory.Transient,
+            providerName,
+            operation,
+            $"Identity provider '{providerName}' failed operation '{operation}' with a transient upstream error.",
+            innerException)
+    {
+    }
+}

--- a/src/Granit.Identity.Federated/Exceptions/IdentityProviderUnauthorizedException.cs
+++ b/src/Granit.Identity.Federated/Exceptions/IdentityProviderUnauthorizedException.cs
@@ -13,21 +13,20 @@ namespace Granit.Identity.Federated.Exceptions;
 /// </para>
 /// <para>
 /// Providers now distinguish 401/403 from transient 5xx and re-throw this exception so
-/// the HTTP layer can surface a 503 (or 401 if appropriate) rather than 200/empty.
+/// the HTTP layer can surface a 503 (or 401 if appropriate) rather than 200/empty. The
+/// graceful-degradation decorator re-throws this category rather than degrading it, so an
+/// IAM outage is never hidden behind an empty result.
 /// </para>
 /// </remarks>
-public sealed class IdentityProviderUnauthorizedException : Exception
+public sealed class IdentityProviderUnauthorizedException : IdentityProviderException
 {
     public IdentityProviderUnauthorizedException(string providerName, string operation, Exception? innerException = null)
-        : base($"Identity provider '{providerName}' rejected operation '{operation}': service-account credentials are missing or unauthorized.", innerException)
+        : base(
+            IdentityProviderFailureCategory.Unauthorized,
+            providerName,
+            operation,
+            $"Identity provider '{providerName}' rejected operation '{operation}': service-account credentials are missing or unauthorized.",
+            innerException)
     {
-        ProviderName = providerName;
-        Operation = operation;
     }
-
-    /// <summary>The provider that returned the 401/403 (e.g. <c>"keycloak"</c>).</summary>
-    public string ProviderName { get; }
-
-    /// <summary>The operation that failed (e.g. <c>"get_user"</c>).</summary>
-    public string Operation { get; }
 }

--- a/src/Granit.Identity.Federated/Extensions/IdentityProviderDegradationExtensions.cs
+++ b/src/Granit.Identity.Federated/Extensions/IdentityProviderDegradationExtensions.cs
@@ -1,0 +1,44 @@
+using Granit.Identity.Federated.Internal;
+using Granit.MultiTenancy;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
+
+namespace Granit.Identity.Federated.Extensions;
+
+/// <summary>
+/// Wires the <see cref="GracefulIdentityProviderDecorator"/> around a concrete federated
+/// identity provider.
+/// </summary>
+public static class IdentityProviderDegradationExtensions
+{
+    /// <summary>
+    /// Wraps the registered <see cref="IIdentityProvider"/> (expected to be
+    /// <typeparamref name="TProvider"/>) with the graceful-degradation decorator. Call this
+    /// immediately after <c>AddIdentityProvider&lt;TProvider&gt;()</c> in a provider's
+    /// registration extension.
+    /// </summary>
+    /// <remarks>
+    /// The concrete <typeparamref name="TProvider"/> is registered by its own type so that
+    /// (a) the decorator can resolve and wrap it, and (b) multi-facet forwarders that need the
+    /// raw provider (the session/device facets, which the decorator does not implement) resolve
+    /// it directly rather than the decorator. Fine-grained <c>IIdentity*</c> facet registrations
+    /// forward to <see cref="IIdentityProvider"/> and therefore inherit the decoration.
+    /// </remarks>
+    public static IServiceCollection DecorateIdentityProviderWithGracefulDegradation<TProvider>(
+        this IServiceCollection services)
+        where TProvider : class, IIdentityProvider
+    {
+        // Concrete provider resolvable by type (for the decorator + session/device forwarders).
+        services.TryAddScoped<TProvider>();
+
+        services.Replace(ServiceDescriptor.Scoped<IIdentityProvider>(sp =>
+            new GracefulIdentityProviderDecorator(
+                sp.GetRequiredService<TProvider>(),
+                sp.GetRequiredService<ILogger<GracefulIdentityProviderDecorator>>(),
+                sp.GetService<Diagnostics.IdentityFederatedMetrics>(),
+                sp.GetService<ICurrentTenant>())));
+
+        return services;
+    }
+}

--- a/src/Granit.Identity.Federated/GranitIdentityFederatedModule.cs
+++ b/src/Granit.Identity.Federated/GranitIdentityFederatedModule.cs
@@ -1,6 +1,7 @@
 using Granit.Authorization;
 using Granit.DataExchange.Extensions;
 using Granit.Entities.Extensions;
+using Granit.Identity.Federated.Diagnostics;
 using Granit.Identity.Federated.Domain;
 using Granit.Identity.Federated.Entities;
 using Granit.Identity.Federated.Exports;
@@ -33,6 +34,9 @@ public sealed class GranitIdentityFederatedModule : GranitModule
     /// <inheritdoc/>
     public override void ConfigureServices(ServiceConfigurationContext context)
     {
+        // Provider-failure metrics, emitted by the graceful-degradation decorator.
+        context.Services.TryAddSingleton<IdentityFederatedMetrics>();
+
         // Query + Export definitions (ADR-020: owned by the base module).
         context.Services.AddQueryDefinition<FederatedIdentity, FederatedIdentityQueryDefinition>();
         context.Services.AddExportDefinition<FederatedIdentity, FederatedIdentityExportDefinition>();

--- a/src/Granit.Identity.Federated/Internal/GracefulIdentityProviderDecorator.cs
+++ b/src/Granit.Identity.Federated/Internal/GracefulIdentityProviderDecorator.cs
@@ -1,0 +1,144 @@
+using Granit.Identity.Federated.Diagnostics;
+using Granit.Identity.Federated.Exceptions;
+using Granit.Identity.Models;
+using Granit.MultiTenancy;
+using Microsoft.Extensions.Logging;
+
+namespace Granit.Identity.Federated.Internal;
+
+/// <summary>
+/// Decorates the registered <see cref="IIdentityProvider"/> with uniform, centralized
+/// graceful degradation. Read operations that fail with a classified
+/// <see cref="IdentityProviderException"/> return an empty/absent result (a blip does not
+/// fail the whole request), while the failure is logged and metered by category. Two rules
+/// are never relaxed:
+/// <list type="bullet">
+/// <item><description><see cref="OperationCanceledException"/> is always re-thrown — cancellation
+/// (request abort, host shutdown) is never swallowed, closing the bug the per-provider
+/// <c>catch (Exception)</c> blocks left open.</description></item>
+/// <item><description><see cref="IdentityProviderFailureCategory.Unauthorized"/> is re-thrown, not
+/// degraded — an IAM outage surfaces to the caller instead of masquerading as "no data".</description></item>
+/// </list>
+/// Write operations pass through unchanged: a failed mutation must always surface. Untyped
+/// exceptions also propagate — the decorator only degrades the classified provider faults,
+/// so genuine bugs are never hidden.
+/// </summary>
+internal sealed partial class GracefulIdentityProviderDecorator(
+    IIdentityProvider inner,
+    ILogger<GracefulIdentityProviderDecorator> logger,
+    IdentityFederatedMetrics? metrics = null,
+    ICurrentTenant? currentTenant = null) : IIdentityProvider
+{
+    // ──── IIdentityUserReader (degrade) ────
+
+    public Task<IReadOnlyList<IIdentityUser>> GetUsersAsync(
+        string? search = null, int? first = null, int? max = null, CancellationToken cancellationToken = default) =>
+        DegradeAsync(() => inner.GetUsersAsync(search, first, max, cancellationToken), []);
+
+    public Task<IIdentityUser?> GetUserAsync(string userId, CancellationToken cancellationToken = default) =>
+        DegradeAsync<IIdentityUser?>(() => inner.GetUserAsync(userId, cancellationToken), null);
+
+    // ──── IIdentityUserWriter (pass-through) ────
+
+    public Task SetUserEnabledAsync(string userId, bool enabled, CancellationToken cancellationToken = default) =>
+        inner.SetUserEnabledAsync(userId, enabled, cancellationToken);
+
+    public Task UpdateUserAsync(string userId, IdentityUserUpdate update, CancellationToken cancellationToken = default) =>
+        inner.UpdateUserAsync(userId, update, cancellationToken);
+
+    public Task<IIdentityUser> CreateUserAsync(IdentityUserCreate user, CancellationToken cancellationToken = default) =>
+        inner.CreateUserAsync(user, cancellationToken);
+
+    // ──── IIdentityRoleManager ────
+
+    public Task<IReadOnlyList<IdentityRole>> GetRolesAsync(CancellationToken cancellationToken = default) =>
+        DegradeAsync(() => inner.GetRolesAsync(cancellationToken), []);
+
+    public Task<IReadOnlyList<IIdentityUser>> GetRoleMembersAsync(string roleName, CancellationToken cancellationToken = default) =>
+        DegradeAsync(() => inner.GetRoleMembersAsync(roleName, cancellationToken), []);
+
+    public Task<IReadOnlyList<IdentityRole>> GetUserRolesAsync(string userId, CancellationToken cancellationToken = default) =>
+        DegradeAsync(() => inner.GetUserRolesAsync(userId, cancellationToken), []);
+
+    public Task AssignRoleAsync(string userId, string roleName, CancellationToken cancellationToken = default) =>
+        inner.AssignRoleAsync(userId, roleName, cancellationToken);
+
+    public Task RemoveRoleAsync(string userId, string roleName, CancellationToken cancellationToken = default) =>
+        inner.RemoveRoleAsync(userId, roleName, cancellationToken);
+
+    // NB: IIdentityClientRoleManager is NOT part of IIdentityProvider — it is an opt-in Phase 2
+    // facet cast off the concrete provider by the sync pipeline (which classifies its own fetch
+    // faults). It is therefore not decorated: provider registration forwards that facet, plus the
+    // session/device facets, to the concrete provider rather than to this decorator.
+
+    // ──── IIdentityGroupManager ────
+
+    public Task<IReadOnlyList<IdentityGroup>> GetGroupsAsync(CancellationToken cancellationToken = default) =>
+        DegradeAsync(() => inner.GetGroupsAsync(cancellationToken), []);
+
+    public Task<IReadOnlyList<IdentityGroup>> GetUserGroupsAsync(string userId, CancellationToken cancellationToken = default) =>
+        DegradeAsync(() => inner.GetUserGroupsAsync(userId, cancellationToken), []);
+
+    public Task AddUserToGroupAsync(string userId, string groupId, CancellationToken cancellationToken = default) =>
+        inner.AddUserToGroupAsync(userId, groupId, cancellationToken);
+
+    public Task RemoveUserFromGroupAsync(string userId, string groupId, CancellationToken cancellationToken = default) =>
+        inner.RemoveUserFromGroupAsync(userId, groupId, cancellationToken);
+
+    // ──── IIdentityPasswordManager ────
+
+    public Task<DateTimeOffset?> GetPasswordChangedAtAsync(string userId, CancellationToken cancellationToken = default) =>
+        DegradeAsync<DateTimeOffset?>(() => inner.GetPasswordChangedAtAsync(userId, cancellationToken), null);
+
+    public Task SendPasswordResetEmailAsync(string userId, CancellationToken cancellationToken = default) =>
+        inner.SendPasswordResetEmailAsync(userId, cancellationToken);
+
+    public Task SetTemporaryPasswordAsync(string userId, string temporaryPassword, CancellationToken cancellationToken = default) =>
+        inner.SetTemporaryPasswordAsync(userId, temporaryPassword, cancellationToken);
+
+    // ──── IIdentityCredentialVerifier (pass-through: never degrade an auth decision) ────
+
+    public Task<bool> VerifyUserCredentialsAsync(string username, string password, CancellationToken cancellationToken = default) =>
+        inner.VerifyUserCredentialsAsync(username, password, cancellationToken);
+
+    // ──── degradation policy ────
+
+    private async Task<T> DegradeAsync<T>(Func<Task<T>> operation, T degraded)
+    {
+        try
+        {
+            return await operation().ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            // Never swallow cancellation — request abort / host shutdown must propagate.
+            throw;
+        }
+        catch (IdentityProviderException ex)
+        {
+            metrics?.RecordProviderFailure(ex.ProviderName, ex.Operation, ex.Category, CurrentTenantId());
+
+            if (ex.Category is IdentityProviderFailureCategory.Unauthorized)
+            {
+                // An IAM outage must surface — degrading it to an empty result hides the problem.
+                LogUnauthorized(logger, ex.ProviderName, ex.Operation, ex);
+                throw;
+            }
+
+            LogDegraded(logger, ex.ProviderName, ex.Operation, ex.Category, ex);
+            return degraded;
+        }
+    }
+
+    private string? CurrentTenantId() =>
+        currentTenant is { IsAvailable: true } tenant ? tenant.Id.ToString() : null;
+
+    [LoggerMessage(Level = LogLevel.Error,
+        Message = "Identity provider '{ProviderName}' operation '{Operation}' failed with an authorization error — surfacing to the caller.")]
+    private static partial void LogUnauthorized(ILogger logger, string providerName, string operation, Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Warning,
+        Message = "Identity provider '{ProviderName}' operation '{Operation}' failed ({Category}) — degrading to an empty result.")]
+    private static partial void LogDegraded(
+        ILogger logger, string providerName, string operation, IdentityProviderFailureCategory category, Exception exception);
+}

--- a/tests/Granit.Identity.Federated.Cognito.Tests/IdentityCognitoServiceCollectionExtensionsClientRoleTests.cs
+++ b/tests/Granit.Identity.Federated.Cognito.Tests/IdentityCognitoServiceCollectionExtensionsClientRoleTests.cs
@@ -1,6 +1,7 @@
 using Granit.Events;
 using Granit.Identity.Extensions;
 using Granit.Identity.Federated.Cognito.Extensions;
+using Granit.Identity.Federated.Cognito.Internal;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
@@ -37,12 +38,14 @@ public sealed class IdentityCognitoServiceCollectionExtensionsClientRoleTests
         using IServiceScope scope = sp.CreateScope();
 
         IIdentityProvider provider = scope.ServiceProvider.GetRequiredService<IIdentityProvider>();
+        CognitoIdentityProvider concrete = scope.ServiceProvider.GetRequiredService<CognitoIdentityProvider>();
         IIdentityClientRoleManager clientRoleManager =
             scope.ServiceProvider.GetRequiredService<IIdentityClientRoleManager>();
 
-        object.ReferenceEquals(provider, clientRoleManager).ShouldBeTrue(
-            "IIdentityProvider and IIdentityClientRoleManager must resolve to the same " +
-            "scoped CognitoIdentityProvider instance — see ADR-027 and the DI block " +
-            "in AddGranitIdentityCognito.");
+        // The client-role facet (which IIdentityProvider does not compose) resolves the concrete
+        // provider, while IIdentityProvider is the graceful-degradation decorator wrapping that
+        // same scoped instance — see ADR-027 and the DI block in AddGranitIdentityCognito.
+        clientRoleManager.ShouldBeSameAs(concrete);
+        provider.ShouldNotBeSameAs(concrete);
     }
 }

--- a/tests/Granit.Identity.Federated.Cognito.Tests/IdentityCognitoServiceCollectionExtensionsTests.cs
+++ b/tests/Granit.Identity.Federated.Cognito.Tests/IdentityCognitoServiceCollectionExtensionsTests.cs
@@ -41,9 +41,10 @@ public sealed class IdentityCognitoServiceCollectionExtensionsTests
     {
         ServiceProvider provider = BuildProvider();
 
-        IIdentityProvider identityProvider = provider.GetRequiredService<IIdentityProvider>();
-
-        identityProvider.ShouldBeOfType<CognitoIdentityProvider>();
+        // IIdentityProvider resolves to the graceful-degradation decorator, which wraps the concrete
+        // CognitoIdentityProvider (registered by its own type).
+        provider.GetRequiredService<CognitoIdentityProvider>().ShouldNotBeNull();
+        provider.GetRequiredService<IIdentityProvider>().ShouldNotBeOfType<CognitoIdentityProvider>();
     }
 
     [Fact]

--- a/tests/Granit.Identity.Federated.EntraId.Tests/GranitIdentityFederatedEntraIdModuleTests.cs
+++ b/tests/Granit.Identity.Federated.EntraId.Tests/GranitIdentityFederatedEntraIdModuleTests.cs
@@ -45,9 +45,15 @@ public sealed class GranitIdentityFederatedEntraIdModuleTests
 
         ServiceDescriptor? descriptor = builder.Services.FirstOrDefault(
             d => d.ServiceType == typeof(IIdentityProvider));
+        // IIdentityProvider now resolves to the graceful-degradation decorator (a factory
+        // registration); the concrete provider is registered by its own type.
         descriptor.ShouldNotBeNull();
-        descriptor!.ImplementationType.ShouldBe(typeof(EntraIdIdentityProvider));
+        descriptor!.ImplementationType.ShouldBeNull();
         descriptor.Lifetime.ShouldBe(ServiceLifetime.Scoped);
+        ServiceDescriptor? concrete = builder.Services.FirstOrDefault(
+            d => d.ServiceType == typeof(EntraIdIdentityProvider));
+        concrete.ShouldNotBeNull();
+        concrete!.ImplementationType.ShouldBe(typeof(EntraIdIdentityProvider));
     }
 
     [Fact]

--- a/tests/Granit.Identity.Federated.EntraId.Tests/IdentityEntraIdServiceCollectionExtensionsClientRoleTests.cs
+++ b/tests/Granit.Identity.Federated.EntraId.Tests/IdentityEntraIdServiceCollectionExtensionsClientRoleTests.cs
@@ -2,6 +2,7 @@ using Granit.Events;
 using Granit.Guids.Extensions;
 using Granit.Identity.Extensions;
 using Granit.Identity.Federated.EntraId.Extensions;
+using Granit.Identity.Federated.EntraId.Internal;
 using Granit.Timing;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -44,12 +45,14 @@ public sealed class IdentityEntraIdServiceCollectionExtensionsClientRoleTests
         using IServiceScope scope = sp.CreateScope();
 
         IIdentityProvider provider = scope.ServiceProvider.GetRequiredService<IIdentityProvider>();
+        EntraIdIdentityProvider concrete = scope.ServiceProvider.GetRequiredService<EntraIdIdentityProvider>();
         IIdentityClientRoleManager clientRoleManager =
             scope.ServiceProvider.GetRequiredService<IIdentityClientRoleManager>();
 
-        object.ReferenceEquals(provider, clientRoleManager).ShouldBeTrue(
-            "IIdentityProvider and IIdentityClientRoleManager must resolve to the same " +
-            "scoped EntraIdIdentityProvider instance — see ADR-026 and the DI block " +
-            "in AddGranitIdentityEntraId.");
+        // The client-role facet (which IIdentityProvider does not compose) resolves the concrete
+        // provider, while IIdentityProvider is the graceful-degradation decorator wrapping that
+        // same scoped instance — see ADR-026 and the DI block in AddGranitIdentityEntraId.
+        clientRoleManager.ShouldBeSameAs(concrete);
+        provider.ShouldNotBeSameAs(concrete);
     }
 }

--- a/tests/Granit.Identity.Federated.EntraId.Tests/IdentityEntraIdServiceCollectionExtensionsTests.cs
+++ b/tests/Granit.Identity.Federated.EntraId.Tests/IdentityEntraIdServiceCollectionExtensionsTests.cs
@@ -22,8 +22,14 @@ public sealed class IdentityEntraIdServiceCollectionExtensionsTests
 
         ServiceDescriptor? descriptor = builder.Services.FirstOrDefault(
             d => d.ServiceType == typeof(IIdentityProvider));
+        // IIdentityProvider now resolves to the graceful-degradation decorator (a factory
+        // registration); the concrete provider is registered by its own type.
         descriptor.ShouldNotBeNull();
-        descriptor!.ImplementationType.ShouldBe(typeof(EntraIdIdentityProvider));
+        descriptor!.ImplementationType.ShouldBeNull();
+        ServiceDescriptor? concrete = builder.Services.FirstOrDefault(
+            d => d.ServiceType == typeof(EntraIdIdentityProvider));
+        concrete.ShouldNotBeNull();
+        concrete!.ImplementationType.ShouldBe(typeof(EntraIdIdentityProvider));
     }
 
     [Fact]

--- a/tests/Granit.Identity.Federated.Keycloak.Tests/GranitIdentityFederatedKeycloakModuleTests.cs
+++ b/tests/Granit.Identity.Federated.Keycloak.Tests/GranitIdentityFederatedKeycloakModuleTests.cs
@@ -45,9 +45,15 @@ public sealed class GranitIdentityFederatedKeycloakModuleTests
 
         ServiceDescriptor? descriptor = builder.Services.FirstOrDefault(
             d => d.ServiceType == typeof(IIdentityProvider));
+        // IIdentityProvider now resolves to the graceful-degradation decorator (a factory
+        // registration); the concrete provider is registered by its own type.
         descriptor.ShouldNotBeNull();
-        descriptor!.ImplementationType.ShouldBe(typeof(KeycloakIdentityProvider));
+        descriptor!.ImplementationType.ShouldBeNull();
         descriptor.Lifetime.ShouldBe(ServiceLifetime.Scoped);
+        ServiceDescriptor? concrete = builder.Services.FirstOrDefault(
+            d => d.ServiceType == typeof(KeycloakIdentityProvider));
+        concrete.ShouldNotBeNull();
+        concrete!.ImplementationType.ShouldBe(typeof(KeycloakIdentityProvider));
     }
 
     [Fact]

--- a/tests/Granit.Identity.Federated.Keycloak.Tests/IdentityKeycloakServiceCollectionExtensionsClientRoleTests.cs
+++ b/tests/Granit.Identity.Federated.Keycloak.Tests/IdentityKeycloakServiceCollectionExtensionsClientRoleTests.cs
@@ -1,6 +1,7 @@
 using Granit.Events;
 using Granit.Identity.Extensions;
 using Granit.Identity.Federated.Keycloak.Extensions;
+using Granit.Identity.Federated.Keycloak.Internal;
 using Granit.Timing;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -43,13 +44,15 @@ public sealed class IdentityKeycloakServiceCollectionExtensionsClientRoleTests
         using IServiceScope scope = sp.CreateScope();
 
         IIdentityProvider provider = scope.ServiceProvider.GetRequiredService<IIdentityProvider>();
+        KeycloakIdentityProvider concrete = scope.ServiceProvider.GetRequiredService<KeycloakIdentityProvider>();
         IIdentityClientRoleManager clientRoleManager =
             scope.ServiceProvider.GetRequiredService<IIdentityClientRoleManager>();
 
-        object.ReferenceEquals(provider, clientRoleManager).ShouldBeTrue(
-            "IIdentityProvider and IIdentityClientRoleManager must resolve to the same " +
-            "scoped KeycloakIdentityProvider instance — see ADR-025 and the DI block " +
-            "in AddGranitIdentityKeycloak.");
+        // The client-role facet (which IIdentityProvider does not compose) resolves the concrete
+        // provider, while IIdentityProvider is the graceful-degradation decorator wrapping that
+        // same scoped instance — see ADR-025 and the DI block in AddGranitIdentityKeycloak.
+        clientRoleManager.ShouldBeSameAs(concrete);
+        provider.ShouldNotBeSameAs(concrete);
     }
 
     [Fact]
@@ -75,19 +78,16 @@ public sealed class IdentityKeycloakServiceCollectionExtensionsClientRoleTests
         using ServiceProvider sp = services.BuildServiceProvider();
         using IServiceScope scope = sp.CreateScope();
 
-        IIdentityProvider provider = scope.ServiceProvider.GetRequiredService<IIdentityProvider>();
+        KeycloakIdentityProvider concrete = scope.ServiceProvider.GetRequiredService<KeycloakIdentityProvider>();
         IUserSessionProvider sessionProvider =
             scope.ServiceProvider.GetRequiredService<IUserSessionProvider>();
         IUserDeviceProvider deviceProvider =
             scope.ServiceProvider.GetRequiredService<IUserDeviceProvider>();
 
-        object.ReferenceEquals(provider, sessionProvider).ShouldBeTrue(
-            "IIdentityProvider and IUserSessionProvider must resolve to the same scoped " +
-            "KeycloakIdentityProvider instance so the canonical /sessions API surfaces Keycloak " +
-            "sessions — see the DI block in AddGranitIdentityKeycloak (#2659).");
-        object.ReferenceEquals(provider, deviceProvider).ShouldBeTrue(
-            "IIdentityProvider and IUserDeviceProvider must resolve to the same scoped " +
-            "KeycloakIdentityProvider instance so the canonical /devices API surfaces Keycloak " +
-            "devices — see the DI block in AddGranitIdentityKeycloak (#2659).");
+        // The session/device facets (which IIdentityProvider does not compose) resolve the concrete
+        // KeycloakIdentityProvider so the canonical /sessions and /devices APIs surface Keycloak data
+        // — see the DI block in AddGranitIdentityKeycloak (#2659).
+        sessionProvider.ShouldBeSameAs(concrete);
+        deviceProvider.ShouldBeSameAs(concrete);
     }
 }

--- a/tests/Granit.Identity.Federated.Keycloak.Tests/IdentityKeycloakServiceCollectionExtensionsTests.cs
+++ b/tests/Granit.Identity.Federated.Keycloak.Tests/IdentityKeycloakServiceCollectionExtensionsTests.cs
@@ -22,8 +22,14 @@ public sealed class IdentityKeycloakServiceCollectionExtensionsTests
 
         ServiceDescriptor? descriptor = builder.Services.FirstOrDefault(
             d => d.ServiceType == typeof(IIdentityProvider));
+        // IIdentityProvider now resolves to the graceful-degradation decorator (a factory
+        // registration); the concrete provider is registered by its own type.
         descriptor.ShouldNotBeNull();
-        descriptor!.ImplementationType.ShouldBe(typeof(KeycloakIdentityProvider));
+        descriptor!.ImplementationType.ShouldBeNull();
+        ServiceDescriptor? concrete = builder.Services.FirstOrDefault(
+            d => d.ServiceType == typeof(KeycloakIdentityProvider));
+        concrete.ShouldNotBeNull();
+        concrete!.ImplementationType.ShouldBe(typeof(KeycloakIdentityProvider));
     }
 
     [Fact]

--- a/tests/Granit.Identity.Federated.Tests/Internal/GracefulIdentityProviderDecoratorTests.cs
+++ b/tests/Granit.Identity.Federated.Tests/Internal/GracefulIdentityProviderDecoratorTests.cs
@@ -1,0 +1,106 @@
+using Granit.Identity.Federated.Exceptions;
+using Granit.Identity.Federated.Internal;
+using Granit.Identity.Models;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Identity.Federated.Tests.Internal;
+
+/// <summary>
+/// Behaviour cover for the graceful-degradation decorator (Vague 6b): read operations degrade
+/// on classified faults, but cancellation and authorization failures are never swallowed, and
+/// write operations always pass through.
+/// </summary>
+public sealed class GracefulIdentityProviderDecoratorTests
+{
+    private readonly IIdentityProvider _inner = Substitute.For<IIdentityProvider>();
+
+    private GracefulIdentityProviderDecorator Sut() =>
+        new(_inner, NullLogger<GracefulIdentityProviderDecorator>.Instance);
+
+    private static IdentityProviderException Fault(IdentityProviderFailureCategory category) => category switch
+    {
+        IdentityProviderFailureCategory.Unauthorized => new IdentityProviderUnauthorizedException("keycloak", "get_users"),
+        IdentityProviderFailureCategory.NotFound => new IdentityProviderNotFoundException("keycloak", "get_users"),
+        IdentityProviderFailureCategory.Throttled => new IdentityProviderThrottledException("keycloak", "get_users"),
+        _ => new IdentityProviderTransientException("keycloak", "get_users"),
+    };
+
+    [Theory]
+    [InlineData(IdentityProviderFailureCategory.Transient)]
+    [InlineData(IdentityProviderFailureCategory.Throttled)]
+    [InlineData(IdentityProviderFailureCategory.NotFound)]
+    public async Task Read_degrades_to_empty_on_degradable_fault(IdentityProviderFailureCategory category)
+    {
+        _inner.GetUsersAsync(cancellationToken: TestContext.Current.CancellationToken).ThrowsAsyncForAnyArgs(Fault(category));
+
+        IReadOnlyList<IIdentityUser> result = await Sut().GetUsersAsync(cancellationToken: TestContext.Current.CancellationToken);
+
+        result.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task Read_rethrows_unauthorized_rather_than_degrading()
+    {
+        _inner.GetUsersAsync(cancellationToken: TestContext.Current.CancellationToken).ThrowsAsyncForAnyArgs(Fault(IdentityProviderFailureCategory.Unauthorized));
+
+        await Should.ThrowAsync<IdentityProviderUnauthorizedException>(
+            () => Sut().GetUsersAsync(cancellationToken: TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task Read_never_swallows_cancellation()
+    {
+        _inner.GetUsersAsync(cancellationToken: TestContext.Current.CancellationToken).ThrowsAsyncForAnyArgs(new OperationCanceledException());
+
+        await Should.ThrowAsync<OperationCanceledException>(
+            () => Sut().GetUsersAsync(cancellationToken: TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task Read_does_not_swallow_unexpected_exceptions()
+    {
+        // Only classified provider faults degrade — a genuine bug must surface, not vanish as "no data".
+        _inner.GetUsersAsync(cancellationToken: TestContext.Current.CancellationToken).ThrowsAsyncForAnyArgs(new InvalidOperationException("bug"));
+
+        await Should.ThrowAsync<InvalidOperationException>(
+            () => Sut().GetUsersAsync(cancellationToken: TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task GetUser_degrades_to_null_on_transient()
+    {
+        _inner.GetUserAsync("u1", Arg.Any<CancellationToken>())
+            .ThrowsAsync(new IdentityProviderTransientException("keycloak", "get_user"));
+
+        IIdentityUser? result = await Sut().GetUserAsync("u1", TestContext.Current.CancellationToken);
+
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task Read_returns_inner_result_on_success()
+    {
+        IReadOnlyList<IIdentityUser> users = [Substitute.For<IIdentityUser>()];
+        _inner.GetUsersAsync(cancellationToken: TestContext.Current.CancellationToken).ReturnsForAnyArgs(users);
+
+        IReadOnlyList<IIdentityUser> result = await Sut().GetUsersAsync(cancellationToken: TestContext.Current.CancellationToken);
+
+        result.ShouldBe(users);
+    }
+
+    [Fact]
+    public async Task Write_passes_through_and_never_degrades()
+    {
+        IdentityUserCreate create = new("u@example.com", "u@example.com", null, null, true, null);
+        _inner.CreateUserAsync(create, Arg.Any<CancellationToken>())
+            .ThrowsAsync(new IdentityProviderTransientException("keycloak", "create_user"));
+
+        // A failed mutation must surface — the decorator does not degrade writes.
+        await Should.ThrowAsync<IdentityProviderTransientException>(
+            () => Sut().CreateUserAsync(create, TestContext.Current.CancellationToken));
+    }
+}


### PR DESCRIPTION
## Vague 6b-i — provider failure taxonomy + decorator (infrastructure half of FEATURE #3064)

Introduces a classified failure taxonomy for the federated identity providers and a single
decorator that owns graceful degradation, replacing the per-method catch-and-return-empty
scattered across the four providers. **Mechanism confirmed with the maintainer: typed
exceptions + decorator, not `IdentityProviderResult<T>`** — the `IIdentityProvider` seam
signatures are unchanged, so there is zero ripple to the 20+ seam consumers (including the
external apps) that a return-type change would have broken.

### Taxonomy (`Granit.Identity.Federated.Exceptions`)

- `IdentityProviderException` (abstract base) + `IdentityProviderFailureCategory`
  `{ Unauthorized, NotFound, Throttled, Transient }`.
- `IdentityProviderUnauthorizedException` reparented onto the base (public ctor unchanged).
- New `IdentityProviderThrottledException` (with `RetryAfter`), `IdentityProviderTransientException`,
  `IdentityProviderNotFoundException`.

### `GracefulIdentityProviderDecorator`

Wraps `IIdentityProvider`:
- Read operations **degrade** to empty/null on a classified fault.
- `OperationCanceledException` is **always re-thrown** — cancellation is never swallowed,
  closing the bug the providers' bare `catch (Exception)` (Cognito/GoogleCloud) and
  `catch (… or TaskCanceledException)` (Keycloak) blocks leave open.
- `Unauthorized` is **re-thrown, not degraded** — an IAM outage surfaces instead of
  masquerading as "no data" (preserves the Vague 0 intent).
- Writes and credential verification pass through; **untyped exceptions propagate** (a genuine
  bug is never hidden). The client-role / session / device facets are **not** decorated — the
  sync engine classifies its own fetch faults, so those facets resolve the concrete provider.

### Wiring

`DecorateIdentityProviderWithGracefulDegradation<TProvider>` registers the concrete provider by
type and replaces `IIdentityProvider` with the decorator; all four provider extensions call it
and repoint their client-role/session/device forwarders at the concrete instance. New
`IdentityFederatedMetrics` (`granit.identity.federated.provider.failures`, tagged
provider/operation/category/tenant_id) is emitted by the decorator and registered by the base module.

### Scope — why this is the "-i" half

Converting each provider's read-method catch blocks to **throw** the typed Throttled/Transient
faults (so the decorator's degrade path becomes the single degradation point) is
provider-specific and only exercisable end-to-end against the Dockerised integration suites.
That churn lands in **Vague 6b-ii** to keep it in its own reviewable, CI-verified PR. This PR is
pure, unit-testable infrastructure and is behaviour-preserving at the seam (Unauthorized still
propagates — now metered; degrade paths unit-tested via NSubstitute).

### Breaking

`!` — `IIdentityProvider` now resolves to the decorator, and the client-role/session/device
facets resolve the concrete provider rather than the same object as `IIdentityProvider`. Code
that resolved `IIdentityProvider` and pattern-matched it to a concrete provider type, or to
`IUserSessionProvider`/`IIdentityClientRoleManager`, must resolve the concrete type or the facet
interface instead. No such call sites exist in-tree outside the provider registrations updated here.

### Verification

- New `GracefulIdentityProviderDecoratorTests` (degrade / rethrow-unauthorized /
  never-swallow-cancellation / don't-swallow-unexpected / write-passthrough).
- Provider DI-resolution tests updated for the decorated shape: Cognito 61/61, EntraId 133/133,
  Keycloak 172/172, GoogleCloud 55/55, Federated 85/85, BackgroundJobs 2/2, Endpoints 5/5.
- Architecture suite 262/262; `dotnet format` clean.

Refs #3064

🤖 Generated with [Claude Code](https://claude.com/claude-code)