### PR TITLE
refactor(identity)!: providers throw classified faults into the degradation decorator (Vague 6b-ii)

### DIFF
--- a/src/Granit.Identity.Federated.Cognito/Internal/CognitoIdentityProvider.cs
+++ b/src/Granit.Identity.Federated.Cognito/Internal/CognitoIdentityProvider.cs
@@ -40,6 +40,34 @@ internal sealed partial class CognitoIdentityProvider(
     private static bool IsAuthorizationFailure(AmazonServiceException ex) =>
         ex.StatusCode is HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden;
 
+    /// <summary>
+    /// Classifies a non-authorization Cognito fault into the taxonomy the graceful-degradation
+    /// decorator understands: AWS throttling (HTTP 429 or a <c>Throttl*</c>/<c>TooManyRequests</c>
+    /// error code) → <see cref="IdentityProviderThrottledException"/>; a missing resource
+    /// (<see cref="ResourceNotFoundException"/>/<see cref="UserNotFoundException"/> or HTTP 404) →
+    /// <see cref="IdentityProviderNotFoundException"/>; everything else (5xx, timeout, connection
+    /// reset) → <see cref="IdentityProviderTransientException"/>. Applied only to the decorated
+    /// <see cref="IIdentityProvider"/> read methods; the caller must re-throw genuine cancellation
+    /// before reaching here.
+    /// </summary>
+    private static Exception ClassifyReadFault(Exception ex, string operation) => ex switch
+    {
+        AmazonServiceException { StatusCode: HttpStatusCode.TooManyRequests } =>
+            new IdentityProviderThrottledException(ProviderName, operation, retryAfter: null, ex),
+        AmazonServiceException svc when IsThrottlingErrorCode(svc.ErrorCode) =>
+            new IdentityProviderThrottledException(ProviderName, operation, retryAfter: null, ex),
+        ResourceNotFoundException or UserNotFoundException =>
+            new IdentityProviderNotFoundException(ProviderName, operation, ex),
+        AmazonServiceException { StatusCode: HttpStatusCode.NotFound } =>
+            new IdentityProviderNotFoundException(ProviderName, operation, ex),
+        _ => new IdentityProviderTransientException(ProviderName, operation, ex),
+    };
+
+    private static bool IsThrottlingErrorCode(string? errorCode) =>
+        errorCode is not null
+        && (errorCode.Contains("Throttl", StringComparison.OrdinalIgnoreCase)
+            || errorCode.Contains("TooManyRequests", StringComparison.OrdinalIgnoreCase));
+
     private readonly CognitoAdminOptions _options = options.Value;
     private readonly CognitoClientRoleSyncOptions _clientRoleSyncOptions = clientRoleSyncOptions.Value;
 
@@ -95,10 +123,14 @@ internal sealed partial class CognitoIdentityProvider(
         {
             throw new IdentityProviderUnauthorizedException(ProviderName, "list_users", ex);
         }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
         catch (Exception ex)
         {
             LogListUsersFailed(ex);
-            return [];
+            throw ClassifyReadFault(ex, "list_users");
         }
     }
 
@@ -137,10 +169,14 @@ internal sealed partial class CognitoIdentityProvider(
         {
             throw new IdentityProviderUnauthorizedException(ProviderName, "get_user", ex);
         }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
         catch (Exception ex)
         {
             LogGetUserFailed(userId, ex);
-            return null;
+            throw ClassifyReadFault(ex, "get_user");
         }
     }
 
@@ -318,10 +354,14 @@ internal sealed partial class CognitoIdentityProvider(
 
             return response.Users.ConvertAll(ToIdentityUser);
         }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
         catch (Exception ex)
         {
             LogOperationFailed("GetRoleMembers", ex);
-            return [];
+            throw ClassifyReadFault(ex, "list_role_members");
         }
     }
 
@@ -369,10 +409,14 @@ internal sealed partial class CognitoIdentityProvider(
             return response.Groups.ConvertAll(g => new IdentityGroup(
                 g.GroupName, g.GroupName, null, []));
         }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
         catch (Exception ex)
         {
             LogOperationFailed("GetGroups", ex);
-            return [];
+            throw ClassifyReadFault(ex, "list_groups");
         }
     }
 
@@ -400,10 +444,14 @@ internal sealed partial class CognitoIdentityProvider(
             return response.Groups.ConvertAll(g => new IdentityGroup(
                 g.GroupName, g.GroupName, null, []));
         }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
         catch (Exception ex)
         {
             LogOperationFailed("GetUserGroups", ex);
-            return [];
+            throw ClassifyReadFault(ex, "list_user_groups");
         }
     }
 

--- a/src/Granit.Identity.Federated.EntraId/Internal/EntraIdIdentityProvider.cs
+++ b/src/Granit.Identity.Federated.EntraId/Internal/EntraIdIdentityProvider.cs
@@ -50,6 +50,24 @@ internal sealed partial class EntraIdIdentityProvider(
     private static bool IsAuthorizationFailure(HttpRequestException ex) =>
         ex.StatusCode is HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden;
 
+    /// <summary>
+    /// Classifies a non-authorization Graph fault into the taxonomy the graceful-degradation
+    /// decorator understands: HTTP 429 → <see cref="IdentityProviderThrottledException"/>, 404 →
+    /// <see cref="IdentityProviderNotFoundException"/>, everything else (5xx, timeout, connection
+    /// reset) → <see cref="IdentityProviderTransientException"/>. Applied only to the decorated
+    /// <see cref="IIdentityProvider"/> read methods; the caller re-throws genuine cancellation first.
+    /// </summary>
+    private static Exception ClassifyReadFault(Exception ex, string operation) => ex switch
+    {
+        HttpRequestException { StatusCode: HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden } =>
+            new IdentityProviderUnauthorizedException(ProviderName, operation, ex),
+        HttpRequestException { StatusCode: HttpStatusCode.TooManyRequests } =>
+            new IdentityProviderThrottledException(ProviderName, operation, retryAfter: null, ex),
+        HttpRequestException { StatusCode: HttpStatusCode.NotFound } =>
+            new IdentityProviderNotFoundException(ProviderName, operation, ex),
+        _ => new IdentityProviderTransientException(ProviderName, operation, ex),
+    };
+
     /// <inheritdoc/>
     public async Task<IReadOnlyList<IIdentityUser>> GetUsersAsync(
         string? search = null,
@@ -84,11 +102,15 @@ internal sealed partial class EntraIdIdentityProvider(
             activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
             throw new IdentityProviderUnauthorizedException(ProviderName, "list_users", ex);
         }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
         catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
         {
             activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
             LogGetUsersFailed(ex);
-            return [];
+            throw ClassifyReadFault(ex, "list_users");
         }
     }
 
@@ -118,11 +140,21 @@ internal sealed partial class EntraIdIdentityProvider(
             activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
             throw new IdentityProviderUnauthorizedException(ProviderName, "get_user", ex);
         }
+        catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+        {
+            // A single-user GET returning 404 is a normal negative result, not a fault.
+            LogGetUserFailed(ex, userId);
+            return null;
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
         catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
         {
             activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
             LogGetUserFailed(ex, userId);
-            return null;
+            throw ClassifyReadFault(ex, "get_user");
         }
     }
 
@@ -308,11 +340,15 @@ internal sealed partial class EntraIdIdentityProvider(
 
             return user?.LastPasswordChangeDateTime;
         }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
         catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
         {
             activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
             LogGetPasswordChangedAtFailed(ex, userId);
-            return null;
+            throw ClassifyReadFault(ex, "get_password_changed_at");
         }
     }
 
@@ -337,11 +373,15 @@ internal sealed partial class EntraIdIdentityProvider(
                 .Select(r => new IdentityRole(r.Id, r.Value, r.Description))
                 .ToList() ?? [];
         }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
         catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
         {
             activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
             LogGetRolesFailed(ex);
-            return [];
+            throw ClassifyReadFault(ex, "list_roles");
         }
     }
 
@@ -391,11 +431,15 @@ internal sealed partial class EntraIdIdentityProvider(
 
             return users;
         }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
         catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
         {
             activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
             LogGetRoleMembersFailed(ex, roleName);
-            return [];
+            throw ClassifyReadFault(ex, "list_role_members");
         }
     }
 
@@ -438,11 +482,15 @@ internal sealed partial class EntraIdIdentityProvider(
                 })
                 .ToList();
         }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
         catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
         {
             activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
             LogGetUserRolesFailed(ex, userId);
-            return [];
+            throw ClassifyReadFault(ex, "list_user_roles");
         }
     }
 
@@ -982,11 +1030,15 @@ internal sealed partial class EntraIdIdentityProvider(
 
             return response?.Value?.ConvertAll(ToIdentityGroup) ?? [];
         }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
         catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
         {
             activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
             LogGetGroupsFailed(ex);
-            return [];
+            throw ClassifyReadFault(ex, "list_groups");
         }
     }
 
@@ -1011,11 +1063,15 @@ internal sealed partial class EntraIdIdentityProvider(
 
             return response?.Value?.ConvertAll(ToIdentityGroup) ?? [];
         }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
         catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
         {
             activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
             LogGetUserGroupsFailed(ex, userId);
-            return [];
+            throw ClassifyReadFault(ex, "list_user_groups");
         }
     }
 

--- a/src/Granit.Identity.Federated.GoogleCloud/Internal/GoogleCloudIdentityProvider.cs
+++ b/src/Granit.Identity.Federated.GoogleCloud/Internal/GoogleCloudIdentityProvider.cs
@@ -37,6 +37,26 @@ internal sealed partial class GoogleCloudIdentityProvider(
     private static bool IsAuthorizationFailure(FirebaseException ex) =>
         ex.ErrorCode is ErrorCode.Unauthenticated or ErrorCode.PermissionDenied;
 
+    /// <summary>
+    /// Classifies a non-authorization Firebase read fault into the taxonomy the graceful-degradation
+    /// decorator understands: HTTP 429 (<see cref="ErrorCode.ResourceExhausted"/>, quota exhaustion) →
+    /// <see cref="IdentityProviderThrottledException"/>; a missing user/resource →
+    /// <see cref="IdentityProviderNotFoundException"/>; everything else (5xx, timeout, connection
+    /// reset, non-Firebase transport error) → <see cref="IdentityProviderTransientException"/>.
+    /// Applied only to the decorated <see cref="IIdentityProvider"/> read methods; the caller must
+    /// re-throw genuine cancellation before reaching here.
+    /// </summary>
+    private static Exception ClassifyReadFault(Exception ex, string operation) => ex switch
+    {
+        FirebaseException { ErrorCode: ErrorCode.ResourceExhausted } =>
+            new IdentityProviderThrottledException(ProviderName, operation, retryAfter: null, ex),
+        FirebaseAuthException { AuthErrorCode: AuthErrorCode.UserNotFound } =>
+            new IdentityProviderNotFoundException(ProviderName, operation, ex),
+        FirebaseException { ErrorCode: ErrorCode.NotFound } =>
+            new IdentityProviderNotFoundException(ProviderName, operation, ex),
+        _ => new IdentityProviderTransientException(ProviderName, operation, ex),
+    };
+
     // ── Users ─────────────────────────────────────────────────────────
 
     public async Task<IReadOnlyList<IIdentityUser>> GetUsersAsync(
@@ -71,10 +91,14 @@ internal sealed partial class GoogleCloudIdentityProvider(
         {
             throw new IdentityProviderUnauthorizedException(ProviderName, "list_users", ex);
         }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
         catch (Exception ex) when (ex is not NotSupportedException)
         {
             LogListUsersFailed(ex);
-            return [];
+            throw ClassifyReadFault(ex, "list_users");
         }
     }
 
@@ -97,10 +121,14 @@ internal sealed partial class GoogleCloudIdentityProvider(
         {
             throw new IdentityProviderUnauthorizedException(ProviderName, "get_user", ex);
         }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
         catch (Exception ex)
         {
             LogGetUserFailed(userId, ex);
-            return null;
+            throw ClassifyReadFault(ex, "get_user");
         }
     }
 
@@ -189,10 +217,14 @@ internal sealed partial class GoogleCloudIdentityProvider(
             List<string> roleNames = ExtractRoleNames(user.CustomClaims);
             return roleNames.ConvertAll(name => new IdentityRole(name, name, null));
         }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
         catch (Exception ex)
         {
             LogGetUserRolesFailed(userId, ex);
-            return [];
+            throw ClassifyReadFault(ex, "list_user_roles");
         }
     }
 

--- a/src/Granit.Identity.Federated.Keycloak/Internal/KeycloakIdentityProvider.cs
+++ b/src/Granit.Identity.Federated.Keycloak/Internal/KeycloakIdentityProvider.cs
@@ -59,6 +59,24 @@ internal sealed partial class KeycloakIdentityProvider(
     private static bool IsAuthorizationFailure(HttpRequestException ex) =>
         ex.StatusCode is HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden;
 
+    /// <summary>
+    /// Classifies a non-authorization admin-API fault into the taxonomy the graceful-degradation
+    /// decorator understands: HTTP 429 → <see cref="IdentityProviderThrottledException"/>, everything
+    /// else (5xx, timeout, connection reset) → <see cref="IdentityProviderTransientException"/>.
+    /// Applied only to the decorated <see cref="IIdentityProvider"/> read methods; the caller must
+    /// re-throw genuine cancellation before reaching here.
+    /// </summary>
+    private static Exception ClassifyReadFault(Exception ex, string operation) => ex switch
+    {
+        HttpRequestException { StatusCode: HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden } =>
+            new IdentityProviderUnauthorizedException(ProviderName, operation, ex),
+        HttpRequestException { StatusCode: HttpStatusCode.TooManyRequests } =>
+            new IdentityProviderThrottledException(ProviderName, operation, retryAfter: null, ex),
+        HttpRequestException { StatusCode: HttpStatusCode.NotFound } =>
+            new IdentityProviderNotFoundException(ProviderName, operation, ex),
+        _ => new IdentityProviderTransientException(ProviderName, operation, ex),
+    };
+
     /// <inheritdoc/>
     public async Task<IReadOnlyList<IIdentityUser>> GetUsersAsync(
         string? search = null,
@@ -86,12 +104,16 @@ internal sealed partial class KeycloakIdentityProvider(
             metrics.RecordOperationError(null, "list_users", ProviderName);
             throw new IdentityProviderUnauthorizedException(ProviderName, "list_users", ex);
         }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
         catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
         {
             activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
             metrics.RecordOperationError(null, "list_users", ProviderName);
             LogKeycloakGetUsersFailed(ex);
-            return [];
+            throw ClassifyReadFault(ex, "list_users");
         }
     }
 
@@ -126,12 +148,22 @@ internal sealed partial class KeycloakIdentityProvider(
             metrics.RecordOperationError(null, GetUserOperation, ProviderName);
             throw new IdentityProviderUnauthorizedException(ProviderName, GetUserOperation, ex);
         }
+        catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+        {
+            // A single-user GET returning 404 is a normal negative result, not a fault.
+            metrics.RecordOperationCompleted(null, GetUserOperation, ProviderName, "not_found");
+            return null;
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
         catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
         {
             activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
             metrics.RecordOperationError(null, GetUserOperation, ProviderName);
             LogKeycloakGetUserFailed(ex, userId);
-            return null;
+            throw ClassifyReadFault(ex, GetUserOperation);
         }
     }
 
@@ -402,11 +434,15 @@ internal sealed partial class KeycloakIdentityProvider(
 
             return roles?.ConvertAll(r => new IdentityRole(r.Id, r.Name, r.Description)) ?? [];
         }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
         catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
         {
             activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
             LogKeycloakGetRolesFailed(ex);
-            return [];
+            throw ClassifyReadFault(ex, "list_roles");
         }
     }
 
@@ -431,11 +467,15 @@ internal sealed partial class KeycloakIdentityProvider(
 
             return users?.ConvertAll(ToIdentityUser) ?? [];
         }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
         catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
         {
             activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
             LogKeycloakGetRoleMembersFailed(ex, roleName);
-            return [];
+            throw ClassifyReadFault(ex, "list_role_members");
         }
     }
 
@@ -462,11 +502,15 @@ internal sealed partial class KeycloakIdentityProvider(
 
             return roles?.ConvertAll(r => new IdentityRole(r.Id, r.Name, r.Description)) ?? [];
         }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
         catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
         {
             activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
             LogKeycloakGetUserRolesFailed(ex, userId);
-            return [];
+            throw ClassifyReadFault(ex, "list_user_roles");
         }
     }
 

--- a/tests/Granit.Identity.Federated.Cognito.Tests/CognitoIdentityProviderTests.cs
+++ b/tests/Granit.Identity.Federated.Cognito.Tests/CognitoIdentityProviderTests.cs
@@ -5,6 +5,7 @@ using Granit.Events;
 using Granit.Identity.Events;
 using Granit.Identity.Federated.Cognito.Internal;
 using Granit.Identity.Federated.Cognito.Options;
+using Granit.Identity.Federated.Exceptions;
 using Granit.Identity.Models;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
@@ -60,15 +61,13 @@ public sealed class CognitoIdentityProviderTests
     }
 
     [Fact]
-    public async Task GetUsersAsync_OnException_ReturnsEmpty()
+    public async Task GetUsersAsync_OnException_ThrowsTransient()
     {
         _cognitoClient.ListUsersAsync(Arg.Any<ListUsersRequest>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new AmazonServiceException("timeout"));
 
-        IReadOnlyList<IIdentityUser> result = await _sut.GetUsersAsync(
-            cancellationToken: TestContext.Current.CancellationToken);
-
-        result.ShouldBeEmpty();
+        await Should.ThrowAsync<IdentityProviderTransientException>(() => _sut.GetUsersAsync(
+            cancellationToken: TestContext.Current.CancellationToken));
     }
 
     // ── GetUserAsync ───────────────────────────────────────────────────────

--- a/tests/Granit.Identity.Federated.EntraId.Tests/EntraIdIdentityProviderAdditionalTests.cs
+++ b/tests/Granit.Identity.Federated.EntraId.Tests/EntraIdIdentityProviderAdditionalTests.cs
@@ -5,6 +5,7 @@ using Granit.Guids;
 using Granit.Identity.Events;
 using Granit.Identity.Federated.EntraId.Internal;
 using Granit.Identity.Federated.EntraId.Options;
+using Granit.Identity.Federated.Exceptions;
 using Granit.Identity.Models;
 using Granit.Timing;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -260,10 +261,8 @@ public sealed class EntraIdIdentityProviderAdditionalTests : IDisposable
         _handler.ResponseStatusCode = HttpStatusCode.ServiceUnavailable;
         _handler.ResponseBody = string.Empty;
 
-        DateTimeOffset? result = await _provider.GetPasswordChangedAtAsync(
-            "user-1", TestContext.Current.CancellationToken);
-
-        result.ShouldBeNull();
+        await Should.ThrowAsync<IdentityProviderTransientException>(
+            () => _provider.GetPasswordChangedAtAsync("user-1", TestContext.Current.CancellationToken));
     }
 
     // ──── GetRolesAsync ────

--- a/tests/Granit.Identity.Federated.EntraId.Tests/EntraIdIdentityProviderTests.cs
+++ b/tests/Granit.Identity.Federated.EntraId.Tests/EntraIdIdentityProviderTests.cs
@@ -5,6 +5,7 @@ using Granit.Guids;
 using Granit.Identity.Events;
 using Granit.Identity.Federated.EntraId.Internal;
 using Granit.Identity.Federated.EntraId.Options;
+using Granit.Identity.Federated.Exceptions;
 using Granit.Identity.Models;
 using Granit.Timing;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -101,10 +102,8 @@ public sealed class EntraIdIdentityProviderTests : IDisposable
         _handler.ResponseStatusCode = HttpStatusCode.ServiceUnavailable;
         _handler.ResponseBody = string.Empty;
 
-        IReadOnlyList<IIdentityUser> result = await _provider.GetUsersAsync(
-            cancellationToken: TestContext.Current.CancellationToken);
-
-        result.ShouldBeEmpty();
+        await Should.ThrowAsync<IdentityProviderTransientException>(
+            () => _provider.GetUsersAsync(cancellationToken: TestContext.Current.CancellationToken));
     }
 
     [Theory]

--- a/tests/Granit.Identity.Federated.EntraId.Tests/IdentityEntraIdActivitySourceTests.cs
+++ b/tests/Granit.Identity.Federated.EntraId.Tests/IdentityEntraIdActivitySourceTests.cs
@@ -5,6 +5,7 @@ using Granit.Guids;
 using Granit.Identity.Federated.EntraId.Diagnostics;
 using Granit.Identity.Federated.EntraId.Internal;
 using Granit.Identity.Federated.EntraId.Options;
+using Granit.Identity.Federated.Exceptions;
 using Granit.Timing;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
@@ -106,10 +107,12 @@ public sealed class IdentityEntraIdActivitySourceTests : IDisposable
         _handler.ResponseStatusCode = HttpStatusCode.ServiceUnavailable;
         _handler.ResponseBody = string.Empty;
 
-        await _provider.GetUsersAsync(cancellationToken: TestContext.Current.CancellationToken);
+        await Should.ThrowAsync<IdentityProviderTransientException>(
+            () => _provider.GetUsersAsync(cancellationToken: TestContext.Current.CancellationToken));
 
-        // Filter by both operation name AND status to avoid cross-contamination from parallel test classes
-        // (EntraIdIdentityProviderTests also calls GetUsersAsync with success, producing Unset activities).
+        // The activity is tagged Error before the fault is thrown. Filter by both operation name AND
+        // status to avoid cross-contamination from parallel test classes (EntraIdIdentityProviderTests
+        // also calls GetUsersAsync with success, producing Unset activities).
         _activities.ShouldContain(a =>
             a.OperationName == IdentityEntraIdActivitySource.GetUsers
             && a.Status == ActivityStatusCode.Error);
@@ -145,7 +148,8 @@ public sealed class IdentityEntraIdActivitySourceTests : IDisposable
         _handler.ResponseStatusCode = HttpStatusCode.InternalServerError;
         _handler.ResponseBody = string.Empty;
 
-        await _provider.GetGroupsAsync(TestContext.Current.CancellationToken);
+        await Should.ThrowAsync<IdentityProviderTransientException>(
+            () => _provider.GetGroupsAsync(TestContext.Current.CancellationToken));
 
         // Filter by both operation name AND status to avoid cross-contamination from parallel test classes
         // (EntraIdIdentityProviderTests also calls GetGroupsAsync with success, producing Unset activities).
@@ -175,7 +179,10 @@ public sealed class IdentityEntraIdActivitySourceTests : IDisposable
         _handler.ResponseStatusCode = HttpStatusCode.Forbidden;
         _handler.ResponseBody = string.Empty;
 
-        await _provider.GetRolesAsync(TestContext.Current.CancellationToken);
+        // 403 is an authorization failure: it surfaces as IdentityProviderUnauthorizedException
+        // (the decorator re-throws it rather than degrading — an IAM outage must not read as "no roles").
+        await Should.ThrowAsync<IdentityProviderUnauthorizedException>(
+            () => _provider.GetRolesAsync(TestContext.Current.CancellationToken));
 
         // Filter by both operation name AND status to avoid cross-contamination from parallel test classes
         // (EntraIdIdentityProviderAdditionalTests also calls GetRolesAsync with success, producing Unset activities).

--- a/tests/Granit.Identity.Federated.GoogleCloud.Tests/GoogleCloudIdentityProviderTests.cs
+++ b/tests/Granit.Identity.Federated.GoogleCloud.Tests/GoogleCloudIdentityProviderTests.cs
@@ -2,6 +2,7 @@ using System.Runtime.CompilerServices;
 using FirebaseAdmin.Auth;
 using Granit.Events;
 using Granit.Identity.Events;
+using Granit.Identity.Federated.Exceptions;
 using Granit.Identity.Federated.GoogleCloud.Internal;
 using Granit.Identity.Federated.GoogleCloud.Options;
 using Granit.Identity.Models;
@@ -47,14 +48,15 @@ public sealed class GoogleCloudIdentityProviderTests
     }
 
     [Fact]
-    public async Task GetUserAsync_ReturnsNull_WhenExceptionThrown()
+    public async Task GetUserAsync_ThrowsTransient_WhenRemoteFaults()
     {
+        // A non-not-found transport fault now throws the typed transient fault so the
+        // GracefulIdentityProviderDecorator becomes the single degradation point.
         _transport.GetUserAsync("uid-1", Arg.Any<CancellationToken>())
             .ThrowsAsync(new InvalidOperationException("transport error"));
 
-        IIdentityUser? result = await _sut.GetUserAsync("uid-1", TestContext.Current.CancellationToken);
-
-        result.ShouldBeNull();
+        await Should.ThrowAsync<IdentityProviderTransientException>(
+            () => _sut.GetUserAsync("uid-1", TestContext.Current.CancellationToken));
     }
 
     // ── SetUserEnabledAsync ─────────────────────────────────────────────
@@ -158,14 +160,13 @@ public sealed class GoogleCloudIdentityProviderTests
     }
 
     [Fact]
-    public async Task GetUserRolesAsync_ReturnsEmpty_OnException()
+    public async Task GetUserRolesAsync_ThrowsTransient_WhenRemoteFaults()
     {
         _transport.GetUserAsync("uid-1", Arg.Any<CancellationToken>())
             .ThrowsAsync(new InvalidOperationException("error"));
 
-        IReadOnlyList<IdentityRole> roles = await _sut.GetUserRolesAsync("uid-1", TestContext.Current.CancellationToken);
-
-        roles.ShouldBeEmpty();
+        await Should.ThrowAsync<IdentityProviderTransientException>(
+            () => _sut.GetUserRolesAsync("uid-1", TestContext.Current.CancellationToken));
     }
 
     [Fact]

--- a/tests/Granit.Identity.Federated.Keycloak.Tests/KeycloakIdentityProviderTests.cs
+++ b/tests/Granit.Identity.Federated.Keycloak.Tests/KeycloakIdentityProviderTests.cs
@@ -4,6 +4,7 @@ using System.Net;
 using Granit.Events;
 using Granit.Identity.Diagnostics;
 using Granit.Identity.Events;
+using Granit.Identity.Federated.Exceptions;
 using Granit.Identity.Federated.Keycloak.Internal;
 using Granit.Identity.Federated.Keycloak.Options;
 using Granit.Identity.Federated.RateLimiting;
@@ -140,10 +141,8 @@ public sealed class KeycloakIdentityProviderTests : IDisposable
         _handler.ResponseStatusCode = HttpStatusCode.ServiceUnavailable;
         _handler.ResponseBody = string.Empty;
 
-        IReadOnlyList<IIdentityUser> result = await _provider.GetRoleMembersAsync(
-            "editor", TestContext.Current.CancellationToken);
-
-        result.ShouldBeEmpty();
+        await Should.ThrowAsync<IdentityProviderTransientException>(
+            () => _provider.GetRoleMembersAsync("editor", TestContext.Current.CancellationToken));
     }
 
     [Fact]
@@ -218,10 +217,8 @@ public sealed class KeycloakIdentityProviderTests : IDisposable
         _handler.ResponseStatusCode = HttpStatusCode.InternalServerError;
         _handler.ResponseBody = string.Empty;
 
-        IReadOnlyList<IdentityRole> result = await _provider.GetRolesAsync(
-            TestContext.Current.CancellationToken);
-
-        result.ShouldBeEmpty();
+        await Should.ThrowAsync<IdentityProviderTransientException>(
+            () => _provider.GetRolesAsync(TestContext.Current.CancellationToken));
     }
 
     // --- Argument guard tests ---
@@ -383,10 +380,8 @@ public sealed class KeycloakIdentityProviderTests : IDisposable
         _handler.ResponseStatusCode = HttpStatusCode.ServiceUnavailable;
         _handler.ResponseBody = string.Empty;
 
-        IReadOnlyList<IIdentityUser> result = await _provider.GetUsersAsync(
-            cancellationToken: TestContext.Current.CancellationToken);
-
-        result.ShouldBeEmpty();
+        await Should.ThrowAsync<IdentityProviderTransientException>(
+            () => _provider.GetUsersAsync(cancellationToken: TestContext.Current.CancellationToken));
     }
 
     [Fact]
@@ -826,10 +821,8 @@ public sealed class KeycloakIdentityProviderTests : IDisposable
         _handler.ResponseStatusCode = HttpStatusCode.ServiceUnavailable;
         _handler.ResponseBody = string.Empty;
 
-        IReadOnlyList<IdentityRole> result = await _provider.GetUserRolesAsync(
-            "user-1", TestContext.Current.CancellationToken);
-
-        result.ShouldBeEmpty();
+        await Should.ThrowAsync<IdentityProviderTransientException>(
+            () => _provider.GetUserRolesAsync("user-1", TestContext.Current.CancellationToken));
     }
 
     [Fact]


### PR DESCRIPTION
## Vague 6b-ii — providers feed the decorator (completes FEATURE #3064 6b)

Completes Vague 6b. The four federated providers' **decorated `IIdentityProvider` read
methods** now THROW the typed taxonomy faults (from 6b-i) instead of catching and returning
empty/null, so the `GracefulIdentityProviderDecorator` is the **single degradation point**.

### Per provider

A `ClassifyReadFault(ex, operation)` helper maps the upstream fault to the taxonomy:
`401/403 → Unauthorized`, `429 → Throttled`, `404 → NotFound`, else `→ Transient`.
- Keycloak / EntraId key on `HttpRequestException.StatusCode`.
- Cognito keys on `AmazonServiceException` status / error-code.
- GoogleCloud keys on Firebase `ErrorCode` (`ResourceExhausted`/`NotFound`).

Each converted read also gains `catch (OperationCanceledException) when
(cancellationToken.IsCancellationRequested) { throw; }` — **closing the cancellation-swallowing
bug** the bare `catch (Exception)` (Cognito/GoogleCloud) and `catch (… or TaskCanceledException)`
(Keycloak/EntraId) blocks left open.

### Scope guards (what is and isn't converted)

- **Converted:** only the decorated `IIdentityProvider` core-facet reads that actually fetch
  (`GetUsers`, `GetUser`, `GetRoles`, `GetRoleMembers`, `GetUserRoles`, `GetGroups`,
  `GetUserGroups`, `GetPasswordChangedAt` — whichever each provider really implements). The
  decorator degrades their throws back to empty/null, so `IIdentityProvider` consumers see the
  **same result** — except a `401/403` now **surfaces** (decorator re-throws `Unauthorized`)
  instead of silently reading as "no data", which was the audit's core complaint.
- **`GetUser` keeps not-found → null** — a single-entity 404 is a normal negative result, not a fault.
- **Deliberately untouched:** the non-decorated facets. Session/device (`IUserSession/DeviceProvider`)
  keep self-degrading for their `/sessions`,`/devices` endpoints; the client-role facet
  (`IIdentityClientRoleManager`) keeps returning `[]` because the `ClientRoleSyncEngine` classifies
  its own fetch faults (`IClientRoleSyncPolicy.ClassifyFetchFault`) — throwing there would require
  updating the sync policies first, so it's out of scope for this PR.

### Breaking

`!` — behaviour is preserved for `IIdentityProvider` consumers (decorator degrades transient
faults back to empty/null), **except**: a `401/403` on a read now surfaces as
`IdentityProviderUnauthorizedException` (re-thrown by the decorator) rather than a silent empty
result. Callers that relied on "empty on IAM failure" now see the fault — which is the intended fix.

### Verification

Provider unit tests updated — failure-path tests on converted methods assert the thrown category
(mocked HTTP handler / SDK exception) instead of empty/null; not-found-on-`GetUser` stays null:
- Keycloak 172/172, EntraId 133/133, Cognito 61/61, GoogleCloud 55/55, Federated 85/85 (decorator).
- Architecture suite 262/262; `dotnet format` clean.

Refs #3064

🤖 Generated with [Claude Code](https://claude.com/claude-code)