### PR TITLE
refactor(identity): shared OAuth2 client-credentials token cache (Vague 7a)

### DIFF
--- a/src/Granit.Identity.Federated.EntraId/Internal/EntraIdAdminTokenService.cs
+++ b/src/Granit.Identity.Federated.EntraId/Internal/EntraIdAdminTokenService.cs
@@ -1,8 +1,6 @@
-using System.Diagnostics;
-using System.Net.Http.Json;
-using System.Text.Json.Serialization;
 using Granit.Identity.Federated.EntraId.Diagnostics;
 using Granit.Identity.Federated.EntraId.Options;
+using Granit.Identity.Federated.Internal;
 using Granit.Timing;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -10,90 +8,38 @@ using Microsoft.Extensions.Options;
 namespace Granit.Identity.Federated.EntraId.Internal;
 
 /// <summary>
-/// Singleton service that obtains and caches a Microsoft Entra ID service account token
-/// using the OAuth 2.0 <c>client_credentials</c> flow.
+/// Singleton service that obtains and caches a Microsoft Entra ID service-account token using the
+/// OAuth 2.0 <c>client_credentials</c> flow. Thin adapter over the shared
+/// <see cref="OAuth2ClientCredentialsTokenService"/>: it supplies the Graph token endpoint,
+/// credentials, the <c>https://graph.microsoft.com/.default</c> scope, and the Entra ID span.
 /// </summary>
-/// <remarks>
-/// Thread-safe: uses a <see cref="SemaphoreSlim"/> to serialize token refresh.
-/// The token is cached until 30 seconds before its actual expiry.
-/// </remarks>
-internal sealed partial class EntraIdAdminTokenService(
+internal sealed class EntraIdAdminTokenService(
     IHttpClientFactory httpClientFactory,
     IOptions<EntraIdAdminOptions> options,
     IClock clock,
     ILogger<EntraIdAdminTokenService> logger) : IDisposable
 {
-    private readonly SemaphoreSlim _semaphore = new(1, 1);
-    private string? _cachedToken;
-    private DateTimeOffset _tokenExpiry;
+    private readonly OAuth2ClientCredentialsTokenService _tokenService = new(httpClientFactory, clock, logger);
 
     /// <summary>
     /// Returns a valid access token, refreshing it if expired or not yet obtained.
     /// </summary>
-    public async Task<string> GetTokenAsync(CancellationToken cancellationToken)
+    public Task<string> GetTokenAsync(CancellationToken cancellationToken)
     {
-        if (_cachedToken is not null && clock.Now < _tokenExpiry)
-        {
-            return _cachedToken;
-        }
-
-        await _semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
-        try
-        {
-            // Double-check after acquiring the lock.
-            if (_cachedToken is not null && clock.Now < _tokenExpiry)
-            {
-                return _cachedToken;
-            }
-
-            using Activity? activity = IdentityEntraIdActivitySource.Source.StartActivity(IdentityEntraIdActivitySource.TokenAcquire);
-
-            EntraIdAdminOptions opts = options.Value;
-            HttpClient client = httpClientFactory.CreateClient("MicrosoftGraph");
-
-            using FormUrlEncodedContent content = new(
-            [
-                new KeyValuePair<string, string>("grant_type", "client_credentials"),
-                new KeyValuePair<string, string>("client_id", opts.ClientId),
-                new KeyValuePair<string, string>("client_secret", opts.ClientSecret),
-                new KeyValuePair<string, string>("scope", "https://graph.microsoft.com/.default"),
-            ]);
-
-            using HttpResponseMessage response = await client.PostAsync(
-                opts.GetTokenEndpoint(), content, cancellationToken).ConfigureAwait(false);
-
-            response.EnsureSuccessStatusCode();
-
-            TokenResponse? token = await response.Content
-                .ReadFromJsonAsync<TokenResponse>(cancellationToken).ConfigureAwait(false);
-
-            if (token is null || string.IsNullOrEmpty(token.AccessToken))
-            {
-                throw new InvalidOperationException(
-                    "Entra ID token endpoint returned an empty access token.");
-            }
-
-            // Cache with a 30-second safety margin.
-            _cachedToken = token.AccessToken;
-            _tokenExpiry = clock.Now.AddSeconds(Math.Max(token.ExpiresIn - 30, 10));
-
-            LogAdminTokenObtained(_tokenExpiry);
-
-            return _cachedToken;
-        }
-        finally
-        {
-            _semaphore.Release();
-        }
+        EntraIdAdminOptions opts = options.Value;
+        return _tokenService.GetTokenAsync(
+            new OAuth2ClientCredentialsRequest(
+                ProviderName: "Entra ID",
+                HttpClientName: "MicrosoftGraph",
+                TokenEndpoint: opts.GetTokenEndpoint(),
+                ClientId: opts.ClientId,
+                ClientSecret: opts.ClientSecret,
+                Scope: "https://graph.microsoft.com/.default",
+                ActivitySource: IdentityEntraIdActivitySource.Source,
+                ActivityName: IdentityEntraIdActivitySource.TokenAcquire),
+            cancellationToken);
     }
 
     /// <inheritdoc/>
-    public void Dispose() => _semaphore.Dispose();
-
-    [LoggerMessage(Level = LogLevel.Debug, Message = "Entra ID admin token obtained, expires at {Expiry}")]
-    private partial void LogAdminTokenObtained(DateTimeOffset expiry);
-
-    private sealed record TokenResponse(
-        [property: JsonPropertyName("access_token")] string AccessToken,
-        [property: JsonPropertyName("expires_in")] int ExpiresIn);
+    public void Dispose() => _tokenService.Dispose();
 }

--- a/src/Granit.Identity.Federated.Keycloak/Internal/KeycloakAdminTokenService.cs
+++ b/src/Granit.Identity.Federated.Keycloak/Internal/KeycloakAdminTokenService.cs
@@ -1,6 +1,4 @@
-using System.Diagnostics;
-using System.Net.Http.Json;
-using System.Text.Json.Serialization;
+using Granit.Identity.Federated.Internal;
 using Granit.Identity.Federated.Keycloak.Diagnostics;
 using Granit.Identity.Federated.Keycloak.Options;
 using Granit.Timing;
@@ -10,89 +8,38 @@ using Microsoft.Extensions.Options;
 namespace Granit.Identity.Federated.Keycloak.Internal;
 
 /// <summary>
-/// Singleton service that obtains and caches a Keycloak service account token
-/// using the OAuth 2.0 <c>client_credentials</c> flow.
+/// Singleton service that obtains and caches a Keycloak service-account token using the OAuth 2.0
+/// <c>client_credentials</c> flow. Thin adapter over the shared
+/// <see cref="OAuth2ClientCredentialsTokenService"/>: it supplies the realm token endpoint,
+/// credentials (no scope), and the Keycloak span.
 /// </summary>
-/// <remarks>
-/// Thread-safe: uses a <see cref="SemaphoreSlim"/> to serialize token refresh.
-/// The token is cached until 30 seconds before its actual expiry.
-/// </remarks>
-internal sealed partial class KeycloakAdminTokenService(
+internal sealed class KeycloakAdminTokenService(
     IHttpClientFactory httpClientFactory,
     IOptions<KeycloakAdminOptions> options,
     IClock clock,
     ILogger<KeycloakAdminTokenService> logger) : IDisposable
 {
-    private readonly SemaphoreSlim _semaphore = new(1, 1);
-    private string? _cachedToken;
-    private DateTimeOffset _tokenExpiry;
+    private readonly OAuth2ClientCredentialsTokenService _tokenService = new(httpClientFactory, clock, logger);
 
     /// <summary>
     /// Returns a valid access token, refreshing it if expired or not yet obtained.
     /// </summary>
-    public async Task<string> GetTokenAsync(CancellationToken cancellationToken)
+    public Task<string> GetTokenAsync(CancellationToken cancellationToken)
     {
-        if (_cachedToken is not null && clock.Now < _tokenExpiry)
-        {
-            return _cachedToken;
-        }
-
-        await _semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
-        try
-        {
-            // Double-check after acquiring the lock.
-            if (_cachedToken is not null && clock.Now < _tokenExpiry)
-            {
-                return _cachedToken;
-            }
-
-            using Activity? activity = IdentityKeycloakActivitySource.Source.StartActivity(IdentityKeycloakActivitySource.TokenAcquire);
-
-            KeycloakAdminOptions opts = options.Value;
-            HttpClient client = httpClientFactory.CreateClient("KeycloakAdmin");
-
-            using FormUrlEncodedContent content = new(
-            [
-                new KeyValuePair<string, string>("grant_type", "client_credentials"),
-                new KeyValuePair<string, string>("client_id", opts.ClientId),
-                new KeyValuePair<string, string>("client_secret", opts.ClientSecret),
-            ]);
-
-            using HttpResponseMessage response = await client.PostAsync(
-                opts.GetTokenEndpoint(), content, cancellationToken).ConfigureAwait(false);
-
-            response.EnsureSuccessStatusCode();
-
-            TokenResponse? token = await response.Content
-                .ReadFromJsonAsync<TokenResponse>(cancellationToken).ConfigureAwait(false);
-
-            if (token is null || string.IsNullOrEmpty(token.AccessToken))
-            {
-                throw new InvalidOperationException(
-                    "Keycloak token endpoint returned an empty access token.");
-            }
-
-            // Cache with a 30-second safety margin.
-            _cachedToken = token.AccessToken;
-            _tokenExpiry = clock.Now.AddSeconds(Math.Max(token.ExpiresIn - 30, 10));
-
-            LogAdminTokenObtained(_tokenExpiry);
-
-            return _cachedToken;
-        }
-        finally
-        {
-            _semaphore.Release();
-        }
+        KeycloakAdminOptions opts = options.Value;
+        return _tokenService.GetTokenAsync(
+            new OAuth2ClientCredentialsRequest(
+                ProviderName: "Keycloak",
+                HttpClientName: "KeycloakAdmin",
+                TokenEndpoint: opts.GetTokenEndpoint(),
+                ClientId: opts.ClientId,
+                ClientSecret: opts.ClientSecret,
+                Scope: null,
+                ActivitySource: IdentityKeycloakActivitySource.Source,
+                ActivityName: IdentityKeycloakActivitySource.TokenAcquire),
+            cancellationToken);
     }
 
     /// <inheritdoc/>
-    public void Dispose() => _semaphore.Dispose();
-
-    [LoggerMessage(Level = LogLevel.Debug, Message = "Keycloak admin token obtained, expires at {Expiry}")]
-    private partial void LogAdminTokenObtained(DateTimeOffset expiry);
-
-    private sealed record TokenResponse(
-        [property: JsonPropertyName("access_token")] string AccessToken,
-        [property: JsonPropertyName("expires_in")] int ExpiresIn);
+    public void Dispose() => _tokenService.Dispose();
 }

--- a/src/Granit.Identity.Federated/Granit.Identity.Federated.csproj
+++ b/src/Granit.Identity.Federated/Granit.Identity.Federated.csproj
@@ -8,6 +8,8 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="Granit.Identity.Federated.Tests" />
+    <InternalsVisibleTo Include="Granit.Identity.Federated.EntraId" />
+    <InternalsVisibleTo Include="Granit.Identity.Federated.Keycloak" />
     <InternalsVisibleTo Include="Granit.Identity.Federated.Endpoints" />
     <InternalsVisibleTo Include="Granit.Identity.Federated.Endpoints.Tests" />
     <InternalsVisibleTo Include="Granit.Identity.Federated.EntityFrameworkCore" />

--- a/src/Granit.Identity.Federated/Internal/OAuth2ClientCredentialsTokenService.cs
+++ b/src/Granit.Identity.Federated/Internal/OAuth2ClientCredentialsTokenService.cs
@@ -1,0 +1,121 @@
+using System.Diagnostics;
+using System.Net.Http.Json;
+using System.Text.Json.Serialization;
+using Granit.Timing;
+using Microsoft.Extensions.Logging;
+
+namespace Granit.Identity.Federated.Internal;
+
+/// <summary>
+/// Obtains and caches an OAuth 2.0 <c>client_credentials</c> service-account token, shared by the
+/// federated providers whose admin APIs authenticate that way (Entra ID, Keycloak). One instance
+/// per provider holds one cached token; refresh is serialized by a <see cref="SemaphoreSlim"/> with
+/// a double-checked lock, and the token is cached until 30 seconds before its advertised expiry.
+/// </summary>
+internal sealed partial class OAuth2ClientCredentialsTokenService(
+    IHttpClientFactory httpClientFactory,
+    IClock clock,
+    ILogger logger) : IDisposable
+{
+    private readonly SemaphoreSlim _semaphore = new(1, 1);
+    private string? _cachedToken;
+    private DateTimeOffset _tokenExpiry;
+
+    /// <summary>
+    /// Returns a valid access token for <paramref name="request"/>, refreshing it if expired or not
+    /// yet obtained. Callers pass their per-provider parameters each call (options may change).
+    /// </summary>
+    public async Task<string> GetTokenAsync(OAuth2ClientCredentialsRequest request, CancellationToken cancellationToken)
+    {
+        if (_cachedToken is not null && clock.Now < _tokenExpiry)
+        {
+            return _cachedToken;
+        }
+
+        await _semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            // Double-check after acquiring the lock.
+            if (_cachedToken is not null && clock.Now < _tokenExpiry)
+            {
+                return _cachedToken;
+            }
+
+            using Activity? activity = request.ActivitySource.StartActivity(request.ActivityName);
+
+            HttpClient client = httpClientFactory.CreateClient(request.HttpClientName);
+
+            List<KeyValuePair<string, string>> form =
+            [
+                new("grant_type", "client_credentials"),
+                new("client_id", request.ClientId),
+                new("client_secret", request.ClientSecret),
+            ];
+
+            if (!string.IsNullOrEmpty(request.Scope))
+            {
+                form.Add(new("scope", request.Scope));
+            }
+
+            using FormUrlEncodedContent content = new(form);
+
+            using HttpResponseMessage response = await client.PostAsync(
+                request.TokenEndpoint, content, cancellationToken).ConfigureAwait(false);
+
+            response.EnsureSuccessStatusCode();
+
+            TokenResponse? token = await response.Content
+                .ReadFromJsonAsync<TokenResponse>(cancellationToken).ConfigureAwait(false);
+
+            if (token is null || string.IsNullOrEmpty(token.AccessToken))
+            {
+                throw new InvalidOperationException(
+                    $"{request.ProviderName} token endpoint returned an empty access token.");
+            }
+
+            // Cache with a 30-second safety margin (floored so a short-lived token still caches briefly).
+            _cachedToken = token.AccessToken;
+            _tokenExpiry = clock.Now.AddSeconds(Math.Max(token.ExpiresIn - 30, 10));
+
+            LogAdminTokenObtained(logger, request.ProviderName, _tokenExpiry);
+
+            return _cachedToken;
+        }
+        finally
+        {
+            _semaphore.Release();
+        }
+    }
+
+    /// <inheritdoc/>
+    public void Dispose() => _semaphore.Dispose();
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "{Provider} admin token obtained, expires at {Expiry}")]
+    private static partial void LogAdminTokenObtained(ILogger logger, string provider, DateTimeOffset expiry);
+
+    private sealed record TokenResponse(
+        [property: JsonPropertyName("access_token")] string AccessToken,
+        [property: JsonPropertyName("expires_in")] int ExpiresIn);
+}
+
+/// <summary>
+/// The per-provider parameters for a single <see cref="OAuth2ClientCredentialsTokenService"/> token
+/// acquisition. Built from the provider's options each call.
+/// </summary>
+/// <param name="ProviderName">Display name for logs / error text (e.g. <c>"Entra ID"</c>).</param>
+/// <param name="HttpClientName">The named <see cref="HttpClient"/> to POST the token request with.</param>
+/// <param name="TokenEndpoint">The absolute token-endpoint URL.</param>
+/// <param name="ClientId">The service-account client id.</param>
+/// <param name="ClientSecret">The service-account client secret.</param>
+/// <param name="Scope">The requested scope, or <see langword="null"/> when the provider needs none (Keycloak).</param>
+/// <param name="ActivitySource">The provider's activity source for the token-acquire span.</param>
+/// <param name="ActivityName">The span name for the token acquisition.</param>
+internal sealed record OAuth2ClientCredentialsRequest(
+    string ProviderName,
+    string HttpClientName,
+    string TokenEndpoint,
+    string ClientId,
+    string ClientSecret,
+    string? Scope,
+    ActivitySource ActivitySource,
+    string ActivityName);


### PR DESCRIPTION
## Vague 7a — shared admin-token cache (part of FEATURE #3065)

`EntraIdAdminTokenService` and `KeycloakAdminTokenService` were ~98% identical: the same
`SemaphoreSlim` double-checked cache, the same `client_credentials` POST, the same 30-second
expiry margin, and a token-acquire span. This extracts the shared logic into one internal
`OAuth2ClientCredentialsTokenService` in the base Federated module.

Each provider service becomes a thin adapter that supplies its per-provider parameters via an
`OAuth2ClientCredentialsRequest`:
- **Entra ID** → Graph token endpoint, `https://graph.microsoft.com/.default` scope, `MicrosoftGraph` client.
- **Keycloak** → realm token endpoint, no scope, `KeycloakAdmin` client.

### Behaviour-preserving

The provider service **types, DI registrations, and `GetTokenAsync` signatures are unchanged**, so
their consumers (the providers) and the existing `*AdminTokenServiceTests` are untouched. The shared
cache is reached via `InternalsVisibleTo` (EntraId, Keycloak) rather than new public API surface. The
optional `scope` form parameter is added only when set, matching each provider's prior request body.

### Verification

- `EntraIdAdminTokenServiceTests` 7/7 and `KeycloakAdminTokenServiceTests` 8/8 pass unchanged (they
  now exercise the shared cache through the adapters).
- EntraId 133/133, Keycloak 172/172, Federated 85/85; architecture 262/262; `dotnet format` clean.

Refs #3065

🤖 Generated with [Claude Code](https://claude.com/claude-code)