### PR TITLE
fix(identity): stop leaking the Keycloak user-search term into telemetry (Vague 7b)

### DIFF
--- a/src/Granit.Identity.Federated.Keycloak/Diagnostics/IdentityKeycloakActivitySource.cs
+++ b/src/Granit.Identity.Federated.Keycloak/Diagnostics/IdentityKeycloakActivitySource.cs
@@ -55,7 +55,9 @@ internal static class IdentityKeycloakActivitySource
     internal const string TagClientId = "identity.keycloak.client_id";
     internal const string TagGroupId = "identity.keycloak.group_id";
     internal const string TagEnabled = "identity.keycloak.enabled";
-    internal const string TagSearch = "identity.keycloak.search";
+    // Records ONLY whether a search filter was supplied, never the search term itself —
+    // the term is user-controlled and can carry PII (email, name) into traces.
+    internal const string TagHasSearch = "identity.keycloak.search_present";
 
 #pragma warning disable GRSEC003 // Operation name constants, not secrets
     internal const string GetPasswordChangedAt = "identity.keycloak.get-password-changed-at";

--- a/src/Granit.Identity.Federated.Keycloak/Internal/KeycloakIdentityProvider.cs
+++ b/src/Granit.Identity.Federated.Keycloak/Internal/KeycloakIdentityProvider.cs
@@ -85,7 +85,7 @@ internal sealed partial class KeycloakIdentityProvider(
         CancellationToken cancellationToken = default)
     {
         using Activity? activity = IdentityKeycloakActivitySource.Source.StartActivity(IdentityKeycloakActivitySource.GetUsers);
-        activity?.SetTag(IdentityKeycloakActivitySource.TagSearch, search);
+        activity?.SetTag(IdentityKeycloakActivitySource.TagHasSearch, !string.IsNullOrWhiteSpace(search));
 
         try
         {

--- a/tests/Granit.Identity.Federated.Keycloak.Tests/KeycloakIdentityProviderTests.cs
+++ b/tests/Granit.Identity.Federated.Keycloak.Tests/KeycloakIdentityProviderTests.cs
@@ -5,6 +5,7 @@ using Granit.Events;
 using Granit.Identity.Diagnostics;
 using Granit.Identity.Events;
 using Granit.Identity.Federated.Exceptions;
+using Granit.Identity.Federated.Keycloak.Diagnostics;
 using Granit.Identity.Federated.Keycloak.Internal;
 using Granit.Identity.Federated.Keycloak.Options;
 using Granit.Identity.Federated.RateLimiting;
@@ -170,6 +171,31 @@ public sealed class KeycloakIdentityProviderTests : IDisposable
         _handler.Requests[0].Url.ShouldContain("search=alice");
         _handler.Requests[0].Url.ShouldContain("first=0");
         _handler.Requests[0].Url.ShouldContain("max=10");
+    }
+
+    [Fact]
+    public async Task GetUsersAsync_DoesNotLeakSearchTermIntoTelemetry()
+    {
+        // The search term is user-controlled and can carry PII (email, display name). The span
+        // must record only whether a search was performed, never the term itself.
+        const string piiSearch = "alice@example.com";
+        _handler.ResponseBody = "[]";
+
+        List<Activity> captured = [];
+        using ActivityListener listener = new()
+        {
+            ShouldListenTo = source => source.Name == IdentityKeycloakActivitySource.Name,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
+            ActivityStopped = captured.Add,
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        await _provider.GetUsersAsync(search: piiSearch, cancellationToken: TestContext.Current.CancellationToken);
+
+        Activity getUsers = captured.Single(a =>
+            a.OperationName == IdentityKeycloakActivitySource.GetUsers);
+        getUsers.GetTagItem("identity.keycloak.search_present").ShouldBe(true);
+        getUsers.Tags.ShouldNotContain(t => t.Value == piiSearch);
     }
 
     [Fact]


### PR DESCRIPTION
## Vague 7b — telemetry PII removal (part of FEATURE #3065)

`KeycloakIdentityProvider.GetUsersAsync` tagged its span with the **raw search string**
(`identity.keycloak.search`). That term is user-controlled and routinely carries PII (an email
or display name), so it landed verbatim in traces — a GDPR data-minimisation gap in observability.

### Fix

Replace the value tag with a privacy-safe **boolean presence indicator**
(`identity.keycloak.search_present`): operators still see whether a filtered search ran, never the
term itself. A regression test captures the span and asserts the search term never reaches a tag value.

This was the only PII-carrying span tag across the four providers (verified by sweeping every
`SetTag` call).

### Scope note

The rest of Vague 7's observability item — retro-porting `IdentityMetrics` and operation spans to
Cognito/EntraId/GoogleCloud (only Keycloak is instrumented today) — is deliberately **not** in this
PR: it adds an `IdentityMetrics` constructor dependency to three providers, which ripples through
every one of their test fixtures for parity-only value. Left as a separate, explicitly-prioritised
effort; this PR keeps the clear privacy win isolated.

### Verification

Keycloak 173/173 (incl. the new `GetUsersAsync_DoesNotLeakSearchTermIntoTelemetry`), `dotnet format` clean.

Refs #3065

🤖 Generated with [Claude Code](https://claude.com/claude-code)