### PR TITLE
fix(ci): sync integration lock for MagickNet config/options deps

### DIFF
--- a/tests/Granit.TextExtraction.Ocr.Tesseract.Tests.Integration/packages.lock.json
+++ b/tests/Granit.TextExtraction.Ocr.Tesseract.Tests.Integration/packages.lock.json
@@ -285,7 +285,11 @@
         "type": "Project",
         "dependencies": {
           "Granit.Imaging": "[0.1.0-dev, )",
-          "Magick.NET-Q8-AnyCPU": "[14.*, )"
+          "Magick.NET-Q8-AnyCPU": "[14.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Logging.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }
       },
       "granit.textextraction": {


### PR DESCRIPTION
Follow-up to #3097. The integration shard still fails locked-mode restore with **NU1004**:

```
error NU1004: The project references granit.imaging.magicknet whose dependencies
has changed. The packages lock file is inconsistent with the project dependencies...
```

## Root cause

`Granit.Imaging.MagickNet` gained 4 package references in #3077 (config-bound options / startup resource limits):

- `Microsoft.Extensions.Hosting.Abstractions`
- `Microsoft.Extensions.Logging.Abstractions`
- `Microsoft.Extensions.Options`
- `Microsoft.Extensions.Options.ConfigurationExtensions`

The transitive consumer `Granit.TextExtraction.Ocr.Tesseract.Tests.Integration` never had its `packages.lock.json` regenerated, so its `granit.imaging.magicknet` block still listed only 2 deps.

## Fix

Force-evaluate restore of the one flagged project records the 4 new deps — no unrelated version drift (a single lock file, one 4-line hunk).

## Verification

Clean-`obj` locked-mode restore of the full `integration.slnf` shard now passes (the earlier "OK" in the #3097 discussion was a false negative from a leftover `obj/` masking the stale lock — verified clean this time).

🤖 Generated with [Claude Code](https://claude.com/claude-code)