### PR TITLE
fix(identity): paginate federated user/role/group listings (Vague 7d)

### DIFF
--- a/src/Granit.Identity.Federated.Cognito/Internal/CognitoIdentityProvider.cs
+++ b/src/Granit.Identity.Federated.Cognito/Internal/CognitoIdentityProvider.cs
@@ -28,6 +28,9 @@ internal sealed partial class CognitoIdentityProvider(
     : IIdentityProvider, IIdentityClientRoleManager, IUserSessionProvider, IUserDeviceProvider
 {
     private const string ProviderName = "cognito";
+
+    // AWS Cognito caps ListUsers at 60 users per page; larger result sets continue via PaginationToken.
+    private const int CognitoListUsersPageSize = 60;
     private const string EmailAttribute = "email";
     private const string GivenNameAttribute = "given_name";
     private const string FamilyNameAttribute = "family_name";
@@ -104,16 +107,38 @@ internal sealed partial class CognitoIdentityProvider(
                 request.Filter = $"username ^= \"{search}\"";
             }
 
-            if (max.HasValue)
+            // Cognito ListUsers caps a page at 60 users and continues via PaginationToken. A single
+            // call (the old behaviour) silently truncated the directory to the first 60. Follow the
+            // token, bounded by the caller's window (first+max) so a small request does not walk the
+            // whole pool.
+            request.Limit = Math.Min(max ?? CognitoListUsersPageSize, CognitoListUsersPageSize);
+            int? fetchLimit = max.HasValue ? (first ?? 0) + max.Value : null;
+
+            List<Amazon.CognitoIdentityProvider.Model.UserType> allUsers = [];
+            do
             {
-                request.Limit = max.Value;
+                ListUsersResponse response = await cognitoClient
+                    .ListUsersAsync(request, cancellationToken)
+                    .ConfigureAwait(false);
+
+                allUsers.AddRange(response.Users);
+                request.PaginationToken = response.PaginationToken;
+            }
+            while (!string.IsNullOrEmpty(request.PaginationToken)
+                && (!fetchLimit.HasValue || allUsers.Count < fetchLimit.Value));
+
+            IEnumerable<Amazon.CognitoIdentityProvider.Model.UserType> window = allUsers;
+            if (first is > 0)
+            {
+                window = window.Skip(first.Value);
             }
 
-            ListUsersResponse response = await cognitoClient
-                .ListUsersAsync(request, cancellationToken)
-                .ConfigureAwait(false);
+            if (max.HasValue)
+            {
+                window = window.Take(max.Value);
+            }
 
-            return response.Users.ConvertAll(ToIdentityUser);
+            return window.Select(ToIdentityUser).ToList();
         }
         catch (NotAuthorizedException ex)
         {

--- a/src/Granit.Identity.Federated.EntraId/Internal/EntraIdIdentityProvider.cs
+++ b/src/Granit.Identity.Federated.EntraId/Internal/EntraIdIdentityProvider.cs
@@ -68,6 +68,41 @@ internal sealed partial class EntraIdIdentityProvider(
         _ => new IdentityProviderTransientException(ProviderName, operation, ex),
     };
 
+    /// <summary>
+    /// Fetches every page of a Microsoft Graph collection by following <c>@odata.nextLink</c>. Graph
+    /// uses cursor pagination — <c>$skip</c> is unsupported on <c>/users</c> and most collections — so
+    /// a single GET returns only the first page (100 items by default). Accumulates up to
+    /// <paramref name="maxItems"/> results when set (a fetch bound so callers requesting a small window
+    /// do not walk the entire directory). The first request uses <paramref name="firstPageEndpoint"/>;
+    /// each continuation uses the absolute next-link URL Graph returns.
+    /// </summary>
+    private static async Task<List<T>> GetAllPagesAsync<T>(
+        HttpClient client, string firstPageEndpoint, int? maxItems, CancellationToken cancellationToken)
+    {
+        List<T> all = [];
+        string? next = firstPageEndpoint;
+
+        while (next is not null)
+        {
+            GraphCollectionResponse<T>? page = await client
+                .GetFromJsonAsync<GraphCollectionResponse<T>>(next, cancellationToken).ConfigureAwait(false);
+
+            if (page?.Value is { Count: > 0 })
+            {
+                all.AddRange(page.Value);
+            }
+
+            next = page?.NextLink;
+
+            if (maxItems.HasValue && all.Count >= maxItems.Value)
+            {
+                break;
+            }
+        }
+
+        return all;
+    }
+
     /// <inheritdoc/>
     public async Task<IReadOnlyList<IIdentityUser>> GetUsersAsync(
         string? search = null,
@@ -89,13 +124,27 @@ internal sealed partial class EntraIdIdentityProvider(
         try
         {
             HttpClient client = await CreateAuthenticatedClientAsync(cancellationToken).ConfigureAwait(false);
-            string endpoint = EntraIdAdminOptions.GetUsersEndpoint(search, first, max);
+            string endpoint = EntraIdAdminOptions.GetUsersEndpoint(search, top: max);
 
-            GraphCollectionResponse<GraphUserRepresentation>? response = await client
-                .GetFromJsonAsync<GraphCollectionResponse<GraphUserRepresentation>>(endpoint, cancellationToken)
-                .ConfigureAwait(false);
+            // Graph paginates via @odata.nextLink and rejects $skip on /users, so the caller's
+            // offset window (first/max) is applied client-side over the followed pages. Cap the
+            // fetch at first+max so a small window does not walk the whole directory.
+            int? fetchLimit = max.HasValue ? (first ?? 0) + max.Value : null;
+            List<GraphUserRepresentation> all = await GetAllPagesAsync<GraphUserRepresentation>(
+                client, endpoint, fetchLimit, cancellationToken).ConfigureAwait(false);
 
-            return response?.Value?.ConvertAll(ToIdentityUser) ?? [];
+            IEnumerable<GraphUserRepresentation> window = all;
+            if (first is > 0)
+            {
+                window = window.Skip(first.Value);
+            }
+
+            if (max.HasValue)
+            {
+                window = window.Take(max.Value);
+            }
+
+            return window.Select(ToIdentityUser).ToList();
         }
         catch (HttpRequestException ex) when (IsAuthorizationFailure(ex))
         {
@@ -399,12 +448,12 @@ internal sealed partial class EntraIdIdentityProvider(
         {
             HttpClient client = await CreateAuthenticatedClientAsync(cancellationToken).ConfigureAwait(false);
 
-            // Get all App Role assignments on the Service Principal
+            // Get all App Role assignments on the Service Principal (paginated — a popular app can
+            // have well over one page of assigned users).
             string endpoint = options.Value.GetServicePrincipalAppRoleAssignedToEndpoint();
 
-            GraphCollectionResponse<GraphAppRoleAssignmentRepresentation>? assignments = await client
-                .GetFromJsonAsync<GraphCollectionResponse<GraphAppRoleAssignmentRepresentation>>(endpoint, cancellationToken)
-                .ConfigureAwait(false);
+            List<GraphAppRoleAssignmentRepresentation> assignments = await GetAllPagesAsync<GraphAppRoleAssignmentRepresentation>(
+                client, endpoint, maxItems: null, cancellationToken).ConfigureAwait(false);
 
             // Resolve the role name to an App Role ID
             string? roleId = await ResolveRoleIdByNameAsync(client, roleName, cancellationToken).ConfigureAwait(false);
@@ -414,10 +463,10 @@ internal sealed partial class EntraIdIdentityProvider(
             }
 
             // Filter assignments by role ID and resolve each user
-            List<string> userIds = assignments?.Value?
+            var userIds = assignments
                 .Where(a => string.Equals(a.AppRoleId, roleId, StringComparison.OrdinalIgnoreCase))
                 .Select(a => a.PrincipalId)
-                .ToList() ?? [];
+                .ToList();
 
             List<IIdentityUser> users = [];
             foreach (string uid in userIds)
@@ -1024,11 +1073,10 @@ internal sealed partial class EntraIdIdentityProvider(
             HttpClient client = await CreateAuthenticatedClientAsync(cancellationToken).ConfigureAwait(false);
             const string endpoint = EntraIdAdminOptions.GroupsEndpoint;
 
-            GraphCollectionResponse<GraphGroupRepresentation>? response = await client
-                .GetFromJsonAsync<GraphCollectionResponse<GraphGroupRepresentation>>(endpoint, cancellationToken)
-                .ConfigureAwait(false);
+            List<GraphGroupRepresentation> groups = await GetAllPagesAsync<GraphGroupRepresentation>(
+                client, endpoint, maxItems: null, cancellationToken).ConfigureAwait(false);
 
-            return response?.Value?.ConvertAll(ToIdentityGroup) ?? [];
+            return groups.ConvertAll(ToIdentityGroup);
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
@@ -1057,11 +1105,10 @@ internal sealed partial class EntraIdIdentityProvider(
             HttpClient client = await CreateAuthenticatedClientAsync(cancellationToken).ConfigureAwait(false);
             string endpoint = EntraIdAdminOptions.GetUserGroupsEndpoint(userId);
 
-            GraphCollectionResponse<GraphGroupRepresentation>? response = await client
-                .GetFromJsonAsync<GraphCollectionResponse<GraphGroupRepresentation>>(endpoint, cancellationToken)
-                .ConfigureAwait(false);
+            List<GraphGroupRepresentation> groups = await GetAllPagesAsync<GraphGroupRepresentation>(
+                client, endpoint, maxItems: null, cancellationToken).ConfigureAwait(false);
 
-            return response?.Value?.ConvertAll(ToIdentityGroup) ?? [];
+            return groups.ConvertAll(ToIdentityGroup);
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {

--- a/src/Granit.Identity.Federated.EntraId/Options/EntraIdAdminOptions.cs
+++ b/src/Granit.Identity.Federated.EntraId/Options/EntraIdAdminOptions.cs
@@ -85,9 +85,11 @@ public sealed class EntraIdAdminOptions
     // ──── Users ────
 
     /// <summary>
-    /// Builds the Graph API URL for listing users with optional search and pagination.
+    /// Builds the Graph API URL for listing users with an optional search filter and page size.
+    /// Graph paginates via <c>@odata.nextLink</c> and rejects <c>$skip</c> on <c>/users</c>, so only
+    /// <c>$top</c> (page size) is emitted; continuation is by following the next-link.
     /// </summary>
-    internal static string GetUsersEndpoint(string? search = null, int? skip = null, int? top = null)
+    internal static string GetUsersEndpoint(string? search = null, int? top = null)
     {
         List<string> queryParams =
         [
@@ -98,11 +100,6 @@ public sealed class EntraIdAdminOptions
         {
             string escaped = EscapeODataStringLiteral(search);
             queryParams.Add($"$filter=startswith(displayName,'{Uri.EscapeDataString(escaped)}') or startswith(mail,'{Uri.EscapeDataString(escaped)}')");
-        }
-
-        if (skip.HasValue)
-        {
-            queryParams.Add($"$skip={skip.Value}");
         }
 
         if (top.HasValue)

--- a/tests/Granit.Identity.Federated.Cognito.Tests/CognitoIdentityProviderTests.cs
+++ b/tests/Granit.Identity.Federated.Cognito.Tests/CognitoIdentityProviderTests.cs
@@ -61,6 +61,30 @@ public sealed class CognitoIdentityProviderTests
     }
 
     [Fact]
+    public async Task GetUsersAsync_FollowsPaginationToken_ReturnsEveryPage()
+    {
+        // Cognito caps a page at 60 and continues via PaginationToken. A single call (the old
+        // behaviour) truncated the pool — this drives two pages and asserts all three users surface.
+        ListUsersResponse page1 = new()
+        {
+            Users = [CreateUserType("u1", "u1@t.com", "A", "B", true), CreateUserType("u2", "u2@t.com", "C", "D", true)],
+            PaginationToken = "NEXT",
+        };
+        ListUsersResponse page2 = new()
+        {
+            Users = [CreateUserType("u3", "u3@t.com", "E", "F", true)],
+        };
+        _cognitoClient.ListUsersAsync(Arg.Any<ListUsersRequest>(), Arg.Any<CancellationToken>())
+            .Returns(page1, page2);
+
+        IReadOnlyList<IIdentityUser> result = await _sut.GetUsersAsync(
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        result.Select(u => u.Username).ShouldBe(["u1", "u2", "u3"]);
+        await _cognitoClient.Received(2).ListUsersAsync(Arg.Any<ListUsersRequest>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task GetUsersAsync_OnException_ThrowsTransient()
     {
         _cognitoClient.ListUsersAsync(Arg.Any<ListUsersRequest>(), Arg.Any<CancellationToken>())

--- a/tests/Granit.Identity.Federated.EntraId.Tests/EntraIdAdminOptionsAdditionalTests.cs
+++ b/tests/Granit.Identity.Federated.EntraId.Tests/EntraIdAdminOptionsAdditionalTests.cs
@@ -88,12 +88,13 @@ public sealed class EntraIdAdminOptionsAdditionalTests
     }
 
     [Fact]
-    public void GetUsersEndpoint_WithSkipAndTop_IncludesParams()
+    public void GetUsersEndpoint_WithTop_EmitsTopButNeverSkip()
     {
-        string endpoint = EntraIdAdminOptions.GetUsersEndpoint(skip: 10, top: 25);
+        // Graph rejects $skip on /users — the page size is $top and continuation is via @odata.nextLink.
+        string endpoint = EntraIdAdminOptions.GetUsersEndpoint(top: 25);
 
-        endpoint.ShouldContain("$skip=10");
         endpoint.ShouldContain("$top=25");
+        endpoint.ShouldNotContain("$skip");
     }
 
     [Fact]

--- a/tests/Granit.Identity.Federated.EntraId.Tests/EntraIdAdminOptionsTests.cs
+++ b/tests/Granit.Identity.Federated.EntraId.Tests/EntraIdAdminOptionsTests.cs
@@ -35,12 +35,13 @@ public sealed class EntraIdAdminOptionsTests
     }
 
     [Fact]
-    public void GetUsersEndpoint_WithPagination_IncludesSkipAndTopParams()
+    public void GetUsersEndpoint_WithTop_EmitsTopAndNeverSkip()
     {
-        string endpoint = EntraIdAdminOptions.GetUsersEndpoint(skip: 10, top: 25);
+        // Graph rejects $skip on /users; pagination is $top (page size) + @odata.nextLink.
+        string endpoint = EntraIdAdminOptions.GetUsersEndpoint(top: 25);
 
-        endpoint.ShouldContain("$skip=10");
         endpoint.ShouldContain("$top=25");
+        endpoint.ShouldNotContain("$skip");
     }
 
     [Fact]

--- a/tests/Granit.Identity.Federated.EntraId.Tests/EntraIdIdentityProviderTests.cs
+++ b/tests/Granit.Identity.Federated.EntraId.Tests/EntraIdIdentityProviderTests.cs
@@ -106,6 +106,32 @@ public sealed class EntraIdIdentityProviderTests : IDisposable
             () => _provider.GetUsersAsync(cancellationToken: TestContext.Current.CancellationToken));
     }
 
+    [Fact]
+    public async Task GetUsersAsync_FollowsODataNextLink_ReturnsEveryPage()
+    {
+        // Graph returns 100 users per page and a @odata.nextLink cursor. A single GET (the old
+        // behaviour) silently truncated to the first page — this drives two pages and asserts all
+        // three users surface, and that the provider actually followed the next-link.
+        const string page1 = """{"value":[{"id":"u1","userPrincipalName":"a@x.com","mail":null,"givenName":null,"surname":null,"accountEnabled":true},{"id":"u2","userPrincipalName":"b@x.com","mail":null,"givenName":null,"surname":null,"accountEnabled":true}],"@odata.nextLink":"https://graph.microsoft.com/v1.0/users?$skiptoken=NEXT"}""";
+        const string page2 = """{"value":[{"id":"u3","userPrincipalName":"c@x.com","mail":null,"givenName":null,"surname":null,"accountEnabled":true}]}""";
+
+        MockSequenceHttpMessageHandler graphHandler = new([page1, page2]);
+        using HttpClient graphClient = new(graphHandler) { BaseAddress = new Uri("https://graph.microsoft.com/") };
+        IHttpClientFactory graphFactory = Substitute.For<IHttpClientFactory>();
+        graphFactory.CreateClient("MicrosoftGraph").Returns(graphClient);
+
+        EntraIdIdentityProvider provider = new(
+            _tokenService, graphFactory, Microsoft.Extensions.Options.Options.Create(_options),
+            _passwordResetNotifier, _distributedEventBus, new SimpleGuidGenerator(),
+            NullLogger<EntraIdIdentityProvider>.Instance);
+
+        IReadOnlyList<IIdentityUser> result = await provider.GetUsersAsync(
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        result.Select(u => u.UserId).ShouldBe(["u1", "u2", "u3"]);
+        graphHandler.CallCount.ShouldBe(2);
+    }
+
     [Theory]
     [InlineData("x') or accountEnabled eq true or startswith(mail,'")]
     [InlineData("a\" or 1 eq 1")]


### PR DESCRIPTION
## Vague 7d — provider pagination (part of FEATURE #3065)

The Entra ID and Cognito providers issued a **single** list call and returned only the first
page, **silently truncating the directory**: Microsoft Graph returns 100 items/page behind an
`@odata.nextLink` cursor, Cognito 60 behind a `PaginationToken`. A tenant with more users — or a
role/group with more members — lost everyone past page one. This is a correctness bug, not a
convenience gap.

### Entra ID

- New `GetAllPagesAsync<T>` helper follows `@odata.nextLink`, bounded by a fetch limit.
- **Stop emitting `$skip`** — Graph rejects it on `/users`; pagination is `$top` (page size) +
  next-link. `GetUsersEndpoint` drops the `skip` parameter.
- Applied to `GetUsersAsync` (with client-side `first`/`max` windowing over the followed pages),
  `GetGroupsAsync`, `GetUserGroupsAsync`, and `GetRoleMembersAsync`.

### Cognito

- `GetUsersAsync` follows `PaginationToken`, bounded by the caller's `first+max` window (page size
  capped at Cognito's 60).

### Verification

Regression tests drive two pages through the mocked transports (Graph `MockSequenceHttpMessageHandler`,
Cognito NSubstitute sequential returns) and assert every page surfaces and the cursor/token was
followed. The `$skip` endpoint tests are updated to assert `$top`-only. EntraId 134/134, Cognito 62/62,
architecture 262/262, `dotnet format` clean.

### Scope note

`GetUserRolesAsync` (a single user's app-role assignments — rarely exceeds a page) was left
unpaginated to keep the change focused on the high-impact list reads; it can adopt the same helper
trivially if needed.

Refs #3065

🤖 Generated with [Claude Code](https://claude.com/claude-code)