### PR TITLE
refactor(openiddict)!: OpenIddictDbContext composes GranitDbContext instead of IdentityDbContext (Phase 3)

### DIFF
--- a/src/Granit.OpenIddict.EntityFrameworkCore/Extensions/OpenIddictModelBuilderExtensions.cs
+++ b/src/Granit.OpenIddict.EntityFrameworkCore/Extensions/OpenIddictModelBuilderExtensions.cs
@@ -66,6 +66,22 @@ public static class OpenIddictModelBuilderExtensions
             b.Property(u => u.CreatedBy).HasMaxLength(256);
             b.Property(u => u.ModifiedBy).HasMaxLength(256);
 
+            // ── Replicated IdentityDbContext<TUser,TRole,TKey> conventions ──
+            // This context is built on GranitDbContext, not IdentityDbContext, so the identity
+            // schema (indexes, maxlengths, concurrency token, join relationships) is declared here.
+            // Names and lengths mirror the framework defaults byte-for-byte (pinning-test guarded).
+            b.Property(u => u.UserName).HasMaxLength(256);
+            b.Property(u => u.NormalizedUserName).HasMaxLength(256);
+            b.Property(u => u.Email).HasMaxLength(256);
+            b.Property(u => u.NormalizedEmail).HasMaxLength(256);
+            b.Property(u => u.ConcurrencyStamp).IsConcurrencyToken();
+            b.HasIndex(u => u.NormalizedUserName).HasDatabaseName("UserNameIndex").IsUnique();
+            b.HasIndex(u => u.NormalizedEmail).HasDatabaseName("EmailIndex");
+            b.HasMany<IdentityUserClaim<Guid>>().WithOne().HasForeignKey(uc => uc.UserId).IsRequired();
+            b.HasMany<IdentityUserLogin<Guid>>().WithOne().HasForeignKey(ul => ul.UserId).IsRequired();
+            b.HasMany<IdentityUserToken<Guid>>().WithOne().HasForeignKey(ut => ut.UserId).IsRequired();
+            b.HasMany<IdentityUserRole<Guid>>().WithOne().HasForeignKey(ur => ur.UserId).IsRequired();
+
             // Manual soft-delete filter with IDataFilter bypass support.
             // LocalIdentity does NOT implement ISoftDeletable (incompatible with UserManager),
             // so ApplyGranitConventions cannot register this filter automatically.
@@ -90,6 +106,14 @@ public static class OpenIddictModelBuilderExtensions
         {
             b.ToTable(prefix + "roles", schema);
             b.Property(r => r.Description).HasMaxLength(512);
+
+            // Replicated IdentityDbContext role conventions (see the LocalIdentity block).
+            b.Property(r => r.Name).HasMaxLength(256);
+            b.Property(r => r.NormalizedName).HasMaxLength(256);
+            b.Property(r => r.ConcurrencyStamp).IsConcurrencyToken();
+            b.HasIndex(r => r.NormalizedName).HasDatabaseName("RoleNameIndex").IsUnique();
+            b.HasMany<IdentityUserRole<Guid>>().WithOne().HasForeignKey(ur => ur.RoleId).IsRequired();
+            b.HasMany<IdentityRoleClaim<Guid>>().WithOne().HasForeignKey(rc => rc.RoleId).IsRequired();
         });
 
         // ASP.NET Identity join/claim entities — define keys explicitly so that

--- a/src/Granit.OpenIddict.EntityFrameworkCore/Internal/EfGranitRoleQueryableSource.cs
+++ b/src/Granit.OpenIddict.EntityFrameworkCore/Internal/EfGranitRoleQueryableSource.cs
@@ -23,7 +23,7 @@ internal sealed class EfGranitRoleQueryableSource(
     public IQueryable<GranitRole> GetQueryable()
     {
         _context ??= contextFactory.CreateDbContext();
-        return _context.Roles.AsNoTracking();
+        return _context.Set<GranitRole>().AsNoTracking();
     }
 
     public ValueTask DisposeAsync()

--- a/src/Granit.OpenIddict.EntityFrameworkCore/Internal/OpenIddictDbContext.cs
+++ b/src/Granit.OpenIddict.EntityFrameworkCore/Internal/OpenIddictDbContext.cs
@@ -1,33 +1,31 @@
-using System.Linq.Expressions;
-using System.Reflection;
 using Granit.DataFiltering;
-using Granit.Domain;
 using Granit.Identity.Local.Domain;
 using Granit.MultiTenancy;
 using Granit.OpenIddict.Domain;
 using Granit.OpenIddict.EntityFrameworkCore.Extensions;
 using Granit.Persistence.EntityFrameworkCore;
-using Granit.Persistence.EntityFrameworkCore.Extensions;
 using Granit.Persistence.EntityFrameworkCore.Metadata;
-using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.Extensions.Options;
 
 namespace Granit.OpenIddict.EntityFrameworkCore.Internal;
 
 /// <summary>
-/// Isolated DbContext for the OpenIddict module, extending
-/// <see cref="IdentityDbContext{TUser,TRole,TKey}"/> with OpenIddict entity support.
+/// Isolated DbContext for the OpenIddict module and its co-located ASP.NET Core Identity tables.
 /// </summary>
 /// <remarks>
 /// <para>
-/// Cannot inherit from <see cref="GranitDbContext"/> because the C# single-inheritance
-/// constraint already binds this type to ASP.NET Identity's
-/// <see cref="IdentityDbContext{TUser,TRole,TKey}"/>. The parameterised IMultiTenant
-/// filter is therefore replicated inline (see <see cref="CurrentTenantId"/>,
-/// <see cref="IsMultiTenantFilterEnabled"/>, <see cref="ConfigureMultiTenantFilter"/>) —
-/// any change to the GranitDbContext filter shape must mirror here.
+/// Built on <see cref="GranitDbContext"/> — the parameterised <c>IMultiTenant</c> filter and
+/// <c>ApplyGranitConventions</c> come from the base, so the reflection-based filter replication a
+/// non-<c>GranitDbContext</c> derivative would need is gone.
+/// </para>
+/// <para>
+/// The context does <b>not</b> inherit <c>IdentityDbContext</c>: the entire model — the Identity
+/// tables (users/roles/claims/logins/tokens/passkeys), their keys, unique indexes
+/// (<c>UserNameIndex</c>/<c>EmailIndex</c>/<c>RoleNameIndex</c>), maxlengths and relationships, plus
+/// the OpenIddict entities, group tables and signing keys — is defined self-contained by
+/// <see cref="OpenIddictModelBuilderExtensions.ConfigureOpenIddictModule"/>. A relational-model
+/// pinning test guards that this produces a byte-identical schema.
 /// </para>
 /// </remarks>
 internal sealed class OpenIddictDbContext(
@@ -35,23 +33,8 @@ internal sealed class OpenIddictDbContext(
     ICurrentTenant currentTenant,
     IDataFilter? dataFilter = null,
     IOptions<MetadataMappingOptions<LocalIdentity>>? extensionOptions = null)
-    : IdentityDbContext<LocalIdentity, GranitRole, Guid>(options)
+    : GranitDbContext(options, currentTenant, dataFilter)
 {
-    private static readonly MethodInfo ConfigureMultiTenantFilterMethod =
-        typeof(OpenIddictDbContext).GetMethod(
-            nameof(ConfigureMultiTenantFilter),
-            BindingFlags.Instance | BindingFlags.NonPublic)!; // NOSONAR S3011 - intentional: ConfigureMultiTenantFilter must stay private to keep its `this`-binding (load-bearing for EF Core parameter extraction); reflection is the only way to invoke a generic instance method per-entity-type.
-
-    private readonly ICurrentTenant _currentTenant = currentTenant
-        ?? throw new ArgumentNullException(nameof(currentTenant));
-    private readonly IDataFilter? _dataFilter = dataFilter;
-
-    /// <inheritdoc cref="GranitDbContext.CurrentTenantId" />
-    public Guid? CurrentTenantId => _currentTenant.IsAvailable ? _currentTenant.Id : null;
-
-    /// <inheritdoc cref="GranitDbContext.IsMultiTenantFilterEnabled" />
-    public bool IsMultiTenantFilterEnabled => _dataFilter?.IsEnabled<IMultiTenant>() ?? true;
-
     /// <summary>Gets the user groups set.</summary>
     public DbSet<GranitUserGroup> UserGroups => Set<GranitUserGroup>();
 
@@ -61,43 +44,20 @@ internal sealed class OpenIddictDbContext(
     /// <summary>Gets the signing keys set.</summary>
     public DbSet<SigningKey> SigningKeys => Set<SigningKey>();
 
+    /// <summary>
+    /// OpenIddict's null-tenant applications, scopes and tokens are global — visible under every
+    /// tenant scope (the ClientId already carries the tenant, so isolation holds via app + subject).
+    /// </summary>
+    protected override bool TenantFilterTreatsNullAsGlobal => true;
+
     /// <inheritdoc/>
-    protected override void OnModelCreating(ModelBuilder builder)
+    protected override void OnGranitModelCreating(ModelBuilder modelBuilder)
     {
-        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(modelBuilder);
 
-        // 1. ASP.NET Identity conventions (default table names, keys, indexes).
-        base.OnModelCreating(builder);
-
-        // 2. Granit OpenIddict conventions (Identity keys, OpenIddict conventions,
-        //    openiddict_* table prefix, column constraints, manual soft-delete filter)
-        builder.ConfigureOpenIddictModule(_dataFilter, extensionOptions?.Value);
-
-        // 3. Granit cross-cutting conventions WITHOUT the IMultiTenant filter (currentTenant: null).
-        builder.ApplyGranitConventions(currentTenant: null, _dataFilter);
-
-        // 4. Parameterised IMultiTenant filter — inlined here because we cannot inherit
-        //    from GranitDbContext (see remarks on the class).
-        foreach (IMutableEntityType entityType in builder.Model.GetEntityTypes()
-            .Where(et => typeof(IMultiTenant).IsAssignableFrom(et.ClrType)))
-        {
-            ConfigureMultiTenantFilterMethod
-                .MakeGenericMethod(entityType.ClrType)
-                .Invoke(this, [builder]);
-        }
-    }
-
-    private void ConfigureMultiTenantFilter<TEntity>(ModelBuilder builder)
-        where TEntity : class
-    {
-        // null-is-global: a row with TenantId == null belongs to no tenant and is visible
-        // to every tenant (and to anonymous requests). The CurrentTenantId disjunct stays
-        // parameterised (@ef_filter__CurrentTenantId) — see MultiTenantFilterParameterizationReproTests.
-        Expression<Func<TEntity, bool>> filter = e =>
-            !IsMultiTenantFilterEnabled
-            || EF.Property<Guid?>(e, nameof(IMultiTenant.TenantId)) == null
-            || EF.Property<Guid?>(e, nameof(IMultiTenant.TenantId)) == CurrentTenantId;
-        builder.Entity<TEntity>()
-            .HasQueryFilter(GranitFilterNames.MultiTenant, filter);
+        // Self-contained model: Identity + OpenIddict entities, the openiddict_* prefix, column
+        // constraints and the manual LocalIdentity soft-delete filter. The IMultiTenant filter and
+        // ApplyGranitConventions run in GranitDbContext.OnModelCreating after this override.
+        modelBuilder.ConfigureOpenIddictModule(DataFilter, extensionOptions?.Value);
     }
 }

--- a/src/Granit.Persistence.EntityFrameworkCore/GranitDbContext.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/GranitDbContext.cs
@@ -175,6 +175,15 @@ public abstract class GranitDbContext : DbContext
     }
 
     /// <summary>
+    /// When <c>true</c>, a row whose <see cref="IMultiTenant.TenantId"/> is <see langword="null"/> is
+    /// treated as global and stays visible under every tenant scope (and to anonymous requests), in
+    /// addition to the current tenant's own rows. Defaults to <c>false</c> — strict isolation, where a
+    /// tenant sees only its own rows. Override to <c>true</c> in a context whose null-tenant rows are
+    /// deliberately shared (e.g. OpenIddict's global clients and scopes).
+    /// </summary>
+    protected virtual bool TenantFilterTreatsNullAsGlobal => false;
+
+    /// <summary>
     /// Registers the parameterised <see cref="IMultiTenant"/> filter for
     /// <typeparamref name="TEntity"/>. Called via reflection from
     /// <see cref="OnModelCreating"/> so the lambda's <c>this</c> reference is bound to the
@@ -184,9 +193,14 @@ public abstract class GranitDbContext : DbContext
     private void ConfigureMultiTenantFilter<TEntity>(ModelBuilder modelBuilder)
         where TEntity : class
     {
-        Expression<Func<TEntity, bool>> filter = e =>
-            !IsMultiTenantFilterEnabled
-            || EF.Property<Guid?>(e, nameof(IMultiTenant.TenantId)) == CurrentTenantId;
+        // The disjunction is chosen at model-creation time (per derived context type). Both branches
+        // read CurrentTenantId via `this`, so EF Core still parameterises it (@ef_filter__CurrentTenantId).
+        Expression<Func<TEntity, bool>> filter = TenantFilterTreatsNullAsGlobal
+            ? e => !IsMultiTenantFilterEnabled
+                || EF.Property<Guid?>(e, nameof(IMultiTenant.TenantId)) == null
+                || EF.Property<Guid?>(e, nameof(IMultiTenant.TenantId)) == CurrentTenantId
+            : e => !IsMultiTenantFilterEnabled
+                || EF.Property<Guid?>(e, nameof(IMultiTenant.TenantId)) == CurrentTenantId;
 
         modelBuilder.Entity<TEntity>()
             .HasQueryFilter(GranitFilterNames.MultiTenant, filter);

--- a/tests/Granit.ArchitectureTests/IsolatedDbContextTests.cs
+++ b/tests/Granit.ArchitectureTests/IsolatedDbContextTests.cs
@@ -50,7 +50,7 @@ public sealed partial class IsolatedDbContextTests
     /// Every concrete DbContext in <c>*.EntityFrameworkCore</c> or <c>*.Database</c> packages
     /// must either inherit from <c>GranitDbContext</c> (preferred) or carry the inline
     /// <c>ConfigureMultiTenantFilter</c> pattern (forced when single-inheritance already binds
-    /// the type elsewhere — currently only OpenIddictDbContext). Calling the legacy
+    /// the type elsewhere — no context currently needs this). Calling the legacy
     /// <c>modelBuilder.ApplyGranitConventions(currentTenant, ...)</c> with a non-null tenant
     /// re-introduces the "frozen tenant" SQL leak fixed in #2129.
     /// </summary>


### PR DESCRIPTION
## Context

First step of the Phase 3 DbContext decomposition, landed under the byte-identical model guard (#3099 + #3102).

`OpenIddictDbContext` inherited `IdentityDbContext<LocalIdentity, GranitRole, Guid>`. Because the single C# inheritance slot was taken, the parameterised multi-tenant filter had to be **replicated inline by reflection** (with duplicated `CurrentTenantId` / `IsMultiTenantFilterEnabled` overrides). This switches the context to `GranitDbContext`, removing that duplication and preparing the two-context split.

## Changes

- **Self-contained model.** The identity schema — users/roles/claims/logins/tokens/passkeys keys, the `UserNameIndex`/`EmailIndex`/`RoleNameIndex` unique indexes, the 256-length normalized columns, concurrency tokens and the join relationships — is now declared explicitly by `ConfigureOpenIddictModule`, no longer inherited from `IdentityDbContext.OnModelCreating`. **The pinning guard proves the produced schema is byte-identical → zero data migration.**
- **Filter from the base.** The inline reflection `ConfigureMultiTenantFilter` and the tenant-property overrides are deleted; the parameterised filter comes from `GranitDbContext`.
- **null-is-global preserved.** OpenIddict's Phase 2E semantics (a null-tenant client/scope is global, visible under every tenant) survive the switch via a new **additive, default-`false`** hook `GranitDbContext.TenantFilterTreatsNullAsGlobal`, overridden to `true` only here. Strict isolation remains the framework default for every other context.

## Verification

- Model guard **43/43** (byte-identical schema **and** null-is-global filter behaviour)
- `Granit.Persistence.EntityFrameworkCore` **392/392** (the new base hook is additive)
- OpenIddict **Postgres integration 38/39** (1 skipped) — the real runtime proof: the new context builds the schema, seeds, and runs the OIDC flows / registration / sessions / signing keys
- Architecture **262/262 + 19/19** · base OpenIddict **274/274** · bundle builds · format clean

## Breaking

`OpenIddictDbContext` (internal) changes base class; no public API change and no schema change. `GranitDbContext` gains a `protected virtual` member (source-compatible).

Extracting `Granit.Identity.Local.EntityFrameworkCore` (the two-context split + moving the identity stores) follows as the next PR, guarded by the same pinning test against a composed host context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)