### PR TITLE
feat(identity): Cognito health check + normalize provider probe timeouts (Vague 7c)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -29093,7 +29093,7 @@
       "kind": "class",
       "project": "Granit.Identity.Federated.Cognito",
       "file": "src/Granit.Identity.Federated.Cognito/Extensions/IdentityCognitoServiceCollectionExtensions.cs",
-      "line": 20,
+      "line": 22,
       "members": [
         {
           "name": "AddGranitIdentityCognito",
@@ -29329,7 +29329,7 @@
       "kind": "class",
       "project": "Granit.Identity.Federated.EntraId",
       "file": "src/Granit.Identity.Federated.EntraId/Extensions/IdentityEntraIdServiceCollectionExtensions.cs",
-      "line": 20,
+      "line": 19,
       "members": [
         {
           "name": "AddGranitIdentityEntraId",

--- a/src/Granit.Identity.Endpoints/Internal/UserCacheHealthCheck.cs
+++ b/src/Granit.Identity.Endpoints/Internal/UserCacheHealthCheck.cs
@@ -14,19 +14,24 @@ namespace Granit.Identity.Endpoints.Internal;
 /// </remarks>
 internal sealed class UserCacheHealthCheck(IUserCacheStats cacheStats) : IHealthCheck
 {
+    // Bound the store round-trips so a hung cache store fails the probe fast instead of stalling it.
+    private static readonly TimeSpan HealthCheckTimeout = TimeSpan.FromSeconds(10);
+
     public async Task<HealthCheckResult> CheckHealthAsync(
         HealthCheckContext context, CancellationToken cancellationToken = default)
     {
         try
         {
-            int total = await cacheStats.GetCountAsync(cancellationToken).ConfigureAwait(false);
+            int total = await cacheStats.GetCountAsync(cancellationToken)
+                .WaitAsync(HealthCheckTimeout, cancellationToken).ConfigureAwait(false);
 
             if (total == 0)
             {
                 return HealthCheckResult.Healthy("User cache is empty.");
             }
 
-            int stale = await cacheStats.GetStaleCountAsync(cancellationToken).ConfigureAwait(false);
+            int stale = await cacheStats.GetStaleCountAsync(cancellationToken)
+                .WaitAsync(HealthCheckTimeout, cancellationToken).ConfigureAwait(false);
 
             double staleRatio = (double)stale / total;
 
@@ -54,6 +59,10 @@ internal sealed class UserCacheHealthCheck(IUserCacheStats cacheStats) : IHealth
             return HealthCheckResult.Healthy(
                 $"User cache healthy: {total} entries, {stale} stale.",
                 data: data);
+        }
+        catch (TimeoutException)
+        {
+            return HealthCheckResult.Unhealthy("User cache store did not respond within the health-check timeout.");
         }
         catch (Exception ex)
         {

--- a/src/Granit.Identity.Federated.Cognito/Extensions/IdentityCognitoServiceCollectionExtensions.cs
+++ b/src/Granit.Identity.Federated.Cognito/Extensions/IdentityCognitoServiceCollectionExtensions.cs
@@ -3,6 +3,7 @@ using Amazon.CognitoIdentityProvider;
 using Amazon.Runtime;
 using Granit.Diagnostics;
 using Granit.Identity.Extensions;
+using Granit.Identity.Federated.Cognito.HealthChecks;
 using Granit.Identity.Federated.Cognito.Internal;
 using Granit.Identity.Federated.Cognito.Options;
 using Granit.Identity.Federated.Cognito.Sync;
@@ -10,6 +11,7 @@ using Granit.Identity.Federated.Extensions;
 using Granit.Identity.Federated.Sync;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Options;
 
 namespace Granit.Identity.Federated.Cognito.Extensions;
@@ -83,5 +85,29 @@ public static class IdentityCognitoServiceCollectionExtensions
         services.AddTransient<IClientRoleSyncPolicy, CognitoClientRoleSyncPolicy>();
 
         return services;
+    }
+
+    /// <summary>
+    /// Adds an AWS Cognito connectivity health check tagged <c>"readiness"</c> and <c>"startup"</c>.
+    /// Verifies the configured user pool is reachable and the service account can read it.
+    /// </summary>
+    /// <param name="builder">The health checks builder.</param>
+    /// <param name="name">Check name. Defaults to <c>"cognito"</c>.</param>
+    /// <param name="failureStatus">Status on failure. Defaults to <see cref="HealthStatus.Unhealthy"/>.</param>
+    /// <param name="timeout">Check timeout. Defaults to 10 seconds.</param>
+    public static IHealthChecksBuilder AddGranitCognitoHealthCheck(
+        this IHealthChecksBuilder builder,
+        string name = "cognito",
+        HealthStatus? failureStatus = null,
+        TimeSpan? timeout = null)
+    {
+        builder.Services.AddSingleton<CognitoHealthCheck>();
+
+        return builder.Add(new HealthCheckRegistration(
+            name,
+            sp => sp.GetRequiredService<CognitoHealthCheck>(),
+            failureStatus,
+            ["readiness", "startup"],
+            timeout ?? TimeSpan.FromSeconds(10)));
     }
 }

--- a/src/Granit.Identity.Federated.Cognito/HealthChecks/CognitoHealthCheck.cs
+++ b/src/Granit.Identity.Federated.Cognito/HealthChecks/CognitoHealthCheck.cs
@@ -1,0 +1,66 @@
+using Amazon.CognitoIdentityProvider;
+using Amazon.CognitoIdentityProvider.Model;
+using Amazon.Runtime;
+using Granit.Identity.Federated.Cognito.Options;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Options;
+
+namespace Granit.Identity.Federated.Cognito.HealthChecks;
+
+/// <summary>
+/// Health check that verifies AWS Cognito connectivity by issuing a minimal
+/// <c>ListUsers</c> (limit 1) against the configured user pool — the same permission the
+/// provider itself needs, so a green check means the service account can actually read.
+/// </summary>
+/// <remarks>
+/// <list type="bullet">
+///   <item>Pool reachable and readable → <see cref="HealthCheckResult.Healthy"/></item>
+///   <item>Credentials rejected (<c>NotAuthorized</c>) or pool missing → <see cref="HealthCheckResult.Unhealthy"/></item>
+///   <item>Other AWS service error → <see cref="HealthCheckResult.Degraded"/></item>
+///   <item>Unreachable or timeout → <see cref="HealthCheckResult.Unhealthy"/></item>
+/// </list>
+/// The response never exposes credentials, user data, or the pool id.
+/// </remarks>
+internal sealed class CognitoHealthCheck(
+    IAmazonCognitoIdentityProvider cognitoClient,
+    IOptions<CognitoAdminOptions> options) : IHealthCheck
+{
+    private static readonly TimeSpan HealthCheckTimeout = TimeSpan.FromSeconds(10);
+
+    public async Task<HealthCheckResult> CheckHealthAsync(
+        HealthCheckContext context, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            _ = await cognitoClient
+                .ListUsersAsync(
+                    new ListUsersRequest { UserPoolId = options.Value.UserPoolId, Limit = 1 },
+                    cancellationToken)
+                .WaitAsync(HealthCheckTimeout, cancellationToken)
+                .ConfigureAwait(false);
+
+            return HealthCheckResult.Healthy("AWS Cognito user pool is reachable.");
+        }
+        catch (NotAuthorizedException)
+        {
+            return HealthCheckResult.Unhealthy("AWS Cognito rejected the service-account credentials.");
+        }
+        catch (ResourceNotFoundException)
+        {
+            return HealthCheckResult.Unhealthy("AWS Cognito user pool was not found.");
+        }
+        catch (TimeoutException)
+        {
+            return HealthCheckResult.Unhealthy("AWS Cognito did not respond within the health-check timeout.");
+        }
+        catch (AmazonServiceException ex)
+        {
+            // Sanitize: never expose the underlying message.
+            return HealthCheckResult.Degraded($"AWS Cognito returned a service error: {ex.GetType().Name}");
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            return HealthCheckResult.Unhealthy($"AWS Cognito is unreachable: {ex.GetType().Name}");
+        }
+    }
+}

--- a/src/Granit.Identity.Federated.EntraId/Extensions/IdentityEntraIdServiceCollectionExtensions.cs
+++ b/src/Granit.Identity.Federated.EntraId/Extensions/IdentityEntraIdServiceCollectionExtensions.cs
@@ -10,7 +10,6 @@ using Granit.Identity.Federated.Sync;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
-using Microsoft.Extensions.Options;
 
 namespace Granit.Identity.Federated.EntraId.Extensions;
 
@@ -103,13 +102,16 @@ public static class IdentityEntraIdServiceCollectionExtensions
         this IHealthChecksBuilder builder,
         string name = "entraid",
         HealthStatus? failureStatus = null,
-        TimeSpan? timeout = null) =>
-        builder.Add(new HealthCheckRegistration(
+        TimeSpan? timeout = null)
+    {
+        // Singleton + a default 10s registration timeout, mirroring AddGranitKeycloakHealthCheck.
+        builder.Services.AddSingleton<EntraIdHealthCheck>();
+
+        return builder.Add(new HealthCheckRegistration(
             name,
-            sp => new EntraIdHealthCheck(
-                sp.GetRequiredService<IHttpClientFactory>(),
-                sp.GetRequiredService<IOptions<EntraIdAdminOptions>>()),
+            sp => sp.GetRequiredService<EntraIdHealthCheck>(),
             failureStatus,
             ["readiness", "startup"],
-            timeout));
+            timeout ?? TimeSpan.FromSeconds(10)));
+    }
 }

--- a/tests/Granit.Identity.Federated.Cognito.Tests/CognitoHealthCheckTests.cs
+++ b/tests/Granit.Identity.Federated.Cognito.Tests/CognitoHealthCheckTests.cs
@@ -1,0 +1,58 @@
+using Amazon.CognitoIdentityProvider;
+using Amazon.CognitoIdentityProvider.Model;
+using Granit.Identity.Federated.Cognito.HealthChecks;
+using Granit.Identity.Federated.Cognito.Options;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Identity.Federated.Cognito.Tests;
+
+public sealed class CognitoHealthCheckTests
+{
+    private static CognitoHealthCheck Build(IAmazonCognitoIdentityProvider client) =>
+        new(client, Microsoft.Extensions.Options.Options.Create(new CognitoAdminOptions { Region = "eu-west-1", UserPoolId = "eu-west-1_TEST" }));
+
+    [Fact]
+    public async Task PoolReachable_ReturnsHealthy()
+    {
+        IAmazonCognitoIdentityProvider client = Substitute.For<IAmazonCognitoIdentityProvider>();
+        client.ListUsersAsync(Arg.Any<ListUsersRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new ListUsersResponse());
+
+        HealthCheckResult result = await Build(client).CheckHealthAsync(
+            new HealthCheckContext(), TestContext.Current.CancellationToken);
+
+        result.Status.ShouldBe(HealthStatus.Healthy);
+    }
+
+    [Fact]
+    public async Task CredentialsRejected_ReturnsUnhealthy()
+    {
+        IAmazonCognitoIdentityProvider client = Substitute.For<IAmazonCognitoIdentityProvider>();
+        client.ListUsersAsync(Arg.Any<ListUsersRequest>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new NotAuthorizedException("denied"));
+
+        HealthCheckResult result = await Build(client).CheckHealthAsync(
+            new HealthCheckContext(), TestContext.Current.CancellationToken);
+
+        result.Status.ShouldBe(HealthStatus.Unhealthy);
+        result.Description!.ShouldNotContain("denied");
+    }
+
+    [Fact]
+    public async Task UnexpectedError_DoesNotLeakMessage()
+    {
+        IAmazonCognitoIdentityProvider client = Substitute.For<IAmazonCognitoIdentityProvider>();
+        client.ListUsersAsync(Arg.Any<ListUsersRequest>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException("connection string secret=abc"));
+
+        HealthCheckResult result = await Build(client).CheckHealthAsync(
+            new HealthCheckContext(), TestContext.Current.CancellationToken);
+
+        result.Status.ShouldBe(HealthStatus.Unhealthy);
+        result.Description!.ShouldNotContain("secret=abc");
+    }
+}


### PR DESCRIPTION
## Vague 7c — provider health checks (part of FEATURE #3065)

Brings the federated provider health checks to parity and bounds them so a hung dependency fails
the probe fast.

- **New `CognitoHealthCheck`** (Cognito had none): verifies the user pool via a minimal
  `ListUsers(limit 1)` — the same permission the provider itself uses, so green means the service
  account can actually read — with a 10s timeout. `NotAuthorized` / `ResourceNotFound` → Unhealthy,
  other AWS service error → Degraded; the response never leaks credentials or the underlying message.
  Registered by `AddGranitCognitoHealthCheck` (tags `readiness`/`startup`, default 10s), mirroring
  `AddGranitKeycloakHealthCheck`.
- **EntraId health check**: register as a **singleton** with a default 10s registration timeout,
  matching Keycloak (was a per-resolution factory with no registration timeout). The 10s request
  timeout was already enforced by `HttpServiceHealthCheckBase`; this adds the missing singleton +
  registration-level bound.
- **`UserCacheHealthCheck`**: wrap the store round-trips in a **10s `WaitAsync`** so a hung cache
  store fails the probe fast instead of stalling it; a timeout maps to Unhealthy.

### Verification

- New `CognitoHealthCheckTests` (healthy / credentials-rejected / no-message-leak).
- Cognito 65/65, EntraId 134/134, Identity.Endpoints 192/192, architecture 262/262, `dotnet format` clean.

Refs #3065

🤖 Generated with [Claude Code](https://claude.com/claude-code)