### PR TITLE
fix(identity)!: private TenantId setter on User + close aggregate-root public-setter blind spot (Vague 8a)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -28310,12 +28310,6 @@
           "returnType": "string?"
         },
         {
-          "name": "TenantId",
-          "kind": "property",
-          "signature": "Guid? TenantId",
-          "returnType": "Guid?"
-        },
-        {
           "name": "Create",
           "kind": "method",
           "signature": "Create(Guid id, string email, string displayName, string? firstName = null, string? lastName = null, string? phoneNumber = null, Guid? tenantId = null)",

--- a/src/Granit.Identity/Domain/User.cs
+++ b/src/Granit.Identity/Domain/User.cs
@@ -98,7 +98,19 @@ public sealed class User : AuditedAggregateRoot, IIdentityUser, IMultiTenant
     public bool IsEnabled { get; private set; } = true;
 
     /// <summary>Tenant identifier, or <see langword="null"/> for cross-tenant / host-side users.</summary>
-    public Guid? TenantId { get; set; }
+    public Guid? TenantId { get; private set; }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Explicit implementation preserves the <c>private set</c> DDD encapsulation on the public
+    /// property while satisfying the interface contract. Used by <c>AuditedEntityInterceptor</c>
+    /// to inject the tenant identifier.
+    /// </remarks>
+    Guid? IMultiTenant.TenantId
+    {
+        get => TenantId;
+        set => TenantId = value;
+    }
 
     /// <inheritdoc cref="IIdentityUser.Username"/>
     string? IIdentityUser.Username => Email;

--- a/tests/Granit.ArchitectureTests.Abstractions/ArchitectureLoader.cs
+++ b/tests/Granit.ArchitectureTests.Abstractions/ArchitectureLoader.cs
@@ -49,6 +49,39 @@ public static class ArchitectureLoader
     }
 
     /// <summary>
+    /// Returns the framework assemblies (matching <paramref name="assemblyPrefix"/>, excluding test /
+    /// analyzer / source-generator dlls) from the caller's output directory. Use for reflection-based
+    /// conventions that need real <see cref="System.Type"/> metadata beyond what ArchUnitNET surfaces.
+    /// </summary>
+    public static IReadOnlyList<Assembly> LoadAssemblies(
+        string assemblyPrefix,
+        Assembly callerAssembly,
+        params string[] additionalExclusions)
+    {
+        ArgumentNullException.ThrowIfNull(assemblyPrefix);
+        ArgumentNullException.ThrowIfNull(callerAssembly);
+
+        string outputDir = Path.GetDirectoryName(callerAssembly.Location)!;
+
+        return Directory.GetFiles(outputDir, $"{assemblyPrefix}*.dll")
+            .Where(path =>
+            {
+                string name = Path.GetFileNameWithoutExtension(path);
+                return !name.Contains("Tests", StringComparison.Ordinal)
+                    && !name.Contains("Analyzers", StringComparison.Ordinal)
+                    && !name.Contains("SourceGenerator", StringComparison.Ordinal)
+                    && !additionalExclusions.Any(ex => name.Contains(ex, StringComparison.Ordinal));
+            })
+            .Select(path =>
+            {
+                try { return Assembly.LoadFrom(path); }
+                catch { return null; }
+            })
+            .Where(a => a is not null)
+            .ToList()!;
+    }
+
+    /// <summary>
     /// Loads assemblies matching multiple prefixes into a single architecture graph.
     /// </summary>
     public static ArchUnitNET.Domain.Architecture Load(

--- a/tests/Granit.ArchitectureTests.Abstractions/Rules/DomainConventionRules.cs
+++ b/tests/Granit.ArchitectureTests.Abstractions/Rules/DomainConventionRules.cs
@@ -1,3 +1,4 @@
+
 using ArchUnitNET.Domain;
 using Shouldly;
 
@@ -286,4 +287,73 @@ public static class DomainConventionRules
             d is ArchUnitNET.Domain.Dependencies.InheritsBaseClassDependency
             && (d.Target.FullName == baseFullName
                 || (d.Target is Class baseClass && HasBaseClass(baseClass, baseFullName))));
+
+    private static readonly string[] s_aggregateRootBaseNames =
+    [
+        "AggregateRoot", "CreationAuditedAggregateRoot", "AuditedAggregateRoot", "FullAuditedAggregateRoot",
+    ];
+
+    /// <summary>
+    /// Reflection-based complement to <see cref="AggregateRootsShouldNotHavePublicSetters"/>: returns
+    /// every aggregate-root property that exposes a <b>public</b> setter. The ArchUnitNET rule
+    /// under-reports a public setter that <em>implicitly</em> implements an interface member (e.g. an
+    /// <c>IMultiTenant.TenantId</c> auto-property declared <c>public Guid? TenantId { get; set; }</c>);
+    /// reading the real accessor via reflection closes that blind spot. A <c>private set</c> plus an
+    /// explicit interface implementation is the correct, non-violating shape.
+    /// </summary>
+    public static IReadOnlyList<string> FindAggregateRootsWithPublicPropertySetters(
+        IEnumerable<System.Reflection.Assembly> assemblies, string typePrefix)
+    {
+        List<string> violations = [];
+
+        foreach (System.Reflection.Assembly assembly in assemblies)
+        {
+            foreach (Type type in SafeGetTypes(assembly))
+            {
+                if (type.IsAbstract
+                    || !(type.FullName ?? string.Empty).StartsWith(typePrefix, StringComparison.Ordinal)
+                    || !InheritsAggregateRootBase(type))
+                {
+                    continue;
+                }
+
+                foreach (System.Reflection.PropertyInfo property in type.GetProperties(
+                    System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.DeclaredOnly))
+                {
+                    if (property.GetSetMethod(nonPublic: false) is { IsPublic: true })
+                    {
+                        violations.Add($"{type.Name}.{property.Name}");
+                    }
+                }
+            }
+        }
+
+        return violations;
+    }
+
+    private static IEnumerable<Type> SafeGetTypes(System.Reflection.Assembly assembly)
+    {
+        try
+        {
+            return assembly.GetTypes();
+        }
+        catch (System.Reflection.ReflectionTypeLoadException ex)
+        {
+            return ex.Types.Where(t => t is not null)!;
+        }
+    }
+
+    private static bool InheritsAggregateRootBase(Type type)
+    {
+        for (Type? baseType = type.BaseType; baseType is not null; baseType = baseType.BaseType)
+        {
+            if (baseType.Namespace == "Granit.Domain"
+                && s_aggregateRootBaseNames.Contains(baseType.Name, StringComparer.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
 }

--- a/tests/Granit.ArchitectureTests/DomainConventionTests.cs
+++ b/tests/Granit.ArchitectureTests/DomainConventionTests.cs
@@ -24,6 +24,28 @@ public sealed class DomainConventionTests
     public void Aggregate_roots_should_not_have_public_setters() =>
         DomainConventionRules.AggregateRootsShouldNotHavePublicSetters(Architecture, "Granit.");
 
+    /// <summary>
+    /// Reflection complement to <see cref="Aggregate_roots_should_not_have_public_setters"/>: the
+    /// ArchUnitNET rule misses a public setter that implicitly implements an interface member (e.g.
+    /// an <c>IMultiTenant.TenantId</c> auto-property). Use <c>private set</c> + an explicit interface
+    /// implementation instead.
+    /// </summary>
+    [Fact]
+    public void Aggregate_roots_must_not_expose_public_property_setters()
+    {
+        IReadOnlyList<System.Reflection.Assembly> assemblies =
+            Granit.ArchitectureTests.Abstractions.ArchitectureLoader.LoadAssemblies(
+                "Granit.", typeof(DomainConventionTests).Assembly);
+
+        IReadOnlyList<string> violations =
+            DomainConventionRules.FindAggregateRootsWithPublicPropertySetters(assemblies, "Granit.");
+
+        violations.ShouldBeEmpty(
+            "Aggregate root properties must use private setters; expose IMultiTenant.TenantId (and "
+            + "similar interface members) via an explicit interface implementation over a private "
+            + $"setter. Violators: {string.Join(", ", violations)}");
+    }
+
     [Fact]
     public void Aggregate_roots_should_have_factory_method() =>
         DomainConventionRules.AggregateRootsShouldHaveFactoryMethod(Architecture, "Granit.");


### PR DESCRIPTION
## Vague 8a — User.TenantId encapsulation + archi-test blind spot (part of FEATURE #3066)

`User` (an `AuditedAggregateRoot`) exposed `public Guid? TenantId { get; set; }` — a **public
setter on an aggregate root**. That lets any caller reassign a user's tenant (a **cross-tenant
isolation hazard**) and breaks DDD encapsulation; every other `User` property already uses a
private setter.

### Fix

`public Guid? TenantId { get; private set; }` plus an explicit `Guid? IMultiTenant.TenantId`
implementation so `AuditedEntityInterceptor` still stamps the tenant — the same shape as
`BlobDescriptor` / `ApiKeyEntry` / `PromptCategory`.

### Blind spot closed

The existing ArchUnitNET rule `Aggregate_roots_should_not_have_public_setters` **missed** this: it
under-reports a public setter that *implicitly* implements an interface member (the
`IMultiTenant.TenantId` auto-property). Add a **reflection-based complement**
(`FindAggregateRootsWithPublicPropertySetters` + `ArchitectureLoader.LoadAssemblies`) that reads the
real public accessor via `PropertyInfo.GetSetMethod(nonPublic: false)`. Verified **red→green** (it
reports `User.TenantId` when the setter is public, passes once private), and it finds **no other
violations** across the framework.

### Breaking

`!` — the public `User.TenantId` setter is removed. Tenant assignment now goes through the factory /
interceptor, never direct property mutation (which was the isolation hazard).

### Verification

Granit.Identity 147/147, architecture **263/263** (incl. the new guard), `dotnet format` clean.

Refs #3066

🤖 Generated with [Claude Code](https://claude.com/claude-code)