### PR TITLE
fix(openiddict): set Cache-Control no-store on the userinfo response (Phase 4)

### DIFF
--- a/src/Granit.OpenIddict.Endpoints/Endpoints/ConnectUserInfoEndpoints.cs
+++ b/src/Granit.OpenIddict.Endpoints/Endpoints/ConnectUserInfoEndpoints.cs
@@ -32,6 +32,10 @@ internal static class ConnectUserInfoEndpoints
 
     private static async Task<IResult> HandleUserInfoAsync(HttpContext context)
     {
+        // userinfo returns PII (name, email, phone, roles). It must never be cached by a browser or an
+        // intermediary proxy — set no-store before any response is produced (OIDC Core §5.3.4).
+        context.Response.Headers.CacheControl = "no-store";
+
         // OpenIddict has already validated the access token via the middleware.
         AuthenticateResult authenticateResult = await context.AuthenticateAsync(
             OpenIddictServerAspNetCoreDefaults.AuthenticationScheme).ConfigureAwait(false);


### PR DESCRIPTION
## Problem

`GET /connect/userinfo` returns PII — name, email, phone number, roles — as JSON, but the handler set **no `Cache-Control` header**. A browser or an intermediary proxy is therefore free to cache the response and later serve one user's claims (to the same or, behind a shared cache, a different client).

## Fix

Set `Cache-Control: no-store` at the top of the handler, before any response is produced, so every userinfo response (success or challenge) is uncacheable — per OIDC Core §5.3.4 ("The UserInfo Endpoint ... SHOULD ... `Cache-Control: no-store`").

One line, no new dependency. `Granit.OpenIddict.Endpoints.Tests` 132/132, format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)