### PR TITLE
fix(openiddict): bind the endpoint options from configuration (Phase 4)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -43252,7 +43252,7 @@
       "kind": "class",
       "project": "Granit.OpenIddict.Endpoints",
       "file": "src/Granit.OpenIddict.Endpoints/Extensions/OpenIddictEndpointRouteBuilderExtensions.cs",
-      "line": 13,
+      "line": 15,
       "members": [
         {
           "name": "MapGranitOpenIddict",
@@ -43268,7 +43268,7 @@
       "kind": "class",
       "project": "Granit.OpenIddict.Endpoints",
       "file": "src/Granit.OpenIddict.Endpoints/GranitOpenIddictEndpointsModule.cs",
-      "line": 39,
+      "line": 41,
       "members": [
         {
           "name": "ConfigureServices",

--- a/src/Granit.OpenIddict.Endpoints/Extensions/OpenIddictEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.OpenIddict.Endpoints/Extensions/OpenIddictEndpointRouteBuilderExtensions.cs
@@ -4,6 +4,8 @@ using Granit.Validation.AspNetCore;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 
 namespace Granit.OpenIddict.Endpoints.Extensions;
 
@@ -29,7 +31,10 @@ public static class OpenIddictEndpointRouteBuilderExtensions
         this IEndpointRouteBuilder endpoints,
         Action<OpenIddictEndpointsOptions>? configure = null)
     {
-        OpenIddictEndpointsOptions options = new();
+        // Seed from configuration (bound in GranitOpenIddictEndpointsModule), then apply any
+        // imperative override so a host can use appsettings, the delegate, or both.
+        OpenIddictEndpointsOptions options =
+            endpoints.ServiceProvider.GetService<IOptions<OpenIddictEndpointsOptions>>()?.Value ?? new();
         configure?.Invoke(options);
 
         // ──── Admin OIDC management (/api/admin) ────
@@ -73,7 +78,8 @@ public static class OpenIddictEndpointRouteBuilderExtensions
         this IEndpointRouteBuilder endpoints,
         Action<OpenIddictServerEndpointsOptions>? configure = null)
     {
-        OpenIddictServerEndpointsOptions options = new();
+        OpenIddictServerEndpointsOptions options =
+            endpoints.ServiceProvider.GetService<IOptions<OpenIddictServerEndpointsOptions>>()?.Value ?? new();
         configure?.Invoke(options);
 
         endpoints.MapConnectAuthorizationEndpoints(options);

--- a/src/Granit.OpenIddict.Endpoints/GranitOpenIddictEndpointsModule.cs
+++ b/src/Granit.OpenIddict.Endpoints/GranitOpenIddictEndpointsModule.cs
@@ -5,12 +5,14 @@ using Granit.Http.ApiDocumentation;
 using Granit.Localization.Extensions;
 using Granit.Modularity;
 using Granit.OpenIddict.Endpoints.Internal;
+using Granit.OpenIddict.Endpoints.Options;
 using Granit.OpenIddict.Endpoints.Workspaces;
 using Granit.OpenIddict.Server;
 using Granit.QueryEngine;
 using Granit.Validation;
 using Granit.Workspaces;
 using Granit.Workspaces.Extensions;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Granit.OpenIddict.Endpoints;
 
@@ -43,5 +45,16 @@ public sealed class GranitOpenIddictEndpointsModule : GranitModule
     {
         context.Services.AddLocalizationResource<OpenIddictEndpointsLocalizationResource>();
         context.Services.AddFeatureProvider<OpenIddictFeatureProvider>();
+
+        // Bind the endpoint options from configuration so appsettings keys are honoured at request
+        // time. The MapGranitOpenIddict* delegates seed from these before applying any imperative
+        // overrides; ValidateOnStart surfaces a bad section at boot.
+        context.Services.AddOptions<OpenIddictEndpointsOptions>()
+            .BindConfiguration(OpenIddictEndpointsOptions.SectionName)
+            .ValidateOnStart();
+
+        context.Services.AddOptions<OpenIddictServerEndpointsOptions>()
+            .BindConfiguration(OpenIddictServerEndpointsOptions.SectionName)
+            .ValidateOnStart();
     }
 }


### PR DESCRIPTION
## Problem

`OpenIddictEndpointsOptions` and `OpenIddictServerEndpointsOptions` were only settable through the imperative `MapGranitOpenIddict*(configure)` delegate. **Nothing bound them to configuration**, so:

- `appsettings` keys (`OpenIddict:Endpoints:*`, `OpenIddict:Server:Endpoints:*`) were silently ignored.
- The request-time `IOptions<T>` consumers (`AdminOidcEndpoints`, `ConnectLogoutEndpoints`, `ConnectAuthorizationEndpoints`) always read unconfigured defaults, regardless of what the map-time delegate set.

## Fix

- Bind both option sets in `GranitOpenIddictEndpointsModule` via `BindConfiguration(SectionName).ValidateOnStart()`.
- Have the two `Map*` extensions **seed** their options from the bound `IOptions<T>` before applying the imperative override.

A host can now configure via appsettings, the delegate, or both — and map-time and request-time see the same values. Backward compatible: with no configuration the defaults are unchanged.

`Granit.OpenIddict.Endpoints.Tests` 132/132 (the minimal test host loads no module, so it keeps defaults — confirming the compatibility path), format clean. A dedicated config-binding integration test would need a separate configured host running `MapGranitGroup`'s full validation stack, disproportionate to a straightforward binding; the behaviour follows directly from `BindConfiguration` + seeding from `IOptions`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)