### PR TITLE
refactor(openiddict): drop unused Granit.Caching/Granit.Encryption deps (Phase 4)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -2169,7 +2169,6 @@
     {
       "name": "Granit.OpenIddict",
       "deps": [
-        "Granit.Caching",
         "Granit.DataExchange.Abstractions",
         "Granit.Encryption",
         "Granit.Entities.Abstractions",
@@ -2204,7 +2203,6 @@
       "deps": [
         "Granit.Auditing",
         "Granit.Authorization",
-        "Granit.Caching",
         "Granit.Http.Idempotency.Abstractions",
         "Granit.Http.ApiDocumentation",
         "Granit.OpenIddict",
@@ -2219,7 +2217,6 @@
       "name": "Granit.OpenIddict.EntityFrameworkCore",
       "deps": [
         "Granit.DataExchange",
-        "Granit.Encryption",
         "Granit.Identity.Local",
         "Granit.Identity.Local.EntityFrameworkCore",
         "Granit.MultiTenancy",
@@ -43268,7 +43265,7 @@
       "kind": "class",
       "project": "Granit.OpenIddict.Endpoints",
       "file": "src/Granit.OpenIddict.Endpoints/GranitOpenIddictEndpointsModule.cs",
-      "line": 41,
+      "line": 39,
       "members": [
         {
           "name": "ConfigureServices",
@@ -43489,7 +43486,7 @@
       "kind": "class",
       "project": "Granit.OpenIddict.EntityFrameworkCore",
       "file": "src/Granit.OpenIddict.EntityFrameworkCore/GranitOpenIddictEntityFrameworkCoreModule.cs",
-      "line": 32,
+      "line": 30,
       "members": [
         {
           "name": "ConfigureServices",
@@ -43610,7 +43607,7 @@
       "kind": "class",
       "project": "Granit.OpenIddict",
       "file": "src/Granit.OpenIddict/GranitOpenIddictModule.cs",
-      "line": 49,
+      "line": 47,
       "members": [
         {
           "name": "ConfigureServices",

--- a/src/Granit.OpenIddict.Endpoints/Granit.OpenIddict.Endpoints.csproj
+++ b/src/Granit.OpenIddict.Endpoints/Granit.OpenIddict.Endpoints.csproj
@@ -18,7 +18,6 @@
   <ItemGroup>
     <ProjectReference Include="..\Granit.Auditing\Granit.Auditing.csproj" />
     <ProjectReference Include="..\Granit.Authorization\Granit.Authorization.csproj" />
-    <ProjectReference Include="..\Granit.Caching\Granit.Caching.csproj" />
     <ProjectReference Include="..\Granit.Http.Idempotency.Abstractions\Granit.Http.Idempotency.Abstractions.csproj" />
     <ProjectReference Include="..\Granit.Http.ApiDocumentation\Granit.Http.ApiDocumentation.csproj" />
     <ProjectReference Include="..\Granit.OpenIddict\Granit.OpenIddict.csproj" />

--- a/src/Granit.OpenIddict.Endpoints/GranitOpenIddictEndpointsModule.cs
+++ b/src/Granit.OpenIddict.Endpoints/GranitOpenIddictEndpointsModule.cs
@@ -1,6 +1,5 @@
 using Granit.Auditing;
 using Granit.Authorization;
-using Granit.Caching;
 using Granit.Http.ApiDocumentation;
 using Granit.Localization.Extensions;
 using Granit.Modularity;
@@ -31,7 +30,6 @@ namespace Granit.OpenIddict.Endpoints;
 [DependsOn(
     typeof(GranitAuditingModule),
     typeof(GranitAuthorizationModule),
-    typeof(GranitCachingModule),
     typeof(GranitHttpApiDocumentationModule),
     typeof(GranitOpenIddictModule),
     typeof(GranitOpenIddictServerModule),

--- a/src/Granit.OpenIddict.EntityFrameworkCore/Granit.OpenIddict.EntityFrameworkCore.csproj
+++ b/src/Granit.OpenIddict.EntityFrameworkCore/Granit.OpenIddict.EntityFrameworkCore.csproj
@@ -27,7 +27,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Granit.DataExchange\Granit.DataExchange.csproj" />
-    <ProjectReference Include="..\Granit.Encryption\Granit.Encryption.csproj" />
     <ProjectReference Include="..\Granit.Identity.Local\Granit.Identity.Local.csproj" />
     <ProjectReference Include="..\Granit.Identity.Local.EntityFrameworkCore\Granit.Identity.Local.EntityFrameworkCore.csproj" />
     <ProjectReference Include="..\Granit.MultiTenancy\Granit.MultiTenancy.csproj" />

--- a/src/Granit.OpenIddict.EntityFrameworkCore/GranitOpenIddictEntityFrameworkCoreModule.cs
+++ b/src/Granit.OpenIddict.EntityFrameworkCore/GranitOpenIddictEntityFrameworkCoreModule.cs
@@ -1,5 +1,4 @@
 using Granit.DataExchange;
-using Granit.Encryption;
 using Granit.Identity.Local;
 using Granit.Identity.Local.EntityFrameworkCore;
 using Granit.Modularity;
@@ -23,7 +22,6 @@ namespace Granit.OpenIddict.EntityFrameworkCore;
 /// </remarks>
 [DependsOn(
     typeof(GranitDataExchangeModule),
-    typeof(GranitEncryptionModule),
     typeof(GranitIdentityLocalEntityFrameworkCoreModule),
     typeof(GranitIdentityLocalModule),
     typeof(GranitMultiTenancyModule),

--- a/src/Granit.OpenIddict/Granit.OpenIddict.csproj
+++ b/src/Granit.OpenIddict/Granit.OpenIddict.csproj
@@ -21,7 +21,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Granit.Caching\Granit.Caching.csproj" />
     <ProjectReference Include="..\Granit.DataExchange.Abstractions\Granit.DataExchange.Abstractions.csproj" />
     <ProjectReference Include="..\Granit.Encryption\Granit.Encryption.csproj" />
     <ProjectReference Include="..\Granit.Entities.Abstractions\Granit.Entities.Abstractions.csproj" />

--- a/src/Granit.OpenIddict/GranitOpenIddictModule.cs
+++ b/src/Granit.OpenIddict/GranitOpenIddictModule.cs
@@ -1,4 +1,3 @@
-using Granit.Caching;
 using Granit.DataExchange;
 using Granit.DataExchange.Extensions;
 using Granit.Diagnostics;
@@ -36,7 +35,6 @@ namespace Granit.OpenIddict;
 /// and Identity cookie configuration (neutral names, env-aware __Host- prefix).
 /// </summary>
 [DependsOn(
-    typeof(GranitCachingModule),
     typeof(GranitDataExchangeAbstractionsModule),
     typeof(GranitEncryptionModule),
     typeof(GranitEntitiesAbstractionsModule),


### PR DESCRIPTION
## What

Prune three **dead direct dependencies** on the `Granit.OpenIddict*` family, flagged as dead surface in the refonte audit (Phase 4 — hygiene):

| Package | Removed dep | Why it was dead |
| --- | --- | --- |
| `Granit.OpenIddict` (base) | `Granit.Caching` | Only a stray `using` + `[DependsOn]`; no cache type (`IFusionCache`, `IDistributedCache`, …) is consumed anywhere in the package. |
| `Granit.OpenIddict.Endpoints` | `Granit.Caching` | Same — unused `using` + `[DependsOn]`. |
| `Granit.OpenIddict.EntityFrameworkCore` | `Granit.Encryption` | The module never encrypts. Signing-key private material is already encrypted **upstream** in the base `KeyRotationService`; `EfSigningKeyStore` only persists the resulting ciphertext. |

`Granit.Encryption` is **kept** in the base module — it is genuinely used (`KeyRotationService.Encrypt(...)`).

## Not breaking

Both packages remain **transitively reachable** — `Granit.Caching` via `Granit.Auditing`/`Granit.Authorization`, `Granit.Encryption` via the base `Granit.OpenIddict`. The resolved dependency graph is therefore unchanged: **every `packages.lock.json` is byte-identical** and CI locked-mode restore passes untouched (verified). No host loses transitive module bootstrapping.

## Verification

- Locked-mode restore (CI parity) on `security` shard: pass, 0 lockfile changes.
- `security` shard: build clean (0 warnings), **10/10 test projects green**.
- `dotnet format --verify-no-changes` clean on all three changed projects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)