### PR TITLE
fix(ci): align codeql-action steps to v4.37.3

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -63,7 +63,7 @@ jobs:
           ram: 13000
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4
+        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
         with:
           threads: 0
           ram: 13000

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -43,6 +43,6 @@ jobs:
           retention-days: 5
 
       - name: Upload to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@7188fc363630916deb702c7fdcf4e481b751f97a # v4
+        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## Problem

The CodeQL analyze post-action fails on `develop`:

```
analyze post-action step failed: Loaded a configuration file for version '4.37.3', but running version '4.37.1'
```

The `codeql-action` steps had drifted to two different versions after a partial dependabot bump:

| Step | File | Was | Version |
|------|------|-----|---------|
| `init` | `codeql.yml` | `e4fba868` | v4.37.3 |
| `analyze` | `codeql.yml` | `7188fc36` | v4.37.1 |
| `upload-sarif` | `scorecard.yml` | `7188fc36` | v4.37.1 |

`init` writes a 4.37.3 config that the 4.37.1 `analyze` post-action refuses to load.

## Fix

Pin `analyze` and scorecard's `upload-sarif` to `e4fba868…` (v4.37.3, the latest release) so every `codeql-action` step runs the same version. No behavioural change beyond version alignment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)