### PR TITLE
feat(openiddict): readiness health check for signing keys + DbContext (Phase 4)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -43449,6 +43449,22 @@
       ]
     },
     {
+      "name": "OpenIddictHealthChecksBuilderExtensions",
+      "fqn": "Granit.OpenIddict.EntityFrameworkCore.Extensions.OpenIddictHealthChecksBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.OpenIddict.EntityFrameworkCore",
+      "file": "src/Granit.OpenIddict.EntityFrameworkCore/Extensions/OpenIddictHealthChecksBuilderExtensions.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "AddGranitOpenIddictHealthCheck",
+          "kind": "method",
+          "signature": "AddGranitOpenIddictHealthCheck(this IHealthChecksBuilder builder, string name = \"openiddict-signing-keys\", HealthStatus? failureStatus = null, TimeSpan? timeout = null)",
+          "returnType": "IHealthChecksBuilder"
+        }
+      ]
+    },
+    {
       "name": "OpenIddictModelBuilderExtensions",
       "fqn": "Granit.OpenIddict.EntityFrameworkCore.Extensions.OpenIddictModelBuilderExtensions",
       "kind": "class",

--- a/src/Granit.OpenIddict.EntityFrameworkCore/Extensions/OpenIddictHealthChecksBuilderExtensions.cs
+++ b/src/Granit.OpenIddict.EntityFrameworkCore/Extensions/OpenIddictHealthChecksBuilderExtensions.cs
@@ -1,0 +1,43 @@
+using Granit.OpenIddict.EntityFrameworkCore.HealthChecks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace Granit.OpenIddict.EntityFrameworkCore.Extensions;
+
+/// <summary>
+/// Health-check registration extensions for OpenIddict EF Core persistence.
+/// </summary>
+public static class OpenIddictHealthChecksBuilderExtensions
+{
+    /// <summary>
+    /// Adds a readiness health check for the OpenIddict signing-key store and its
+    /// <see cref="Internal.OpenIddictDbContext"/>, tagged <c>"readiness"</c> and <c>"startup"</c>.
+    /// </summary>
+    /// <remarks>
+    /// Uncached — consistent with the framework's own <c>AddGranitDbContextHealthCheck</c>; the
+    /// check runs a single lightweight <c>EXISTS</c> query. The check opens a scope per probe, so it
+    /// is registered as a singleton without capturing the scoped DbContext factory.
+    /// </remarks>
+    /// <param name="builder">The health checks builder.</param>
+    /// <param name="name">Check name. Defaults to <c>"openiddict-signing-keys"</c>.</param>
+    /// <param name="failureStatus">Status on failure. Defaults to <see cref="HealthStatus.Unhealthy"/>.</param>
+    /// <param name="timeout">Check timeout. Defaults to 10 seconds.</param>
+    /// <returns>The health checks builder for chaining.</returns>
+    public static IHealthChecksBuilder AddGranitOpenIddictHealthCheck(
+        this IHealthChecksBuilder builder,
+        string name = "openiddict-signing-keys",
+        HealthStatus? failureStatus = null,
+        TimeSpan? timeout = null)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder.Services.AddSingleton<OpenIddictSigningKeyHealthCheck>();
+
+        return builder.Add(new HealthCheckRegistration(
+            name,
+            sp => sp.GetRequiredService<OpenIddictSigningKeyHealthCheck>(),
+            failureStatus,
+            ["readiness", "startup"],
+            timeout ?? TimeSpan.FromSeconds(10)));
+    }
+}

--- a/src/Granit.OpenIddict.EntityFrameworkCore/HealthChecks/OpenIddictSigningKeyHealthCheck.cs
+++ b/src/Granit.OpenIddict.EntityFrameworkCore/HealthChecks/OpenIddictSigningKeyHealthCheck.cs
@@ -1,0 +1,76 @@
+using Granit.OpenIddict.Domain;
+using Granit.OpenIddict.EntityFrameworkCore.Internal;
+using Granit.OpenIddict.Options;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Options;
+
+namespace Granit.OpenIddict.EntityFrameworkCore.HealthChecks;
+
+/// <summary>
+/// Readiness health check for the OpenIddict signing-key store and its backing
+/// <see cref="OpenIddictDbContext"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A single query against the signing-key table exercises both the DbContext connection and the
+/// schema, so this one check reports DbContext readiness and signing-key availability together:
+/// </para>
+/// <list type="bullet">
+///   <item>Store unreachable (database down, schema not migrated) → <see cref="HealthStatus.Unhealthy"/>.</item>
+///   <item>Key rotation enabled but no active key present → <see cref="HealthStatus.Unhealthy"/>;
+///   the server cannot mint tokens until a key is seeded.</item>
+///   <item>Otherwise → <see cref="HealthStatus.Healthy"/>. With rotation disabled an empty table is
+///   healthy — signing credentials then come from ephemeral or configured keys, not the store.</item>
+/// </list>
+/// <para>
+/// Registered as a singleton; opens a scope per probe to resolve the scoped
+/// <see cref="IDbContextFactory{TContext}"/>, so there is no captive dependency.
+/// </para>
+/// <para>The response never surfaces key material, connection strings, or tenant identifiers.</para>
+/// </remarks>
+internal sealed class OpenIddictSigningKeyHealthCheck(
+    IServiceScopeFactory scopeFactory,
+    IOptions<GranitKeyRotationOptions> rotationOptions) : IHealthCheck
+{
+    /// <inheritdoc/>
+    public async Task<HealthCheckResult> CheckHealthAsync(
+        HealthCheckContext context,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            await using AsyncServiceScope scope = scopeFactory.CreateAsyncScope();
+            IDbContextFactory<OpenIddictDbContext> dbContextFactory = scope.ServiceProvider
+                .GetRequiredService<IDbContextFactory<OpenIddictDbContext>>();
+
+            await using OpenIddictDbContext db = await dbContextFactory
+                .CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+
+            // Touching the signing-key table proves both connectivity and schema presence.
+            bool hasActiveKey = await db.SigningKeys
+                .AsNoTracking()
+                .AnyAsync(k => k.Status == SigningKeyStatus.Active, cancellationToken)
+                .ConfigureAwait(false);
+
+            if (rotationOptions.Value.Enabled && !hasActiveKey)
+            {
+                return HealthCheckResult.Unhealthy(
+                    "Key rotation is enabled but no active OpenIddict signing key is present.");
+            }
+
+            return HealthCheckResult.Healthy();
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            // Sanitize: never surface connection strings or key material in the probe response.
+            return HealthCheckResult.Unhealthy(
+                $"OpenIddict signing-key store unreachable: {ex.GetType().Name}");
+        }
+    }
+}

--- a/tests/Granit.OpenIddict.EntityFrameworkCore.Tests/OpenIddictSigningKeyHealthCheckTests.cs
+++ b/tests/Granit.OpenIddict.EntityFrameworkCore.Tests/OpenIddictSigningKeyHealthCheckTests.cs
@@ -1,0 +1,131 @@
+using Granit.MultiTenancy;
+using Granit.OpenIddict.Domain;
+using Granit.OpenIddict.EntityFrameworkCore.HealthChecks;
+using Granit.OpenIddict.EntityFrameworkCore.Internal;
+using Granit.OpenIddict.Options;
+using Granit.Testing.Fakes;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Options;
+using Shouldly;
+using Xunit;
+
+namespace Granit.OpenIddict.EntityFrameworkCore.Tests;
+
+/// <summary>
+/// The signing-key health check reports DbContext readiness and signing-key availability from a
+/// single query. Exercised against SQLite so the actual EF query path (and a genuinely absent
+/// schema) drive the result, not a substituted store.
+/// </summary>
+public sealed class OpenIddictSigningKeyHealthCheckTests : IAsyncLifetime
+{
+    private SqliteConnection _connection = null!;
+    private ServiceProvider _provider = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        await _connection.OpenAsync(TestContext.Current.CancellationToken);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_provider is not null)
+        {
+            await _provider.DisposeAsync();
+        }
+
+        await _connection.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task Healthy_WhenRotationEnabled_AndActiveKeyPresent()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+        OpenIddictSigningKeyHealthCheck check = BuildCheck(rotationEnabled: true);
+        await CreateSchemaAsync(ct);
+        await SeedActiveKeyAsync(ct);
+
+        HealthCheckResult result = await check.CheckHealthAsync(new HealthCheckContext(), ct);
+
+        result.Status.ShouldBe(HealthStatus.Healthy);
+    }
+
+    [Fact]
+    public async Task Unhealthy_WhenRotationEnabled_ButNoActiveKey()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+        OpenIddictSigningKeyHealthCheck check = BuildCheck(rotationEnabled: true);
+        await CreateSchemaAsync(ct);
+
+        HealthCheckResult result = await check.CheckHealthAsync(new HealthCheckContext(), ct);
+
+        result.Status.ShouldBe(HealthStatus.Unhealthy);
+        result.Description.ShouldNotBeNull().ShouldContain("no active", Case.Insensitive);
+    }
+
+    [Fact]
+    public async Task Healthy_WhenRotationDisabled_AndTableEmpty()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+        OpenIddictSigningKeyHealthCheck check = BuildCheck(rotationEnabled: false);
+        await CreateSchemaAsync(ct);
+
+        HealthCheckResult result = await check.CheckHealthAsync(new HealthCheckContext(), ct);
+
+        result.Status.ShouldBe(HealthStatus.Healthy);
+    }
+
+    [Fact]
+    public async Task Unhealthy_WhenSchemaMissing()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+        // No CreateSchemaAsync: the signing-key table does not exist, standing in for an
+        // unmigrated or unreachable database.
+        OpenIddictSigningKeyHealthCheck check = BuildCheck(rotationEnabled: true);
+
+        HealthCheckResult result = await check.CheckHealthAsync(new HealthCheckContext(), ct);
+
+        result.Status.ShouldBe(HealthStatus.Unhealthy);
+        result.Description.ShouldNotBeNull().ShouldContain("unreachable", Case.Insensitive);
+    }
+
+    private OpenIddictSigningKeyHealthCheck BuildCheck(bool rotationEnabled)
+    {
+        ServiceCollection services = new();
+        services.AddSingleton<ICurrentTenant>(new FakeCurrentTenant());
+        services.AddDbContextFactory<OpenIddictDbContext>(options => options.UseSqlite(_connection));
+        services.AddOptions<GranitKeyRotationOptions>().Configure(o => o.Enabled = rotationEnabled);
+
+        _provider = services.BuildServiceProvider();
+
+        return new OpenIddictSigningKeyHealthCheck(
+            _provider.GetRequiredService<IServiceScopeFactory>(),
+            _provider.GetRequiredService<IOptions<GranitKeyRotationOptions>>());
+    }
+
+    private async Task CreateSchemaAsync(CancellationToken ct)
+    {
+        IDbContextFactory<OpenIddictDbContext> factory =
+            _provider.GetRequiredService<IDbContextFactory<OpenIddictDbContext>>();
+        await using OpenIddictDbContext db = await factory.CreateDbContextAsync(ct);
+        await db.Database.EnsureCreatedAsync(ct);
+    }
+
+    private async Task SeedActiveKeyAsync(CancellationToken ct)
+    {
+        IDbContextFactory<OpenIddictDbContext> factory =
+            _provider.GetRequiredService<IDbContextFactory<OpenIddictDbContext>>();
+        await using OpenIddictDbContext db = await factory.CreateDbContextAsync(ct);
+        db.SigningKeys.Add(SigningKey.Create(
+            keyId: "kid-1",
+            keyType: "signing",
+            algorithm: "RS256",
+            encryptedKeyMaterial: "cipher",
+            activatedAt: DateTimeOffset.UnixEpoch,
+            expiresAt: DateTimeOffset.UnixEpoch.AddDays(90)));
+        await db.SaveChangesAsync(ct);
+    }
+}


### PR DESCRIPTION
## What

Adds an opt-in readiness health check for the OpenIddict persistence layer (Phase 4 — hygiene). A host wires it with:

```csharp
builder.Services.AddHealthChecks()
    .AddGranitOpenIddictHealthCheck(); // tags: "readiness", "startup"
```

A single `EXISTS` query against the signing-key table reports **DbContext readiness** and **signing-key availability** together:

| Condition | Result |
| --- | --- |
| Store unreachable (DB down, schema not migrated) | `Unhealthy` — `"…store unreachable: {ExceptionType}"` |
| Key rotation enabled but no active key present | `Unhealthy` — the server cannot mint tokens |
| Otherwise (incl. rotation disabled + empty table) | `Healthy` — with rotation off, keys come from ephemeral/configured credentials, not the store |

## Design notes

- **No captive dependency.** `IDbContextFactory<OpenIddictDbContext>` is registered **scoped** (interceptor wiring), so the check is a singleton that opens a scope per probe to resolve it — rather than injecting the scoped factory into a singleton.
- **Uncached**, consistent with the framework's own `AddGranitDbContextHealthCheck` (a lightweight `EXISTS`). This deliberately avoids pulling `Granit.Diagnostics`/`CachedHealthCheck` into the data-only module — keeping the change **purely additive with zero lockfile or csproj churn**.
- **No PII / secrets:** the response never surfaces key material, connection strings, or tenant identifiers (exception messages are reduced to the exception type name).

## Verification

- SQLite-backed tests exercising the real EF path and a genuinely absent schema — 4 cases (active key → healthy; rotation on + no key → unhealthy; rotation off + empty → healthy; schema missing → unhealthy/unreachable).
- `Granit.OpenIddict.EntityFrameworkCore.Tests`: **47/47 green**.
- `dotnet format --verify-no-changes` clean; locked-mode restore passes with unchanged lockfiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)