### PR TITLE
feat(openiddict): drive impersonation token lifetimes from settings (Phase 4)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -2177,6 +2177,7 @@
         "Granit.Identity.Local.AspNetIdentity",
         "Granit.OpenIddict.Abstractions",
         "Granit.QueryEngine.Abstractions",
+        "Granit.Settings",
         "Granit.Identity.Abstractions"
       ],
       "framework": "net10.0"
@@ -43623,7 +43624,7 @@
       "kind": "class",
       "project": "Granit.OpenIddict",
       "file": "src/Granit.OpenIddict/GranitOpenIddictModule.cs",
-      "line": 47,
+      "line": 49,
       "members": [
         {
           "name": "ConfigureServices",

--- a/src/Granit.OpenIddict.Abstractions/OpenIddictSettingNames.cs
+++ b/src/Granit.OpenIddict.Abstractions/OpenIddictSettingNames.cs
@@ -22,6 +22,13 @@ public static class OpenIddictSettingNames
     public const string RefreshTokenLifetime = "OpenIddict.RefreshTokenLifetime";
 
     /// <summary>
+    /// Impersonation session lifetime (TimeSpan string), applied to both the access and refresh
+    /// token issued when an administrator starts impersonating a user. Kept short by design.
+    /// Default: <c>"01:00:00"</c> (1 hour).
+    /// </summary>
+    public const string ImpersonationSessionLifetime = "OpenIddict.ImpersonationSessionLifetime";
+
+    /// <summary>
     /// Authorization code lifetime (TimeSpan string). Default: <c>"00:05:00"</c> (5 minutes).
     /// </summary>
     public const string AuthCodeLifetime = "OpenIddict.AuthCodeLifetime";

--- a/src/Granit.OpenIddict.BackgroundJobs/packages.lock.json
+++ b/src/Granit.OpenIddict.BackgroundJobs/packages.lock.json
@@ -638,6 +638,7 @@
           "Granit.Identity.Local.AspNetIdentity": "[0.1.0-dev, )",
           "Granit.OpenIddict.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Settings": "[0.1.0-dev, )",
           "OpenIddict": "[7.*, )"
         }
       },

--- a/src/Granit.OpenIddict.Endpoints/packages.lock.json
+++ b/src/Granit.OpenIddict.Endpoints/packages.lock.json
@@ -505,6 +505,7 @@
           "Granit.Identity.Local.AspNetIdentity": "[0.1.0-dev, )",
           "Granit.OpenIddict.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Settings": "[0.1.0-dev, )",
           "OpenIddict": "[7.*, )"
         }
       },

--- a/src/Granit.OpenIddict.EntityFrameworkCore/packages.lock.json
+++ b/src/Granit.OpenIddict.EntityFrameworkCore/packages.lock.json
@@ -556,6 +556,7 @@
           "Granit.Identity.Local.AspNetIdentity": "[0.1.0-dev, )",
           "Granit.OpenIddict.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Settings": "[0.1.0-dev, )",
           "OpenIddict": "[7.*, )"
         }
       },

--- a/src/Granit.OpenIddict.Server.DPoP/packages.lock.json
+++ b/src/Granit.OpenIddict.Server.DPoP/packages.lock.json
@@ -648,6 +648,7 @@
           "Granit.Identity.Local.AspNetIdentity": "[0.1.0-dev, )",
           "Granit.OpenIddict.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Settings": "[0.1.0-dev, )",
           "OpenIddict": "[7.*, )"
         }
       },

--- a/src/Granit.OpenIddict.Server/packages.lock.json
+++ b/src/Granit.OpenIddict.Server/packages.lock.json
@@ -500,6 +500,7 @@
           "Granit.Identity.Local.AspNetIdentity": "[0.1.0-dev, )",
           "Granit.OpenIddict.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Settings": "[0.1.0-dev, )",
           "OpenIddict": "[7.*, )"
         }
       },

--- a/src/Granit.OpenIddict/Granit.OpenIddict.csproj
+++ b/src/Granit.OpenIddict/Granit.OpenIddict.csproj
@@ -29,6 +29,7 @@
     <ProjectReference Include="..\Granit.Identity.Local.AspNetIdentity\Granit.Identity.Local.AspNetIdentity.csproj" />
     <ProjectReference Include="..\Granit.OpenIddict.Abstractions\Granit.OpenIddict.Abstractions.csproj" />
     <ProjectReference Include="..\Granit.QueryEngine.Abstractions\Granit.QueryEngine.Abstractions.csproj" />
+    <ProjectReference Include="..\Granit.Settings\Granit.Settings.csproj" />
     <ProjectReference Include="..\Granit.Identity.Abstractions\Granit.Identity.Abstractions.csproj" />
   </ItemGroup>
 

--- a/src/Granit.OpenIddict/GranitOpenIddictModule.cs
+++ b/src/Granit.OpenIddict/GranitOpenIddictModule.cs
@@ -21,6 +21,7 @@ using Granit.OpenIddict.Queries;
 using Granit.OpenIddict.Services;
 using Granit.QueryEngine;
 using Granit.QueryEngine.Extensions;
+using Granit.Settings;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
@@ -43,7 +44,8 @@ namespace Granit.OpenIddict;
     typeof(GranitIdentityLocalAspNetIdentityModule),
     typeof(GranitIdentityLocalModule),
     typeof(GranitOpenIddictAbstractionsModule),
-    typeof(GranitQueryEngineAbstractionsModule))]
+    typeof(GranitQueryEngineAbstractionsModule),
+    typeof(GranitSettingsModule))]
 public sealed class GranitOpenIddictModule : GranitModule
 {
     /// <inheritdoc/>

--- a/src/Granit.OpenIddict/Internal/AspNetImpersonationService.cs
+++ b/src/Granit.OpenIddict/Internal/AspNetImpersonationService.cs
@@ -1,9 +1,11 @@
 using System.Collections.Immutable;
+using System.Globalization;
 using System.Security.Claims;
 using Granit.Identity.Local.Diagnostics;
 using Granit.Identity.Local.Domain;
 using Granit.Identity.Local.Extensions;
 using Granit.Identity.Local.Services;
+using Granit.Settings.Services;
 using Granit.Timing;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Logging;
@@ -22,10 +24,13 @@ internal sealed partial class AspNetImpersonationService(
     UserManager<LocalIdentity> userManager,
     IOpenIddictTokenManager tokenManager,
     IdentityLocalMetrics metrics,
+    ISettingProvider settingProvider,
     IClock clock,
     ILogger<AspNetImpersonationService> logger) : IImpersonationService
 {
-    private static readonly TimeSpan ImpersonationTokenLifetime = TimeSpan.FromHours(1);
+    private static readonly TimeSpan DefaultImpersonationLifetime = TimeSpan.FromHours(1);
+    private static readonly TimeSpan DefaultAccessTokenLifetime = TimeSpan.FromHours(1);
+    private static readonly TimeSpan DefaultRefreshTokenLifetime = TimeSpan.FromDays(14);
 
     /// <inheritdoc/>
     public async Task<ImpersonationResult> ImpersonateAsync(
@@ -77,6 +82,12 @@ internal sealed partial class AspNetImpersonationService(
             claim.SetDestinations(GetImpersonationDestinations(claim));
         }
 
+        // Impersonation sessions are short-lived by design; both tokens share one configurable
+        // lifetime (per-tenant via Granit.Settings, default 1h).
+        TimeSpan lifetime = await ResolveLifetimeAsync(
+            OpenIddictSettingNames.ImpersonationSessionLifetime, DefaultImpersonationLifetime, cancellationToken)
+            .ConfigureAwait(false);
+
         // Create access token descriptor
         DateTimeOffset now = clock.Now;
         var accessTokenDescriptor = new OpenIddictTokenDescriptor
@@ -84,7 +95,7 @@ internal sealed partial class AspNetImpersonationService(
             Principal = principal,
             Subject = targetUser.Id.ToString(),
             CreationDate = now,
-            ExpirationDate = now + ImpersonationTokenLifetime,
+            ExpirationDate = now + lifetime,
             Type = OpenIddictConstants.TokenTypeHints.AccessToken,
         };
 
@@ -97,7 +108,7 @@ internal sealed partial class AspNetImpersonationService(
             Principal = principal,
             Subject = targetUser.Id.ToString(),
             CreationDate = now,
-            ExpirationDate = now + ImpersonationTokenLifetime,
+            ExpirationDate = now + lifetime,
             Type = OpenIddictConstants.TokenTypeHints.RefreshToken,
         };
 
@@ -112,7 +123,7 @@ internal sealed partial class AspNetImpersonationService(
         return new ImpersonationResult(
             accessToken ?? string.Empty,
             refreshToken ?? string.Empty,
-            (int)ImpersonationTokenLifetime.TotalSeconds);
+            (int)lifetime.TotalSeconds);
     }
 
     /// <inheritdoc/>
@@ -153,13 +164,22 @@ internal sealed partial class AspNetImpersonationService(
             claim.SetDestinations(GetStandardDestinations(claim));
         }
 
+        // Returning to the admin's own session restores a normal session governed by the standard
+        // per-tenant token lifetime settings (defaults 1h access / 14d refresh).
+        TimeSpan accessLifetime = await ResolveLifetimeAsync(
+            OpenIddictSettingNames.AccessTokenLifetime, DefaultAccessTokenLifetime, cancellationToken)
+            .ConfigureAwait(false);
+        TimeSpan refreshLifetime = await ResolveLifetimeAsync(
+            OpenIddictSettingNames.RefreshTokenLifetime, DefaultRefreshTokenLifetime, cancellationToken)
+            .ConfigureAwait(false);
+
         DateTimeOffset now = clock.Now;
         var accessTokenDescriptor = new OpenIddictTokenDescriptor
         {
             Principal = principal,
             Subject = adminUser.Id.ToString(),
             CreationDate = now,
-            ExpirationDate = now + TimeSpan.FromHours(1),
+            ExpirationDate = now + accessLifetime,
             Type = OpenIddictConstants.TokenTypeHints.AccessToken,
         };
 
@@ -171,7 +191,7 @@ internal sealed partial class AspNetImpersonationService(
             Principal = principal,
             Subject = adminUser.Id.ToString(),
             CreationDate = now,
-            ExpirationDate = now + TimeSpan.FromDays(14),
+            ExpirationDate = now + refreshLifetime,
             Type = OpenIddictConstants.TokenTypeHints.RefreshToken,
         };
 
@@ -183,7 +203,21 @@ internal sealed partial class AspNetImpersonationService(
         return new ImpersonationResult(
             accessToken ?? string.Empty,
             refreshToken ?? string.Empty,
-            3600);
+            (int)accessLifetime.TotalSeconds);
+    }
+
+    /// <summary>
+    /// Resolves a lifetime from a per-tenant <see cref="ISettingProvider"/> setting (a
+    /// <see cref="TimeSpan"/> string such as <c>"01:00:00"</c>), falling back to
+    /// <paramref name="fallback"/> when unset, unparseable, or non-positive.
+    /// </summary>
+    private async Task<TimeSpan> ResolveLifetimeAsync(
+        string settingName, TimeSpan fallback, CancellationToken cancellationToken)
+    {
+        string? value = await settingProvider.GetOrNullAsync(settingName, cancellationToken).ConfigureAwait(false);
+        return TimeSpan.TryParse(value, CultureInfo.InvariantCulture, out TimeSpan parsed) && parsed > TimeSpan.Zero
+            ? parsed
+            : fallback;
     }
 
     private static ImmutableArray<string> GetImpersonationDestinations(Claim claim)

--- a/tests/Granit.ArchitectureTests/packages.lock.json
+++ b/tests/Granit.ArchitectureTests/packages.lock.json
@@ -3563,6 +3563,7 @@
           "Granit.Identity.Local.AspNetIdentity": "[0.1.0-dev, )",
           "Granit.OpenIddict.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Settings": "[0.1.0-dev, )",
           "OpenIddict": "[7.*, )"
         }
       },

--- a/tests/Granit.OpenIddict.BackgroundJobs.Tests/packages.lock.json
+++ b/tests/Granit.OpenIddict.BackgroundJobs.Tests/packages.lock.json
@@ -846,6 +846,7 @@
           "Granit.Identity.Local.AspNetIdentity": "[0.1.0-dev, )",
           "Granit.OpenIddict.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Settings": "[0.1.0-dev, )",
           "OpenIddict": "[7.*, )"
         }
       },

--- a/tests/Granit.OpenIddict.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.OpenIddict.Endpoints.Tests/packages.lock.json
@@ -805,6 +805,7 @@
           "Granit.Identity.Local.AspNetIdentity": "[0.1.0-dev, )",
           "Granit.OpenIddict.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Settings": "[0.1.0-dev, )",
           "OpenIddict": "[7.*, )"
         }
       },

--- a/tests/Granit.OpenIddict.EntityFrameworkCore.Tests/packages.lock.json
+++ b/tests/Granit.OpenIddict.EntityFrameworkCore.Tests/packages.lock.json
@@ -795,6 +795,7 @@
           "Granit.Identity.Local.AspNetIdentity": "[0.1.0-dev, )",
           "Granit.OpenIddict.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Settings": "[0.1.0-dev, )",
           "OpenIddict": "[7.*, )"
         }
       },

--- a/tests/Granit.OpenIddict.Server.DPoP.Tests/packages.lock.json
+++ b/tests/Granit.OpenIddict.Server.DPoP.Tests/packages.lock.json
@@ -709,6 +709,7 @@
           "Granit.Identity.Local.AspNetIdentity": "[0.1.0-dev, )",
           "Granit.OpenIddict.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Settings": "[0.1.0-dev, )",
           "OpenIddict": "[7.*, )"
         }
       },

--- a/tests/Granit.OpenIddict.Server.Tests/packages.lock.json
+++ b/tests/Granit.OpenIddict.Server.Tests/packages.lock.json
@@ -682,6 +682,7 @@
           "Granit.Identity.Local.AspNetIdentity": "[0.1.0-dev, )",
           "Granit.OpenIddict.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Settings": "[0.1.0-dev, )",
           "OpenIddict": "[7.*, )"
         }
       },

--- a/tests/Granit.OpenIddict.Tests.Integration/packages.lock.json
+++ b/tests/Granit.OpenIddict.Tests.Integration/packages.lock.json
@@ -950,6 +950,7 @@
           "Granit.Identity.Local.AspNetIdentity": "[0.1.0-dev, )",
           "Granit.OpenIddict.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Settings": "[0.1.0-dev, )",
           "OpenIddict": "[7.*, )"
         }
       },

--- a/tests/Granit.OpenIddict.Tests/AspNetImpersonationServiceTests.cs
+++ b/tests/Granit.OpenIddict.Tests/AspNetImpersonationServiceTests.cs
@@ -3,6 +3,7 @@ using Granit.Identity.Local.Diagnostics;
 using Granit.Identity.Local.Domain;
 using Granit.Identity.Local.Services;
 using Granit.OpenIddict.Internal;
+using Granit.Settings.Services;
 using Granit.Timing;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -19,6 +20,7 @@ public sealed class AspNetImpersonationServiceTests
 
     private readonly UserManager<LocalIdentity> _userManager;
     private readonly IOpenIddictTokenManager _tokenManager = Substitute.For<IOpenIddictTokenManager>();
+    private readonly ISettingProvider _settingProvider = Substitute.For<ISettingProvider>();
     private readonly IClock _clock = Substitute.For<IClock>();
     private readonly AspNetImpersonationService _sut;
 
@@ -37,6 +39,7 @@ public sealed class AspNetImpersonationServiceTests
             _userManager,
             _tokenManager,
             metrics,
+            _settingProvider,
             _clock,
             NullLogger<AspNetImpersonationService>.Instance);
     }
@@ -101,6 +104,35 @@ public sealed class AspNetImpersonationServiceTests
             Arg.Is<OpenIddictTokenDescriptor>(d =>
                 d.Type == OpenIddictConstants.TokenTypeHints.RefreshToken &&
                 d.Subject == targetId),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ImpersonateAsync_HonoursConfiguredSessionLifetime()
+    {
+        LocalIdentity target = CreateUser();
+        string targetId = target.Id.ToString();
+
+        _userManager.FindByIdAsync(targetId).Returns(target);
+        _userManager.GetRolesAsync(target).Returns([]);
+        SetupTokenCreation();
+        _settingProvider
+            .GetOrNullAsync(OpenIddictSettingNames.ImpersonationSessionLifetime, Arg.Any<CancellationToken>())
+            .Returns("02:00:00");
+
+        ImpersonationResult result = await _sut.ImpersonateAsync(
+            targetId, Guid.NewGuid().ToString(), "Admin", TestContext.Current.CancellationToken);
+
+        result.ExpiresIn.ShouldBe(7200);
+        await _tokenManager.Received(1).CreateAsync(
+            Arg.Is<OpenIddictTokenDescriptor>(d =>
+                d.Type == OpenIddictConstants.TokenTypeHints.AccessToken &&
+                d.ExpirationDate == FixedNow + TimeSpan.FromHours(2)),
+            Arg.Any<CancellationToken>());
+        await _tokenManager.Received(1).CreateAsync(
+            Arg.Is<OpenIddictTokenDescriptor>(d =>
+                d.Type == OpenIddictConstants.TokenTypeHints.RefreshToken &&
+                d.ExpirationDate == FixedNow + TimeSpan.FromHours(2)),
             Arg.Any<CancellationToken>());
     }
 
@@ -244,6 +276,38 @@ public sealed class AspNetImpersonationServiceTests
                 d.Type == OpenIddictConstants.TokenTypeHints.RefreshToken &&
                 d.Subject == adminId &&
                 d.ExpirationDate == FixedNow + TimeSpan.FromDays(14)),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task BackToImpersonatorAsync_HonoursConfiguredLifetimes()
+    {
+        LocalIdentity admin = CreateUser();
+        string adminId = admin.Id.ToString();
+
+        _userManager.FindByIdAsync(adminId).Returns(admin);
+        _userManager.GetRolesAsync(admin).Returns([]);
+        SetupTokenCreation();
+        _settingProvider
+            .GetOrNullAsync(OpenIddictSettingNames.AccessTokenLifetime, Arg.Any<CancellationToken>())
+            .Returns("00:30:00");
+        _settingProvider
+            .GetOrNullAsync(OpenIddictSettingNames.RefreshTokenLifetime, Arg.Any<CancellationToken>())
+            .Returns("07.00:00:00");
+
+        ImpersonationResult result = await _sut.BackToImpersonatorAsync(
+            adminId, TestContext.Current.CancellationToken);
+
+        result.ExpiresIn.ShouldBe(1800);
+        await _tokenManager.Received(1).CreateAsync(
+            Arg.Is<OpenIddictTokenDescriptor>(d =>
+                d.Type == OpenIddictConstants.TokenTypeHints.AccessToken &&
+                d.ExpirationDate == FixedNow + TimeSpan.FromMinutes(30)),
+            Arg.Any<CancellationToken>());
+        await _tokenManager.Received(1).CreateAsync(
+            Arg.Is<OpenIddictTokenDescriptor>(d =>
+                d.Type == OpenIddictConstants.TokenTypeHints.RefreshToken &&
+                d.ExpirationDate == FixedNow + TimeSpan.FromDays(7)),
             Arg.Any<CancellationToken>());
     }
 

--- a/tests/Granit.OpenIddict.Tests/packages.lock.json
+++ b/tests/Granit.OpenIddict.Tests/packages.lock.json
@@ -728,6 +728,7 @@
           "Granit.Identity.Local.AspNetIdentity": "[0.1.0-dev, )",
           "Granit.OpenIddict.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Settings": "[0.1.0-dev, )",
           "OpenIddict": "[7.*, )"
         }
       },


### PR DESCRIPTION
## What

`AspNetImpersonationService` hardcoded three token lifetimes. This moves them to **per-tenant `Granit.Settings`**, aligning with the framework's documented design (token lifetimes belong in `Granit.Settings`, per `GranitOpenIddictOptions` remarks) and the one already-working consumer (`IdleSessionTimeout`).

| Flow | Before (hardcoded) | Now (setting, default) |
| --- | --- | --- |
| `ImpersonateAsync` (access + refresh) | `1h` | `OpenIddict.ImpersonationSessionLifetime` (**new**, default `1h`) |
| `BackToImpersonatorAsync` access | `1h` | `OpenIddict.AccessTokenLifetime` (default `1h`) |
| `BackToImpersonatorAsync` refresh | `14d` | `OpenIddict.RefreshTokenLifetime` (default `14d`) |

The impersonation session is deliberately short — its own setting rather than the normal token lifetime. Returning to the admin's own session restores a **normal** session, so it (finally) consumes the previously-declared-but-unused `AccessTokenLifetime` / `RefreshTokenLifetime` settings.

## Behaviour & safety

- Values are `TimeSpan` strings (e.g. `"01:00:00"`) resolved via `ISettingProvider`, with a fallback to the **prior hardcoded defaults** when unset, unparseable, or non-positive → **no behavioural change** unless a tenant configures otherwise.
- Adds `Granit.Settings` as a direct dependency of the base module (`[DependsOn(GranitSettingsModule)]`). It was already transitively present, so lockfiles gain only the dependency edge — **zero version drift**.

## Verification

- `Granit.OpenIddict.Tests`: **276/276 green**, incl. 2 new tests asserting configured settings override the defaults (both flows) while unconfigured runs keep the 1h/14d/`ExpiresIn` defaults.
- `dotnet format --verify-no-changes` clean; locked-mode restore consistent across the OpenIddict family (13 lockfiles, edge-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)