### PR TITLE
feat(openiddict): validate resource-server token-validation options at startup (Phase 4)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -10912,7 +10912,7 @@
       "kind": "class",
       "project": "Granit.Authentication.OpenIddict",
       "file": "src/Granit.Authentication.OpenIddict/Extensions/OpenIddictValidationHostApplicationBuilderExtensions.cs",
-      "line": 13,
+      "line": 14,
       "members": [
         {
           "name": "AddGranitOpenIddictAuthentication",

--- a/src/Granit.Authentication.OpenIddict/Extensions/OpenIddictValidationHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Authentication.OpenIddict/Extensions/OpenIddictValidationHostApplicationBuilderExtensions.cs
@@ -3,6 +3,7 @@ using Granit.Authentication.OpenIddict.Options;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
 
 namespace Granit.Authentication.OpenIddict.Extensions;
 
@@ -23,6 +24,17 @@ public static class OpenIddictValidationHostApplicationBuilderExtensions
     {
         ArgumentNullException.ThrowIfNull(builder);
 
+        // Bind + validate the options so a bad section fails fast at startup (missing issuer, or a
+        // cleartext issuer on a non-loopback host).
+        builder.Services
+            .AddOptions<GranitOpenIddictValidationOptions>()
+            .BindConfiguration(GranitOpenIddictValidationOptions.SectionName)
+            .ValidateOnStart();
+        builder.Services
+            .AddSingleton<IValidateOptions<GranitOpenIddictValidationOptions>, GranitOpenIddictValidationOptionsValidator>();
+
+        // The OpenIddict validation builder configures at composition time, so read the same section
+        // once here for SetIssuer/AddAudiences; ValidateOnStart above still guards the runtime value.
         GranitOpenIddictValidationOptions validationOptions = new();
         builder.Configuration
             .GetSection(GranitOpenIddictValidationOptions.SectionName)

--- a/src/Granit.Authentication.OpenIddict/Options/GranitOpenIddictValidationOptionsValidator.cs
+++ b/src/Granit.Authentication.OpenIddict/Options/GranitOpenIddictValidationOptionsValidator.cs
@@ -1,0 +1,43 @@
+using Microsoft.Extensions.Options;
+
+namespace Granit.Authentication.OpenIddict.Options;
+
+/// <summary>
+/// Validates <see cref="GranitOpenIddictValidationOptions"/> at startup.
+/// </summary>
+/// <remarks>
+/// Remote token validation resolves the authorization server's signing keys over the network from
+/// the issuer's discovery endpoint, so the issuer must be an absolute, TLS-protected URI. Plaintext
+/// http is tolerated only for loopback hosts (a local mock/proxy in development or tests) — any
+/// non-loopback issuer must use https, which is what "https in production" reduces to.
+/// </remarks>
+internal sealed class GranitOpenIddictValidationOptionsValidator : IValidateOptions<GranitOpenIddictValidationOptions>
+{
+    public ValidateOptionsResult Validate(string? name, GranitOpenIddictValidationOptions options)
+    {
+        if (options.Issuer is null)
+        {
+            return ValidateOptionsResult.Fail(
+                $"{nameof(options.Issuer)} is required (the remote authorization server's issuer URI).");
+        }
+
+        if (!options.Issuer.IsAbsoluteUri)
+        {
+            return ValidateOptionsResult.Fail($"{nameof(options.Issuer)} must be an absolute URI.");
+        }
+
+        if (options.Issuer.Scheme != Uri.UriSchemeHttps && options.Issuer.Scheme != Uri.UriSchemeHttp)
+        {
+            return ValidateOptionsResult.Fail($"{nameof(options.Issuer)} must use http or https.");
+        }
+
+        if (options.Issuer.Scheme == Uri.UriSchemeHttp && !options.Issuer.IsLoopback)
+        {
+            return ValidateOptionsResult.Fail(
+                $"{nameof(options.Issuer)} must use https for non-loopback hosts "
+                + "(token validation fetches signing keys from the issuer and must not do so over cleartext).");
+        }
+
+        return ValidateOptionsResult.Success;
+    }
+}

--- a/tests/Granit.Authentication.OpenIddict.Tests/Options/GranitOpenIddictValidationOptionsValidatorTests.cs
+++ b/tests/Granit.Authentication.OpenIddict.Tests/Options/GranitOpenIddictValidationOptionsValidatorTests.cs
@@ -1,0 +1,59 @@
+using Granit.Authentication.OpenIddict.Options;
+using Microsoft.Extensions.Options;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Authentication.OpenIddict.Tests.Options;
+
+public sealed class GranitOpenIddictValidationOptionsValidatorTests
+{
+    private readonly GranitOpenIddictValidationOptionsValidator _sut = new();
+
+    [Fact]
+    public void Validate_HttpsIssuer_Succeeds()
+    {
+        GranitOpenIddictValidationOptions options = new() { Issuer = new Uri("https://auth.example.com") };
+
+        _sut.Validate(null, options).Succeeded.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Validate_NullIssuer_Fails()
+    {
+        ValidateOptionsResult result = _sut.Validate(null, new GranitOpenIddictValidationOptions());
+
+        result.Failed.ShouldBeTrue();
+        result.FailureMessage.ShouldContain("Issuer");
+    }
+
+    [Fact]
+    public void Validate_HttpNonLoopbackIssuer_Fails()
+    {
+        GranitOpenIddictValidationOptions options = new() { Issuer = new Uri("http://auth.example.com") };
+
+        ValidateOptionsResult result = _sut.Validate(null, options);
+
+        result.Failed.ShouldBeTrue();
+        result.FailureMessage.ShouldContain("https");
+    }
+
+    [Fact]
+    public void Validate_HttpLoopbackIssuer_Succeeds()
+    {
+        // Loopback http is tolerated so a local mock authorization server works in dev/tests.
+        GranitOpenIddictValidationOptions options = new() { Issuer = new Uri("http://localhost:5000") };
+
+        _sut.Validate(null, options).Succeeded.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Validate_RelativeIssuer_Fails()
+    {
+        GranitOpenIddictValidationOptions options = new() { Issuer = new Uri("/auth", UriKind.Relative) };
+
+        ValidateOptionsResult result = _sut.Validate(null, options);
+
+        result.Failed.ShouldBeTrue();
+        result.FailureMessage.ShouldContain("absolute");
+    }
+}


### PR DESCRIPTION
## What

`GranitOpenIddictValidationOptions` (resource-server remote token validation) was bound imperatively with **no validation** — a missing or cleartext issuer surfaced only as silent auth failures at runtime. This registers it via `AddOptions().BindConfiguration().ValidateOnStart()` plus a `GranitOpenIddictValidationOptionsValidator` (`IValidateOptions`), so misconfiguration **fails fast at startup**.

Rules:
- **`Issuer` is required** and must be an absolute URI — remote validation resolves the AS signing keys from the issuer's discovery endpoint, so it can't be null.
- **`Issuer` must use https for non-loopback hosts.** Loopback http is tolerated for a local mock authorization server in dev/tests, so this is exactly *"https in production"* without needing `IHostEnvironment`. Mirrors the established `IpInfoIpGeolocationOptionsValidator` pattern.

The OpenIddict validation builder still reads the section once at composition time for `SetIssuer`/`AddAudiences` (it configures at build time); `ValidateOnStart` guards the runtime value.

## Note on scope

The plan grouped `RsaKeySize` / `GracePeriod` DataAnnotations under this bullet, but those belong to `GranitKeyRotationOptions` in the base module (a different class) — deferred to a separate change to keep this PR focused on the resource-server options.

## Verification

- `Granit.Authentication.OpenIddict.Tests`: **20/20 green**, incl. 5 new validator tests (https ok, null fails, http non-loopback fails, http loopback ok, relative uri fails).
- `dotnet format --verify-no-changes` clean; no lockfile change (no new dependency).

🤖 Generated with [Claude Code](https://claude.com/claude-code)