### PR TITLE
fix(text-extraction): drive Tesseract OCR integration test via host builder (CS1929)

### DIFF
--- a/tests/Granit.TextExtraction.Ocr.Tesseract.Tests.Integration/LiveTesseractRecognizerTests.cs
+++ b/tests/Granit.TextExtraction.Ocr.Tesseract.Tests.Integration/LiveTesseractRecognizerTests.cs
@@ -1,8 +1,8 @@
 using Granit.Imaging.MagickNet.Extensions;
 using Granit.TextExtraction.Ocr.Tesseract.Extensions;
 using ImageMagick;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Shouldly;
 using Xunit;
 
@@ -75,17 +75,19 @@ public sealed class LiveTesseractRecognizerTests
         // /opt/granit-ocr-libs; local opt-in is described in the package README.
         string? libDir = Environment.GetEnvironmentVariable("GRANIT_TESSERACT_LIB_DIR");
 
-        ServiceCollection services = [];
-        services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
-        services.AddLogging();
-        // ImagingMetrics (pulled in by AddGranitImagingMagickNet) ctor-injects IMeterFactory,
-        // which the generic host registers automatically but a bare ServiceCollection does not.
-        services.AddMetrics();
+        // AddGranitImagingMagickNet binds options from configuration and targets
+        // IHostApplicationBuilder (since #3077), so drive registration through a minimal
+        // host builder rather than a bare ServiceCollection. The builder registers
+        // IConfiguration; logging + metrics are added explicitly (ImagingMetrics
+        // ctor-injects IMeterFactory, which a bare ServiceCollection would not provide).
+        HostApplicationBuilder builder = Host.CreateEmptyApplicationBuilder(null);
+        builder.Services.AddLogging();
+        builder.Services.AddMetrics();
         // TesseractOcrExtractor depends on IImageProcessor for its pre-decode pixel-bomb guard
         // (the host must register an imaging provider — see the module docs). Magick.NET is the
         // reference provider and is already used below to render the test fixtures.
-        services.AddGranitImagingMagickNet();
-        services.AddTesseractOcrExtractor(o =>
+        builder.AddGranitImagingMagickNet();
+        builder.Services.AddTesseractOcrExtractor(o =>
         {
             o.DataPath = TessdataPath;
             o.Language = "eng";
@@ -94,7 +96,7 @@ public sealed class LiveTesseractRecognizerTests
                 o.LibrarySearchPath = libDir;
             }
         });
-        return services.BuildServiceProvider();
+        return builder.Services.BuildServiceProvider();
     }
 
     private static byte[] RenderPngWithText(string text)


### PR DESCRIPTION
## Problem

The `integration` shard fails to compile:

```
error CS1929: 'ServiceCollection' does not contain a definition for 'AddGranitImagingMagickNet'
and the best extension method overload ... requires a receiver of type
'Microsoft.Extensions.Hosting.IHostApplicationBuilder'
```

**#3077** (`fix(imaging)!`) reworked `AddGranitImagingMagickNet` into an `IHostApplicationBuilder` extension (config-bound options + startup resource limits) and dropped the `IServiceCollection` overload. `LiveTesseractRecognizerTests.BuildHost()` still registered it on a bare `ServiceCollection`, so it never compiled after that change. (Pre-existing on develop — the integration shard doesn't compile on every PR — surfaced by a full CI run.)

## Fix

Rebuild the test host with `Host.CreateEmptyApplicationBuilder(null)` — the idiom used in ~290 other host-extension tests — register logging/metrics on `builder.Services`, call `builder.AddGranitImagingMagickNet()`, and return `builder.Services.BuildServiceProvider()`. The builder also provides `IConfiguration`, so the manual `IConfiguration` stub (and its `using`) are dropped. Single-file test change, no production code touched.

## Verification

The **entire `integration` shard compiles** (`dotnet build integration.slnf`) — CS1929 was the only error. `Host`/`HostApplicationBuilder` resolve transitively; no new package reference needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)