### PR TITLE
feat(openiddict): validate key-rotation options at startup (Phase 4)

### DIFF
--- a/src/Granit.OpenIddict/GranitOpenIddictModule.cs
+++ b/src/Granit.OpenIddict/GranitOpenIddictModule.cs
@@ -68,7 +68,10 @@ public sealed class GranitOpenIddictModule : GranitModule
 
         context.Services
             .AddOptions<GranitKeyRotationOptions>()
-            .BindConfiguration(GranitKeyRotationOptions.SectionName);
+            .BindConfiguration(GranitKeyRotationOptions.SectionName)
+            .ValidateOnStart();
+        context.Services.AddSingleton<IValidateOptions<GranitKeyRotationOptions>,
+            GranitKeyRotationOptionsValidator>();
 
         // FAPI 2.0 profile → PS256 signing algorithm (unless an explicit non-default was set).
         context.Services.AddSingleton<IPostConfigureOptions<GranitKeyRotationOptions>,

--- a/src/Granit.OpenIddict/Options/GranitKeyRotationOptionsValidator.cs
+++ b/src/Granit.OpenIddict/Options/GranitKeyRotationOptionsValidator.cs
@@ -1,0 +1,75 @@
+using Microsoft.Extensions.Options;
+
+namespace Granit.OpenIddict.Options;
+
+/// <summary>
+/// Validates <see cref="GranitKeyRotationOptions"/> at startup when rotation is enabled.
+/// </summary>
+/// <remarks>
+/// The knobs are inert unless <see cref="GranitKeyRotationOptions.Enabled"/> is set (rotation off
+/// means ephemeral/configured keys), so validation is skipped in that case rather than blocking
+/// startup for an unused feature. Runs after post-configuration, so the FAPI 2.0 PS256 override on
+/// <see cref="GranitKeyRotationOptions.SigningAlgorithm"/> has already been applied.
+/// </remarks>
+internal sealed class GranitKeyRotationOptionsValidator : IValidateOptions<GranitKeyRotationOptions>
+{
+    private const int MinRsaKeySize = 2048;
+    private const int MaxRsaKeySize = 4096;
+
+    public ValidateOptionsResult Validate(string? name, GranitKeyRotationOptions options)
+    {
+        if (!options.Enabled)
+        {
+            return ValidateOptionsResult.Success;
+        }
+
+        List<string> failures = [];
+
+        if (options.RsaKeySize is < MinRsaKeySize or > MaxRsaKeySize)
+        {
+            failures.Add(
+                $"{nameof(options.RsaKeySize)} must be between {MinRsaKeySize} and {MaxRsaKeySize} bits.");
+        }
+
+        if (options.KeyLifetime <= TimeSpan.Zero)
+        {
+            failures.Add($"{nameof(options.KeyLifetime)} must be a positive duration.");
+        }
+
+        if (options.GracePeriod <= TimeSpan.Zero)
+        {
+            failures.Add($"{nameof(options.GracePeriod)} must be a positive duration.");
+        }
+
+        if (options.RotationLeadTime <= TimeSpan.Zero)
+        {
+            failures.Add($"{nameof(options.RotationLeadTime)} must be a positive duration.");
+        }
+        else if (options.RotationLeadTime >= options.KeyLifetime)
+        {
+            failures.Add(
+                $"{nameof(options.RotationLeadTime)} must be shorter than {nameof(options.KeyLifetime)} "
+                + "so a new key is minted before the active one expires.");
+        }
+
+        if (options.RefreshCheckInterval <= TimeSpan.Zero)
+        {
+            failures.Add($"{nameof(options.RefreshCheckInterval)} must be a positive duration.");
+        }
+        else if (options.RefreshCheckInterval >= options.GracePeriod)
+        {
+            failures.Add(
+                $"{nameof(options.RefreshCheckInterval)} must be well below {nameof(options.GracePeriod)} "
+                + "so a rotated-in key is picked up before the retired key is revoked.");
+        }
+
+        if (string.IsNullOrWhiteSpace(options.SigningAlgorithm))
+        {
+            failures.Add($"{nameof(options.SigningAlgorithm)} must be non-empty.");
+        }
+
+        return failures.Count > 0
+            ? ValidateOptionsResult.Fail(failures)
+            : ValidateOptionsResult.Success;
+    }
+}

--- a/tests/Granit.OpenIddict.Tests/Options/GranitKeyRotationOptionsValidatorTests.cs
+++ b/tests/Granit.OpenIddict.Tests/Options/GranitKeyRotationOptionsValidatorTests.cs
@@ -1,0 +1,108 @@
+using Granit.OpenIddict.Options;
+using Microsoft.Extensions.Options;
+using Shouldly;
+using Xunit;
+
+namespace Granit.OpenIddict.Tests.Options;
+
+public sealed class GranitKeyRotationOptionsValidatorTests
+{
+    private readonly GranitKeyRotationOptionsValidator _sut = new();
+
+    [Fact]
+    public void Validate_EnabledWithDefaults_Succeeds() =>
+        _sut.Validate(null, new GranitKeyRotationOptions { Enabled = true })
+            .Succeeded.ShouldBeTrue();
+
+    [Fact]
+    public void Validate_Disabled_SkipsValidation()
+    {
+        // Rotation off → the knobs are inert, so even nonsense values must not block startup.
+        GranitKeyRotationOptions options = new()
+        {
+            Enabled = false,
+            RsaKeySize = 512,
+            GracePeriod = TimeSpan.Zero,
+        };
+
+        _sut.Validate(null, options).Succeeded.ShouldBeTrue();
+    }
+
+    [Theory]
+    [InlineData(1024)]
+    [InlineData(8192)]
+    public void Validate_RsaKeySizeOutOfRange_Fails(int keySize)
+    {
+        GranitKeyRotationOptions options = new() { Enabled = true, RsaKeySize = keySize };
+
+        ValidateOptionsResult result = _sut.Validate(null, options);
+
+        result.Failed.ShouldBeTrue();
+        result.FailureMessage.ShouldContain(nameof(GranitKeyRotationOptions.RsaKeySize));
+    }
+
+    [Fact]
+    public void Validate_NonPositiveGracePeriod_Fails()
+    {
+        GranitKeyRotationOptions options = new() { Enabled = true, GracePeriod = TimeSpan.Zero };
+
+        _sut.Validate(null, options).Failed.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Validate_RotationLeadTimeNotShorterThanKeyLifetime_Fails()
+    {
+        GranitKeyRotationOptions options = new()
+        {
+            Enabled = true,
+            KeyLifetime = TimeSpan.FromDays(30),
+            RotationLeadTime = TimeSpan.FromDays(30),
+        };
+
+        ValidateOptionsResult result = _sut.Validate(null, options);
+
+        result.Failed.ShouldBeTrue();
+        result.FailureMessage.ShouldContain(nameof(GranitKeyRotationOptions.RotationLeadTime));
+    }
+
+    [Fact]
+    public void Validate_RefreshCheckIntervalNotBelowGracePeriod_Fails()
+    {
+        GranitKeyRotationOptions options = new()
+        {
+            Enabled = true,
+            GracePeriod = TimeSpan.FromMinutes(5),
+            RefreshCheckInterval = TimeSpan.FromMinutes(5),
+        };
+
+        ValidateOptionsResult result = _sut.Validate(null, options);
+
+        result.Failed.ShouldBeTrue();
+        result.FailureMessage.ShouldContain(nameof(GranitKeyRotationOptions.RefreshCheckInterval));
+    }
+
+    [Fact]
+    public void Validate_EmptySigningAlgorithm_Fails()
+    {
+        GranitKeyRotationOptions options = new() { Enabled = true, SigningAlgorithm = "  " };
+
+        _sut.Validate(null, options).Failed.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Validate_CollectsAllFailures()
+    {
+        GranitKeyRotationOptions options = new()
+        {
+            Enabled = true,
+            RsaKeySize = 512,
+            GracePeriod = TimeSpan.Zero,
+            SigningAlgorithm = "",
+        };
+
+        ValidateOptionsResult result = _sut.Validate(null, options);
+
+        result.Failures.ShouldNotBeNull();
+        result.Failures.Count().ShouldBeGreaterThanOrEqualTo(3);
+    }
+}


### PR DESCRIPTION
## What

`GranitKeyRotationOptions` was bound with **no validation**, so a misconfigured rotation surfaced only as broken token signing at runtime. Adds `GranitKeyRotationOptionsValidator` (`IValidateOptions`) wired via `.ValidateOnStart()`:

- **`RsaKeySize`** in `[2048, 4096]`.
- **`KeyLifetime` / `GracePeriod` / `RotationLeadTime` / `RefreshCheckInterval`** must be positive.
- **`RotationLeadTime` < `KeyLifetime`** (a new key must be minted before the active one expires).
- **`RefreshCheckInterval` < `GracePeriod`** (a rotated-in key must be picked up before the retired key is revoked — matches the documented invariant).
- **`SigningAlgorithm`** non-empty.

## Design

- **Skipped when rotation is disabled** — the knobs are inert with ephemeral/configured keys, so dev startup is never blocked by an unused feature's config; only an enabled-but-misconfigured rotation fails fast.
- Runs **after** the FAPI 2.0 PS256 post-configure (`IValidateOptions` runs after `IPostConfigureOptions`).
- **All failures collected** into one `ValidateOptionsResult` for a complete error message.

This completes the options-hardening theme (resource-server validation options were done in #3124; the plan had grouped `RsaKeySize`/`GracePeriod` there but they live on this class).

## Verification

- `Granit.OpenIddict.Tests`: **285/285 green**, incl. 9 new validator tests (defaults ok, disabled-skips, out-of-range key size, non-positive grace, lead-time/refresh cross-field rules, empty algorithm, multi-failure aggregation).
- `dotnet format --verify-no-changes` clean; no lockfile change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)