### PR TITLE
fix(identity): make self-registration UserRegisteredEto durable (Phase 4, 2C-C)

### DIFF
--- a/src/Granit.Identity.Local.Endpoints/Endpoints/AccountRegistrationEndpoints.cs
+++ b/src/Granit.Identity.Local.Endpoints/Endpoints/AccountRegistrationEndpoints.cs
@@ -2,16 +2,17 @@ using System.Diagnostics;
 using Granit.Events;
 using Granit.Http.Idempotency;
 using Granit.Identity.Local.Diagnostics;
+using Granit.Identity.Local.Domain;
 using Granit.Identity.Local.Endpoints.Dtos;
 using Granit.Identity.Local.Endpoints.Internal;
 using Granit.Identity.Local.Events;
-using Granit.Identity.Local.Exceptions;
 using Granit.Identity.Local.Services;
-using Granit.Identity.Models;
 using Granit.Settings.Services;
+using Granit.Timing;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
 
@@ -64,10 +65,11 @@ internal static class AccountRegistrationEndpoints
         AccountRegisterRequest request,
         HttpContext httpContext,
         [FromServices] ISettingProvider settingProvider,
-        [FromServices] IIdentityProvider identityProvider,
+        [FromServices] UserManager<LocalIdentity> userManager,
         [FromServices] IEmailConfirmationService emailConfirmation,
         [FromServices] IDistributedEventBus eventBus,
         [FromServices] IdentityLocalMetrics metrics,
+        [FromServices] IClock clock,
         CancellationToken cancellationToken)
     {
         using Activity? activity = IdentityLocalActivitySource.Source.StartActivity(
@@ -85,37 +87,34 @@ internal static class AccountRegistrationEndpoints
                 statusCode: StatusCodes.Status403Forbidden);
         }
 
-        try
+        LocalIdentity newUser = new()
         {
-            IIdentityUser user = await identityProvider.CreateUserAsync(
-                new IdentityUserCreate(
-                    request.Email,
-                    request.Email,
-                    request.FirstName,
-                    request.LastName,
-                    true,
-                    request.Password),
-                cancellationToken).ConfigureAwait(false);
+            UserName = request.Email,
+            Email = request.Email,
+            FirstName = request.FirstName,
+            LastName = request.LastName,
 
-            await emailConfirmation.SendConfirmationEmailAsync(
-                user.UserId, request.Email, cancellationToken).ConfigureAwait(false);
+            // Stamp the registration-event intent in the same commit that inserts the user, so the
+            // reconciler can recover the UserRegisteredEto if the inline publish below is lost to a
+            // crash (the identity DbContext is not enrolled in the Wolverine outbox). This closes the
+            // gap that the provider-agnostic CreateUserAsync path (shared with admin-create, which
+            // must NOT emit the event) could not.
+            RegistrationEventPendingSince = clock.Now,
+        };
 
-            await eventBus.PublishAsync(
-                new UserRegisteredEto(Guid.Parse(user.UserId), null),
-                cancellationToken).ConfigureAwait(false);
+        IdentityResult createResult = await userManager
+            .CreateAsync(newUser, request.Password).ConfigureAwait(false);
 
-            metrics.RecordRegistration(null);
-        }
-        catch (IdentityOperationException ex) when (ex.IsConflict)
+        if (!createResult.Succeeded)
         {
-            // Silently succeed — return 202 to prevent email enumeration. Classified on the
-            // stable DuplicateUserName/DuplicateEmail error codes, not the localized message,
-            // so a host wiring a translated IdentityErrorDescriber cannot regress this path.
-            // The existing user could be notified via a "someone tried to register
-            // with your email" notification if desired (app-level concern).
-        }
-        catch (IdentityOperationException)
-        {
+            // Duplicate username/email → silently succeed (202) to prevent email enumeration.
+            // Classified on the stable Duplicate* error codes, not the localized message, so a host
+            // wiring a translated IdentityErrorDescriber cannot regress this path.
+            if (createResult.Errors.Any(e => e.Code.Contains("Duplicate", StringComparison.OrdinalIgnoreCase)))
+            {
+                return TypedResults.Accepted((string?)null);
+            }
+
             return ProblemFactory.Localized(
                 httpContext,
                 "Granit:Identity:Account:RegistrationRejected",
@@ -123,7 +122,20 @@ internal static class AccountRegistrationEndpoints
                 StatusCodes.Status422UnprocessableEntity);
         }
 
-        // Always return 202 regardless of outcome (anti-enumeration)
+        await emailConfirmation.SendConfirmationEmailAsync(
+            newUser.Id.ToString(), request.Email, cancellationToken).ConfigureAwait(false);
+
+        // Fast path: publish inline, then clear the pending marker so the reconciler skips it. A crash
+        // before the clear leaves the marker set and the sweep re-publishes (at-least-once); consumers
+        // of UserRegisteredEto are idempotent.
+        await eventBus.PublishAsync(
+            new UserRegisteredEto(newUser.Id, newUser.TenantId), cancellationToken).ConfigureAwait(false);
+
+        newUser.RegistrationEventPendingSince = null;
+        await userManager.UpdateAsync(newUser).ConfigureAwait(false);
+
+        metrics.RecordRegistration(newUser.TenantId?.ToString());
+
         return TypedResults.Accepted((string?)null);
     }
 

--- a/tests/Granit.Identity.Local.Endpoints.Tests/Integration/AccountEndpointsIntegrationTests.cs
+++ b/tests/Granit.Identity.Local.Endpoints.Tests/Integration/AccountEndpointsIntegrationTests.cs
@@ -29,14 +29,16 @@ public sealed class AccountEndpointsIntegrationTests : IAsyncLifetime
     // -------------------------------------------------------------------------
 
     [Fact]
-    public async Task Register_ValidRequest_Returns202()
+    public async Task Register_ValidRequest_Returns202_AndStampsThenClearsPendingMarker()
     {
-        IIdentityUser fakeUser = Substitute.For<IIdentityUser>();
-        fakeUser.UserId.Returns(AccountEndpointsTestServer.TestUserIdString);
-
-        _server.IdentityProvider
-            .CreateUserAsync(Arg.Any<Granit.Identity.Models.IdentityUserCreate>(), Arg.Any<CancellationToken>())
-            .Returns(fakeUser);
+        // Capture the marker at creation time — the handler clears it after the inline publish, so
+        // asserting on the (same, mutated) instance afterwards would give a false negative.
+        DateTimeOffset? markerAtCreate = null;
+        _server.UserManager
+            .CreateAsync(
+                Arg.Do<LocalIdentity>(u => markerAtCreate = u.RegistrationEventPendingSince),
+                Arg.Any<string>())
+            .Returns(Microsoft.AspNetCore.Identity.IdentityResult.Success);
 
         HttpResponseMessage response = await _server.AnonymousClient.PostAsJsonAsync(
             "/account/register",
@@ -45,27 +47,38 @@ public sealed class AccountEndpointsIntegrationTests : IAsyncLifetime
 
         response.StatusCode.ShouldBe(HttpStatusCode.Accepted);
 
+        // Durable intent stamped in the creation commit, then published and cleared.
+        markerAtCreate.ShouldNotBeNull();
+        await _server.UserManager.Received(1).CreateAsync(
+            Arg.Is<LocalIdentity>(u => u.Email == "new@example.com"), "StrongP@ss1!");
         await _server.EmailConfirmation.Received(1).SendConfirmationEmailAsync(
-            AccountEndpointsTestServer.TestUserIdString,
-            "new@example.com",
-            Arg.Any<CancellationToken>());
+            Arg.Any<string>(), "new@example.com", Arg.Any<CancellationToken>());
+        await _server.EventBus.Received(1).PublishAsync(
+            Arg.Any<UserRegisteredEto>(), Arg.Any<CancellationToken>());
+        await _server.UserManager.Received(1).UpdateAsync(
+            Arg.Is<LocalIdentity>(u => u.RegistrationEventPendingSince == null));
     }
 
     [Fact]
-    public async Task Register_EmailAlreadyTaken_StillReturns202()
+    public async Task Register_EmailAlreadyTaken_StillReturns202_AndDoesNotPublish()
     {
-        _server.IdentityProvider
-            .CreateUserAsync(Arg.Any<Granit.Identity.Models.IdentityUserCreate>(), Arg.Any<CancellationToken>())
-            .ThrowsAsync(new IdentityOperationException("User creation",
-                [new IdentityOperationError("DuplicateEmail", IdentityOperationErrorKind.DuplicateEmail, "Email already in use.")]));
+        _server.UserManager
+            .CreateAsync(Arg.Any<LocalIdentity>(), Arg.Any<string>())
+            .Returns(Microsoft.AspNetCore.Identity.IdentityResult.Failed(new Microsoft.AspNetCore.Identity.IdentityError
+            {
+                Code = "DuplicateEmail",
+                Description = "Email already in use.",
+            }));
 
         HttpResponseMessage response = await _server.AnonymousClient.PostAsJsonAsync(
             "/account/register",
             new AccountRegisterRequest("taken@example.com", "StrongP@ss1!", null, null),
             TestContext.Current.CancellationToken);
 
-        // Anti-enumeration: always 202 even if email is taken
+        // Anti-enumeration: always 202 even if email is taken, and no registration event is emitted.
         response.StatusCode.ShouldBe(HttpStatusCode.Accepted);
+        await _server.EventBus.DidNotReceive().PublishAsync(
+            Arg.Any<UserRegisteredEto>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -84,15 +97,19 @@ public sealed class AccountEndpointsIntegrationTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task Register_WeakPassword_Returns422()
+    public async Task Register_CreationRejected_Returns422()
     {
-        _server.IdentityProvider
-            .CreateUserAsync(Arg.Any<Granit.Identity.Models.IdentityUserCreate>(), Arg.Any<CancellationToken>())
-            .ThrowsAsync(new InvalidOperationException("Password too weak"));
+        _server.UserManager
+            .CreateAsync(Arg.Any<LocalIdentity>(), Arg.Any<string>())
+            .Returns(Microsoft.AspNetCore.Identity.IdentityResult.Failed(new Microsoft.AspNetCore.Identity.IdentityError
+            {
+                Code = "PasswordTooShort",
+                Description = "Password is too short.",
+            }));
 
         HttpResponseMessage response = await _server.AnonymousClient.PostAsJsonAsync(
             "/account/register",
-            new AccountRegisterRequest("user@example.com", "weak", null, null),
+            new AccountRegisterRequest("user@example.com", "StrongP@ss1!", null, null),
             TestContext.Current.CancellationToken);
 
         response.StatusCode.ShouldBe(HttpStatusCode.UnprocessableEntity);


### PR DESCRIPTION
## What

Closes the last open 2C item. Self-registration published `UserRegisteredEto` **inline after** `CreateUserAsync` had already committed, with **no durable marker** — a crash in between dropped the event, so the welcome notification and default-role assignment never ran. The external-login path already guarded this with a recovery marker; self-registration did not.

## Why the gap existed

Self-registration went through the provider-agnostic `IIdentityProvider.CreateUserAsync`, which is **shared with admin-create** (`IdentityProviderUserWriteEndpoints`) that must **not** emit the event — so the marker couldn't be baked into that path, and federated providers (Google/Firebase) implement the same abstraction.

## Fix

Self-registration is inherently local (you cannot self-register into a federated provider), so the fix lives in the local endpoint, **mirroring `AccountExternalLoginEndpoints`**:

- Build the `LocalIdentity` with `RegistrationEventPendingSince = clock.Now`, so the durable intent is stamped in the **same commit that inserts the user** (atomic — no lossy window).
- Publish inline, then clear the marker. A crash before the clear leaves it set, and the **existing generic reconciler + recurring dispatch job** (`openiddict-registration-eto-dispatch`, every 5 min) re-publish at-least-once (`UserRegisteredEto` consumers are idempotent).

Also fixes two latent bugs on this path: the event's tenant id (was hardcoded `null`, now the user's `TenantId`) and the registration metric's tenant tag.

The shared `IIdentityProvider` contract and federated providers are untouched.

## Verification

- `Granit.Identity.Local.Endpoints.Tests`: **196/196 green**. Register tests reworked to assert the marker is stamped at create (captured at call time to avoid the NSubstitute mutable-arg trap) and cleared after publish, and that a taken email returns 202 with **no** event emitted.
- `dotnet format --verify-no-changes` clean; no lockfile change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)