### PR TITLE
test(identity): deflake MinimumResponseTimeGuard no-op timing test

### DIFF
--- a/tests/Granit.Identity.Local.Endpoints.Tests/MinimumResponseTimeGuardTests.cs
+++ b/tests/Granit.Identity.Local.Endpoints.Tests/MinimumResponseTimeGuardTests.cs
@@ -48,16 +48,18 @@ public sealed class MinimumResponseTimeGuardTests
         const int floorMs = 20;
         const int handlerWorkMs = 120;
 
-        long start = Stopwatch.GetTimestamp();
-        await using (var guard = MinimumResponseTimeGuard.Begin(floorMs, floorMs, TestContext.Current.CancellationToken))
-        {
-            await Task.Delay(handlerWorkMs, TestContext.Current.CancellationToken);
-        }
-        TimeSpan elapsed = Stopwatch.GetElapsedTime(start);
+        var guard = MinimumResponseTimeGuard.Begin(floorMs, floorMs, TestContext.Current.CancellationToken);
+        await Task.Delay(handlerWorkMs, TestContext.Current.CancellationToken);
 
-        // The guard must not add extra padding once the floor is already reached.
-        // Generous upper bound to keep the test robust on slow CI runners.
-        elapsed.TotalMilliseconds.ShouldBeLessThan(handlerWorkMs + 80);
+        // Time ONLY the dispose, not the total: the handler's Task.Delay can overshoot arbitrarily on
+        // a loaded CI runner (that overshoot flaked the previous total-elapsed upper bound, see
+        // Floor_picked_within_inclusive_range). Once the floor is already exceeded, dispose must add
+        // no padding, so its own duration stays near zero regardless of how long the handler ran.
+        long disposeStart = Stopwatch.GetTimestamp();
+        await guard.DisposeAsync();
+        TimeSpan disposeElapsed = Stopwatch.GetElapsedTime(disposeStart);
+
+        disposeElapsed.TotalMilliseconds.ShouldBeLessThan(floorMs + 60);
     }
 
     [Fact]


### PR DESCRIPTION
## Problem

`MinimumResponseTimeGuardTests.DisposeAsync_is_noop_when_handler_already_exceeds_floor` is flaky on CI:

```
elapsed.TotalMilliseconds should be less than 200 but was 209.8
```

It asserted an upper bound on **total** elapsed time, which included a 120 ms `Task.Delay` simulating handler work. `Task.Delay` overshoots arbitrarily on a loaded CI runner, so the handler's overshoot was wrongly attributed to the guard. This is the exact failure mode already fixed in the sibling `Floor_picked_within_inclusive_range` test (which documents it in a comment).

## Fix

Time **only** the `DisposeAsync` call instead of the total. Once the floor is already exceeded, the guard adds no padding, so its own duration stays near zero regardless of how long the handler ran — excluding the handler delay removes the flake source. The assertion still proves the no-op property (`disposeElapsed < floorMs + 60`).

Unrelated to any feature change — surfaced on an in-flight PR's CI run.

## Verification

- `MinimumResponseTimeGuardTests`: **6/6 green**, format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)