### PR TITLE
feat(openiddict): localize query/entity definition labels (Phase 4)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -43662,6 +43662,15 @@
       "members": []
     },
     {
+      "name": "OpenIddictLocalizationResource",
+      "fqn": "Granit.OpenIddict.OpenIddictLocalizationResource",
+      "kind": "class",
+      "project": "Granit.OpenIddict",
+      "file": "src/Granit.OpenIddict/OpenIddictLocalizationResource.cs",
+      "line": 16,
+      "members": []
+    },
+    {
       "name": "OpenIddictSettingNames",
       "fqn": "Granit.OpenIddict.OpenIddictSettingNames",
       "kind": "class",
@@ -43846,6 +43855,12 @@
           "kind": "property",
           "signature": "string Name",
           "returnType": "string"
+        },
+        {
+          "name": "typeof",
+          "kind": "method",
+          "signature": "typeof(OpenIddictLocalizationResource)",
+          "returnType": "Type? LocalizationResourceType =>"
         }
       ]
     },
@@ -43862,6 +43877,12 @@
           "kind": "property",
           "signature": "string Name",
           "returnType": "string"
+        },
+        {
+          "name": "typeof",
+          "kind": "method",
+          "signature": "typeof(OpenIddictLocalizationResource)",
+          "returnType": "Type? LocalizationResourceType =>"
         }
       ]
     },

--- a/src/Granit.OpenIddict/Granit.OpenIddict.csproj
+++ b/src/Granit.OpenIddict/Granit.OpenIddict.csproj
@@ -33,4 +33,8 @@
     <ProjectReference Include="..\Granit.Identity.Abstractions\Granit.Identity.Abstractions.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <EmbeddedResource Include="Localization\**\*.json" />
+  </ItemGroup>
+
 </Project>

--- a/src/Granit.OpenIddict/Localization/OpenIddict/cs.json
+++ b/src/Granit.OpenIddict/Localization/OpenIddict/cs.json
@@ -1,0 +1,15 @@
+{
+  "culture": "cs",
+  "texts": {
+    "OpenIddict.Columns.Tenant": "Tenant",
+    "OpenIddict.Columns.ClientId": "ID klienta",
+    "OpenIddict.Columns.DisplayName": "Zobrazovaný název",
+    "OpenIddict.Columns.ClientType": "Typ klienta",
+    "OpenIddict.Columns.ConsentType": "Typ souhlasu",
+    "OpenIddict.Columns.ApplicationType": "Typ aplikace",
+    "OpenIddict.Columns.ScopeName": "Název",
+    "OpenIddict.Columns.Description": "Popis",
+    "OpenIddict:Entity.Application": "Aplikace",
+    "OpenIddict:Entity.Scope": "Rozsah"
+  }
+}

--- a/src/Granit.OpenIddict/Localization/OpenIddict/de.json
+++ b/src/Granit.OpenIddict/Localization/OpenIddict/de.json
@@ -1,0 +1,15 @@
+{
+  "culture": "de",
+  "texts": {
+    "OpenIddict.Columns.Tenant": "Mandant",
+    "OpenIddict.Columns.ClientId": "Client-ID",
+    "OpenIddict.Columns.DisplayName": "Anzeigename",
+    "OpenIddict.Columns.ClientType": "Client-Typ",
+    "OpenIddict.Columns.ConsentType": "Einwilligungstyp",
+    "OpenIddict.Columns.ApplicationType": "Anwendungstyp",
+    "OpenIddict.Columns.ScopeName": "Name",
+    "OpenIddict.Columns.Description": "Beschreibung",
+    "OpenIddict:Entity.Application": "Anwendung",
+    "OpenIddict:Entity.Scope": "Geltungsbereich"
+  }
+}

--- a/src/Granit.OpenIddict/Localization/OpenIddict/en-GB.json
+++ b/src/Granit.OpenIddict/Localization/OpenIddict/en-GB.json
@@ -1,0 +1,4 @@
+{
+  "culture": "en-GB",
+  "texts": {}
+}

--- a/src/Granit.OpenIddict/Localization/OpenIddict/en.json
+++ b/src/Granit.OpenIddict/Localization/OpenIddict/en.json
@@ -1,0 +1,15 @@
+{
+  "culture": "en",
+  "texts": {
+    "OpenIddict.Columns.Tenant": "Tenant",
+    "OpenIddict.Columns.ClientId": "Client ID",
+    "OpenIddict.Columns.DisplayName": "Display Name",
+    "OpenIddict.Columns.ClientType": "Client Type",
+    "OpenIddict.Columns.ConsentType": "Consent Type",
+    "OpenIddict.Columns.ApplicationType": "Application Type",
+    "OpenIddict.Columns.ScopeName": "Name",
+    "OpenIddict.Columns.Description": "Description",
+    "OpenIddict:Entity.Application": "Application",
+    "OpenIddict:Entity.Scope": "Scope"
+  }
+}

--- a/src/Granit.OpenIddict/Localization/OpenIddict/es.json
+++ b/src/Granit.OpenIddict/Localization/OpenIddict/es.json
@@ -1,0 +1,15 @@
+{
+  "culture": "es",
+  "texts": {
+    "OpenIddict.Columns.Tenant": "Inquilino",
+    "OpenIddict.Columns.ClientId": "ID de cliente",
+    "OpenIddict.Columns.DisplayName": "Nombre para mostrar",
+    "OpenIddict.Columns.ClientType": "Tipo de cliente",
+    "OpenIddict.Columns.ConsentType": "Tipo de consentimiento",
+    "OpenIddict.Columns.ApplicationType": "Tipo de aplicación",
+    "OpenIddict.Columns.ScopeName": "Nombre",
+    "OpenIddict.Columns.Description": "Descripción",
+    "OpenIddict:Entity.Application": "Aplicación",
+    "OpenIddict:Entity.Scope": "Ámbito"
+  }
+}

--- a/src/Granit.OpenIddict/Localization/OpenIddict/fr-CA.json
+++ b/src/Granit.OpenIddict/Localization/OpenIddict/fr-CA.json
@@ -1,0 +1,4 @@
+{
+  "culture": "fr-CA",
+  "texts": {}
+}

--- a/src/Granit.OpenIddict/Localization/OpenIddict/fr.json
+++ b/src/Granit.OpenIddict/Localization/OpenIddict/fr.json
@@ -1,0 +1,15 @@
+{
+  "culture": "fr",
+  "texts": {
+    "OpenIddict.Columns.Tenant": "Locataire",
+    "OpenIddict.Columns.ClientId": "ID client",
+    "OpenIddict.Columns.DisplayName": "Nom d'affichage",
+    "OpenIddict.Columns.ClientType": "Type de client",
+    "OpenIddict.Columns.ConsentType": "Type de consentement",
+    "OpenIddict.Columns.ApplicationType": "Type d'application",
+    "OpenIddict.Columns.ScopeName": "Nom",
+    "OpenIddict.Columns.Description": "Description",
+    "OpenIddict:Entity.Application": "Application",
+    "OpenIddict:Entity.Scope": "Portée"
+  }
+}

--- a/src/Granit.OpenIddict/Localization/OpenIddict/hi.json
+++ b/src/Granit.OpenIddict/Localization/OpenIddict/hi.json
@@ -1,0 +1,15 @@
+{
+  "culture": "hi",
+  "texts": {
+    "OpenIddict.Columns.Tenant": "Tenant",
+    "OpenIddict.Columns.ClientId": "क्लाइंट आईडी",
+    "OpenIddict.Columns.DisplayName": "प्रदर्शन नाम",
+    "OpenIddict.Columns.ClientType": "क्लाइंट प्रकार",
+    "OpenIddict.Columns.ConsentType": "सहमति प्रकार",
+    "OpenIddict.Columns.ApplicationType": "एप्लिकेशन प्रकार",
+    "OpenIddict.Columns.ScopeName": "नाम",
+    "OpenIddict.Columns.Description": "विवरण",
+    "OpenIddict:Entity.Application": "एप्लिकेशन",
+    "OpenIddict:Entity.Scope": "दायरा"
+  }
+}

--- a/src/Granit.OpenIddict/Localization/OpenIddict/it.json
+++ b/src/Granit.OpenIddict/Localization/OpenIddict/it.json
@@ -1,0 +1,15 @@
+{
+  "culture": "it",
+  "texts": {
+    "OpenIddict.Columns.Tenant": "Tenant",
+    "OpenIddict.Columns.ClientId": "ID client",
+    "OpenIddict.Columns.DisplayName": "Nome visualizzato",
+    "OpenIddict.Columns.ClientType": "Tipo di client",
+    "OpenIddict.Columns.ConsentType": "Tipo di consenso",
+    "OpenIddict.Columns.ApplicationType": "Tipo di applicazione",
+    "OpenIddict.Columns.ScopeName": "Nome",
+    "OpenIddict.Columns.Description": "Descrizione",
+    "OpenIddict:Entity.Application": "Applicazione",
+    "OpenIddict:Entity.Scope": "Ambito"
+  }
+}

--- a/src/Granit.OpenIddict/Localization/OpenIddict/ja.json
+++ b/src/Granit.OpenIddict/Localization/OpenIddict/ja.json
@@ -1,0 +1,15 @@
+{
+  "culture": "ja",
+  "texts": {
+    "OpenIddict.Columns.Tenant": "Tenant",
+    "OpenIddict.Columns.ClientId": "クライアント ID",
+    "OpenIddict.Columns.DisplayName": "表示名",
+    "OpenIddict.Columns.ClientType": "クライアントの種類",
+    "OpenIddict.Columns.ConsentType": "同意の種類",
+    "OpenIddict.Columns.ApplicationType": "アプリケーションの種類",
+    "OpenIddict.Columns.ScopeName": "名前",
+    "OpenIddict.Columns.Description": "説明",
+    "OpenIddict:Entity.Application": "アプリケーション",
+    "OpenIddict:Entity.Scope": "スコープ"
+  }
+}

--- a/src/Granit.OpenIddict/Localization/OpenIddict/ko.json
+++ b/src/Granit.OpenIddict/Localization/OpenIddict/ko.json
@@ -1,0 +1,15 @@
+{
+  "culture": "ko",
+  "texts": {
+    "OpenIddict.Columns.Tenant": "Tenant",
+    "OpenIddict.Columns.ClientId": "클라이언트 ID",
+    "OpenIddict.Columns.DisplayName": "표시 이름",
+    "OpenIddict.Columns.ClientType": "클라이언트 유형",
+    "OpenIddict.Columns.ConsentType": "동의 유형",
+    "OpenIddict.Columns.ApplicationType": "애플리케이션 유형",
+    "OpenIddict.Columns.ScopeName": "이름",
+    "OpenIddict.Columns.Description": "설명",
+    "OpenIddict:Entity.Application": "애플리케이션",
+    "OpenIddict:Entity.Scope": "범위"
+  }
+}

--- a/src/Granit.OpenIddict/Localization/OpenIddict/nl.json
+++ b/src/Granit.OpenIddict/Localization/OpenIddict/nl.json
@@ -1,0 +1,15 @@
+{
+  "culture": "nl",
+  "texts": {
+    "OpenIddict.Columns.Tenant": "Tenant",
+    "OpenIddict.Columns.ClientId": "Client-ID",
+    "OpenIddict.Columns.DisplayName": "Weergavenaam",
+    "OpenIddict.Columns.ClientType": "Clienttype",
+    "OpenIddict.Columns.ConsentType": "Toestemmingstype",
+    "OpenIddict.Columns.ApplicationType": "Applicatietype",
+    "OpenIddict.Columns.ScopeName": "Naam",
+    "OpenIddict.Columns.Description": "Beschrijving",
+    "OpenIddict:Entity.Application": "Applicatie",
+    "OpenIddict:Entity.Scope": "Bereik"
+  }
+}

--- a/src/Granit.OpenIddict/Localization/OpenIddict/pl.json
+++ b/src/Granit.OpenIddict/Localization/OpenIddict/pl.json
@@ -1,0 +1,15 @@
+{
+  "culture": "pl",
+  "texts": {
+    "OpenIddict.Columns.Tenant": "Tenant",
+    "OpenIddict.Columns.ClientId": "Identyfikator klienta",
+    "OpenIddict.Columns.DisplayName": "Nazwa wyświetlana",
+    "OpenIddict.Columns.ClientType": "Typ klienta",
+    "OpenIddict.Columns.ConsentType": "Typ zgody",
+    "OpenIddict.Columns.ApplicationType": "Typ aplikacji",
+    "OpenIddict.Columns.ScopeName": "Nazwa",
+    "OpenIddict.Columns.Description": "Opis",
+    "OpenIddict:Entity.Application": "Aplikacja",
+    "OpenIddict:Entity.Scope": "Zakres"
+  }
+}

--- a/src/Granit.OpenIddict/Localization/OpenIddict/pt-BR.json
+++ b/src/Granit.OpenIddict/Localization/OpenIddict/pt-BR.json
@@ -1,0 +1,7 @@
+{
+  "culture": "pt-BR",
+  "texts": {
+    "OpenIddict.Columns.DisplayName": "Nome de exibição",
+    "OpenIddict:Entity.Scope": "Escopo"
+  }
+}

--- a/src/Granit.OpenIddict/Localization/OpenIddict/pt.json
+++ b/src/Granit.OpenIddict/Localization/OpenIddict/pt.json
@@ -1,0 +1,15 @@
+{
+  "culture": "pt",
+  "texts": {
+    "OpenIddict.Columns.Tenant": "Tenant",
+    "OpenIddict.Columns.ClientId": "ID do cliente",
+    "OpenIddict.Columns.DisplayName": "Nome a apresentar",
+    "OpenIddict.Columns.ClientType": "Tipo de cliente",
+    "OpenIddict.Columns.ConsentType": "Tipo de consentimento",
+    "OpenIddict.Columns.ApplicationType": "Tipo de aplicação",
+    "OpenIddict.Columns.ScopeName": "Nome",
+    "OpenIddict.Columns.Description": "Descrição",
+    "OpenIddict:Entity.Application": "Aplicação",
+    "OpenIddict:Entity.Scope": "Âmbito"
+  }
+}

--- a/src/Granit.OpenIddict/Localization/OpenIddict/sv.json
+++ b/src/Granit.OpenIddict/Localization/OpenIddict/sv.json
@@ -1,0 +1,15 @@
+{
+  "culture": "sv",
+  "texts": {
+    "OpenIddict.Columns.Tenant": "Tenant",
+    "OpenIddict.Columns.ClientId": "Klient-ID",
+    "OpenIddict.Columns.DisplayName": "Visningsnamn",
+    "OpenIddict.Columns.ClientType": "Klienttyp",
+    "OpenIddict.Columns.ConsentType": "Samtyckestyp",
+    "OpenIddict.Columns.ApplicationType": "Applikationstyp",
+    "OpenIddict.Columns.ScopeName": "Namn",
+    "OpenIddict.Columns.Description": "Beskrivning",
+    "OpenIddict:Entity.Application": "Applikation",
+    "OpenIddict:Entity.Scope": "Omfattning"
+  }
+}

--- a/src/Granit.OpenIddict/Localization/OpenIddict/tr.json
+++ b/src/Granit.OpenIddict/Localization/OpenIddict/tr.json
@@ -1,0 +1,15 @@
+{
+  "culture": "tr",
+  "texts": {
+    "OpenIddict.Columns.Tenant": "Tenant",
+    "OpenIddict.Columns.ClientId": "İstemci kimliği",
+    "OpenIddict.Columns.DisplayName": "Görünen ad",
+    "OpenIddict.Columns.ClientType": "İstemci türü",
+    "OpenIddict.Columns.ConsentType": "Onay türü",
+    "OpenIddict.Columns.ApplicationType": "Uygulama türü",
+    "OpenIddict.Columns.ScopeName": "Ad",
+    "OpenIddict.Columns.Description": "Açıklama",
+    "OpenIddict:Entity.Application": "Uygulama",
+    "OpenIddict:Entity.Scope": "Kapsam"
+  }
+}

--- a/src/Granit.OpenIddict/Localization/OpenIddict/zh.json
+++ b/src/Granit.OpenIddict/Localization/OpenIddict/zh.json
@@ -1,0 +1,15 @@
+{
+  "culture": "zh",
+  "texts": {
+    "OpenIddict.Columns.Tenant": "Tenant",
+    "OpenIddict.Columns.ClientId": "客户端 ID",
+    "OpenIddict.Columns.DisplayName": "显示名称",
+    "OpenIddict.Columns.ClientType": "客户端类型",
+    "OpenIddict.Columns.ConsentType": "同意类型",
+    "OpenIddict.Columns.ApplicationType": "应用程序类型",
+    "OpenIddict.Columns.ScopeName": "名称",
+    "OpenIddict.Columns.Description": "描述",
+    "OpenIddict:Entity.Application": "应用程序",
+    "OpenIddict:Entity.Scope": "范围"
+  }
+}

--- a/src/Granit.OpenIddict/OpenIddictLocalizationResource.cs
+++ b/src/Granit.OpenIddict/OpenIddictLocalizationResource.cs
@@ -1,0 +1,16 @@
+using Granit.Localization;
+
+namespace Granit.OpenIddict;
+
+/// <summary>
+/// Marker class for the <c>OpenIddict</c> localization resource.
+/// JSON files: <c>Localization/OpenIddict/{culture}.json</c>, embedded in this assembly.
+/// Auto-discovered by <see cref="LocalizationResourceNameAttribute"/>.
+/// </summary>
+/// <remarks>
+/// Backs the <c>LabelKey</c>/<c>DisplayKey</c> values on the OpenIddict application and scope
+/// query and entity definitions (e.g. <c>OpenIddict.Columns.ClientId</c>,
+/// <c>OpenIddict:Entity.Scope</c>).
+/// </remarks>
+[LocalizationResourceName("OpenIddict", DefaultCulture = "en")]
+public sealed class OpenIddictLocalizationResource;

--- a/src/Granit.OpenIddict/Queries/GranitOpenIddictApplicationQueryDefinition.cs
+++ b/src/Granit.OpenIddict/Queries/GranitOpenIddictApplicationQueryDefinition.cs
@@ -13,6 +13,9 @@ public sealed class GranitOpenIddictApplicationQueryDefinition : QueryDefinition
     public override string Name => "Granit.OpenIddict.ApplicationQuery";
 
     /// <inheritdoc/>
+    public override Type? LocalizationResourceType => typeof(OpenIddictLocalizationResource);
+
+    /// <inheritdoc/>
     protected override void Configure(QueryDefinitionBuilder<OpenIddictApplicationModel> builder)
     {
         builder

--- a/src/Granit.OpenIddict/Queries/GranitOpenIddictScopeQueryDefinition.cs
+++ b/src/Granit.OpenIddict/Queries/GranitOpenIddictScopeQueryDefinition.cs
@@ -13,6 +13,9 @@ public sealed class GranitOpenIddictScopeQueryDefinition : QueryDefinition<OpenI
     public override string Name => "Granit.OpenIddict.ScopeQuery";
 
     /// <inheritdoc/>
+    public override Type? LocalizationResourceType => typeof(OpenIddictLocalizationResource);
+
+    /// <inheritdoc/>
     protected override void Configure(QueryDefinitionBuilder<OpenIddictScopeModel> builder)
     {
         builder


### PR DESCRIPTION
## What

The OpenIddict application/scope **query column `LabelKey`s** and **entity `DisplayKey`s** (`OpenIddict.Columns.*`, `OpenIddict:Entity.*`) had no backing localization resource, so admin grids/manifests rendered raw keys instead of localized labels. This adds the resource and wires it up.

- `OpenIddictLocalizationResource` marker (`[LocalizationResourceName("OpenIddict", DefaultCulture = "en")]`), auto-discovered, with `Localization/OpenIddict/{culture}.json` embedded — **all 18 cultures**.
- Both query definitions now override `LocalizationResourceType => typeof(OpenIddictLocalizationResource)`, mirroring the established `BlobStorage` / `AI.Prompts` / `Webhooks` pattern.

## Translations

- **15 base cultures** carry full translations of the 10 labels: Tenant, Client ID, Display Name, Client/Consent/Application Type, Name, Description, Application, Scope. `Tenant` reuses `Granit.BlobStorage`'s values (Locataire / Mandant / Inquilino / …) for cross-module consistency.
- **Regional files carry only differing keys** (per the langues convention): `en-GB` and `fr-CA` inherit their base entirely (empty `texts`); `pt-BR` overrides only Display Name (`Nome de exibição`) and Scope (`Escopo`) with the Brazilian forms vs European `pt`.

## Verification

- `LocalizationFileShapeTests`: green (all 18 files match the `{ culture, texts }` envelope and the culture ↔ filename check).
- `Granit.OpenIddict.Tests`: **285/285 green**.
- `dotnet format --verify-no-changes` clean; **no lockfile change** (`Granit.Localization` is already transitive, matching BlobStorage which also references it transitively).

🤖 Generated with [Claude Code](https://claude.com/claude-code)