### PR TITLE
fix(odata): restore silent $top clamp instead of 400 (QueryHardening regression)

### DIFF
--- a/src/Granit.Http.ODataExposure/Extensions/ODataExposureEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Http.ODataExposure/Extensions/ODataExposureEndpointRouteBuilderExtensions.cs
@@ -706,6 +706,12 @@ public static class ODataExposureEndpointRouteBuilderExtensions
 
         ApplyMaxTopAppliedHeader(httpContext, descriptor, metrics, tenantTag, feedKindTag);
 
+        // #1392 silent-clamp contract: an over-cap $top is pinned down to MaxTop BEFORE
+        // validation so options.Validate() — which enforces the model-bound MaxTop set via
+        // SetMaxTop and would otherwise return 400 — accepts it. ApplyTo applies the same cap;
+        // the OData-MaxTop-Applied header was already emitted above from the original value.
+        options = ClampTopToCap(options, httpContext, descriptor.MaxTop);
+
         // #3004 — the user's $filter is translated into the engine's strict predicate tree
         // instead of being composed as arbitrary LINQ by ApplyTo. Untranslatable constructs
         // return 400 here; field-level violations return 400 from BuildFilteredQuery below.
@@ -1084,6 +1090,45 @@ public static class ODataExposureEndpointRouteBuilderExtensions
     /// to observability tooling. Also bumps the rejected-query counter for
     /// the same reason.
     /// </summary>
+    /// <summary>
+    /// Pins an over-cap user <c>$top</c> down to the EntitySet's
+    /// <see cref="ODataEntitySetDescriptor.MaxTop"/> by rewriting the request query string and
+    /// re-parsing the options. Preserves the historical silent-clamp contract (#1392): a
+    /// <c>$top</c> above the cap is served capped, not rejected — the downstream
+    /// <c>options.Validate</c> enforces the model-bound MaxTop and would otherwise return 400.
+    /// No-op when <c>$top</c> is absent or already within the cap.
+    /// </summary>
+    private static ODataQueryOptions<TEntity> ClampTopToCap<TEntity>(
+        ODataQueryOptions<TEntity> options,
+        HttpContext httpContext,
+        int maxTop)
+        where TEntity : class
+    {
+        if (options.Top is not { Value: int requested } || requested <= maxTop)
+        {
+            return options;
+        }
+
+        List<KeyValuePair<string, string?>> query = [];
+        foreach ((string key, StringValues values) in httpContext.Request.Query)
+        {
+            if (string.Equals(key, "$top", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            foreach (string? value in values)
+            {
+                query.Add(new(key, value));
+            }
+        }
+
+        query.Add(new("$top", maxTop.ToString(System.Globalization.CultureInfo.InvariantCulture)));
+        httpContext.Request.QueryString = QueryString.Create(query);
+
+        return new ODataQueryOptions<TEntity>(options.Context, httpContext.Request);
+    }
+
     private static void ApplyMaxTopAppliedHeader(
         HttpContext httpContext,
         ODataEntitySetDescriptor descriptor,


### PR DESCRIPTION
## Problem

`QueryHardeningTests.MaxTop_RequestAboveCap_ResponseSilentlyClamped_AndHeaderEmitted` fails: `$top=1000000` against an EntitySet with `MaxTop=5` returns **400** instead of a silently-clamped **200**.

```
"detail":"The limit of '5' for Top query has been exceeded. The value from the incoming request is '1000000'."
```

## Root cause

The per-EntitySet `$top` cap (#1392) is a **silent clamp**: over-cap `$top` → 200, data capped, `OData-MaxTop-Applied` header emitted — so BI refresh jobs sending a large `$top` keep working.

- `MaxTop` is set model-bound via `SetMaxTop(descriptor.MaxTop)`, which makes `ApplyTo` clamp `$top` correctly (verified: bypassing validation makes the test pass).
- The OData-hardening work (#3032/#3034) added an explicit `options.Validate()` call. Because the cap is model-bound, `Validate()` **also** enforces it and **rejects** `$top > MaxTop` with 400 — breaking the clamp contract.
- #3077 then broke the integration shard's **compilation** (unrelated `CS1929`), so `QueryHardeningTests` stopped running. The regression stayed hidden until the shard compiled again (#3126).

This is **not** a security hole (over-cap `$top` was being rejected, not served) — it's a broken UX/observability contract.

## Fix

Pin an over-cap `$top` down to `MaxTop` **before** validation (rewrite the query string, re-parse the options). `Validate()` then accepts the compliant value and `ApplyTo` applies the same cap — the silent-clamp contract is restored **with full validation coverage intact** (orderby whitelist, expansion depth, node count, disallowed options all still enforced). The `OData-MaxTop-Applied` header is still emitted from the original request value. No-op when `$top` is absent or within the cap.

## Verification

- `Granit.Http.ODataExposure.Tests.Integration`: **56/56** green (incl. the previously-failing clamp test; no regression in expand/filter/count/orderby/tenant-isolation/rate-limiting).
- `Granit.Http.ODataExposure.Tests`: **143/143** green.
- `dotnet format --verify-no-changes`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)