### PR TITLE
feat(openiddict)!: paginate admin OIDC lists with PagedResult envelope (Phase 4)

### DIFF
--- a/src/Granit.OpenIddict.Endpoints/Endpoints/AdminOidcEndpoints.cs
+++ b/src/Granit.OpenIddict.Endpoints/Endpoints/AdminOidcEndpoints.cs
@@ -7,6 +7,7 @@ using Granit.OpenIddict.Endpoints.Dtos;
 using Granit.OpenIddict.Extensions;
 using Granit.OpenIddict.Models;
 using Granit.OpenIddict.Permissions;
+using Granit.QueryEngine;
 using Granit.Validation.AspNetCore;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
@@ -20,6 +21,9 @@ namespace Granit.OpenIddict.Endpoints.Endpoints;
 
 internal static class AdminOidcEndpoints
 {
+    private const int DefaultPageSize = 25;
+    private const int MaxPageSize = 100;
+
     internal static RouteGroupBuilder MapAdminOidcEndpoints(this RouteGroupBuilder group)
     {
         // ──── Applications ────
@@ -28,9 +32,9 @@ internal static class AdminOidcEndpoints
         apps.MapGet("/", ListApplicationsAsync)
             .WithMetadata(new EntityEndpointMetadata(typeof(OpenIddictApplicationModel), EntityEndpointKind.List))
             .WithName("ListOidcApplications")
-            .WithSummary("Returns all OIDC applications.")
-            .WithDescription("Returns all registered OIDC client applications with their full configuration: client ID, display name, type, tenant, permissions, redirect URIs, consent type, and signing-key presence. Use this list to manage the registered clients in the admin panel.")
-            .Produces<IReadOnlyList<AdminOidcApplicationResponse>>()
+            .WithSummary("Returns a page of OIDC applications.")
+            .WithDescription("Returns a page of registered OIDC client applications with their full configuration: client ID, display name, type, tenant, permissions, redirect URIs, consent type, and signing-key presence. Paginated via the 'page' (1-based, default 1) and 'pageSize' (default 25, max 100) query parameters; the envelope carries the total count and a has-more flag.")
+            .Produces<PagedResult<AdminOidcApplicationResponse>>()
             .RequireAuthorization(OpenIddictPermissions.Applications.Read);
 
         apps.MapGet("/{clientId}", GetApplicationAsync)
@@ -90,9 +94,9 @@ internal static class AdminOidcEndpoints
         scopes.MapGet("/", ListScopesAsync)
             .WithMetadata(new EntityEndpointMetadata(typeof(OpenIddictScopeModel), EntityEndpointKind.List))
             .WithName("ListOidcScopes")
-            .WithSummary("Returns all OIDC scopes.")
-            .WithDescription("Returns all registered OIDC scopes with their name, display name, and associated resources. Scopes define the claims and resources that tokens can grant access to. Use this endpoint to audit which scopes are available for client configuration.")
-            .Produces<IReadOnlyList<AdminOidcScopeResponse>>()
+            .WithSummary("Returns a page of OIDC scopes.")
+            .WithDescription("Returns a page of registered OIDC scopes with their name, display name, and associated resources. Scopes define the claims and resources that tokens can grant access to. Paginated via the 'page' (1-based, default 1) and 'pageSize' (default 25, max 100) query parameters; the envelope carries the total count and a has-more flag.")
+            .Produces<PagedResult<AdminOidcScopeResponse>>()
             .RequireAuthorization(OpenIddictPermissions.Scopes.Read);
 
         scopes.MapPost("/", CreateScopeAsync)
@@ -140,9 +144,9 @@ internal static class AdminOidcEndpoints
 
         auths.MapGet("/", ListAuthorizationsAsync)
             .WithName("ListOidcAuthorizations")
-            .WithSummary("Returns OIDC authorizations.")
-            .WithDescription("Returns up to the first 100 OIDC authorizations. Each authorization represents a user's consent grant to an application, with its status (valid, revoked) and type (permanent, ad-hoc). Server-side filtering by user or client and pagination are not yet implemented.")
-            .Produces<IReadOnlyList<AdminOidcAuthorizationResponse>>()
+            .WithSummary("Returns a page of OIDC authorizations.")
+            .WithDescription("Returns a page of OIDC authorizations. Each authorization represents a user's consent grant to an application, with its status (valid, revoked) and type (permanent, ad-hoc). Paginated via the 'page' (1-based, default 1) and 'pageSize' (default 25, max 100) query parameters; the envelope carries the total count and a has-more flag. Server-side filtering by user or client is not yet implemented.")
+            .Produces<PagedResult<AdminOidcAuthorizationResponse>>()
             .RequireAuthorization(OpenIddictPermissions.Authorizations.Read);
 
         auths.MapDelete("/{authorizationId:guid}", RevokeAuthorizationAsync)
@@ -185,13 +189,16 @@ internal static class AdminOidcEndpoints
         return TypedResults.Ok(ToResponse(descriptor, tenantId));
     }
 
-    private static async Task<Ok<IReadOnlyList<AdminOidcApplicationResponse>>> ListApplicationsAsync(
+    private static async Task<Ok<PagedResult<AdminOidcApplicationResponse>>> ListApplicationsAsync(
         [FromServices] IOpenIddictApplicationManager applicationManager,
+        [FromQuery] int? page,
+        [FromQuery] int? pageSize,
         CancellationToken cancellationToken)
     {
+        (int size, int offset) = ResolvePaging(page, pageSize);
         var results = new List<AdminOidcApplicationResponse>();
 
-        await foreach (object app in applicationManager.ListAsync(null, null, cancellationToken).ConfigureAwait(false))
+        await foreach (object app in applicationManager.ListAsync(size, offset, cancellationToken).ConfigureAwait(false))
         {
             var descriptor = new OpenIddictApplicationDescriptor();
             await applicationManager.PopulateAsync(descriptor, app, cancellationToken).ConfigureAwait(false);
@@ -199,7 +206,9 @@ internal static class AdminOidcEndpoints
             results.Add(ToResponse(descriptor, tenantId));
         }
 
-        return TypedResults.Ok<IReadOnlyList<AdminOidcApplicationResponse>>(results);
+        long total = await applicationManager.CountAsync(cancellationToken).ConfigureAwait(false);
+        return TypedResults.Ok(new PagedResult<AdminOidcApplicationResponse>(
+            results, (int)total, offset + results.Count < total));
     }
 
     private static async Task<Results<Created<AdminOidcApplicationResponse>, ProblemHttpResult>> CreateApplicationAsync(
@@ -443,13 +452,16 @@ internal static class AdminOidcEndpoints
 
     // ──── Scope handlers ────
 
-    private static async Task<Ok<IReadOnlyList<AdminOidcScopeResponse>>> ListScopesAsync(
+    private static async Task<Ok<PagedResult<AdminOidcScopeResponse>>> ListScopesAsync(
         [FromServices] IOpenIddictScopeManager scopeManager,
+        [FromQuery] int? page,
+        [FromQuery] int? pageSize,
         CancellationToken cancellationToken)
     {
+        (int size, int offset) = ResolvePaging(page, pageSize);
         var results = new List<AdminOidcScopeResponse>();
 
-        await foreach (object scope in scopeManager.ListAsync(null, null, cancellationToken).ConfigureAwait(false))
+        await foreach (object scope in scopeManager.ListAsync(size, offset, cancellationToken).ConfigureAwait(false))
         {
             var descriptor = new OpenIddictScopeDescriptor();
             await scopeManager.PopulateAsync(descriptor, scope, cancellationToken).ConfigureAwait(false);
@@ -457,7 +469,9 @@ internal static class AdminOidcEndpoints
             results.Add(ToScopeResponse(descriptor, tenantId));
         }
 
-        return TypedResults.Ok<IReadOnlyList<AdminOidcScopeResponse>>(results);
+        long total = await scopeManager.CountAsync(cancellationToken).ConfigureAwait(false);
+        return TypedResults.Ok(new PagedResult<AdminOidcScopeResponse>(
+            results, (int)total, offset + results.Count < total));
     }
 
     private static async Task<Results<Created<AdminOidcScopeResponse>, ProblemHttpResult>> CreateScopeAsync(
@@ -614,15 +628,18 @@ internal static class AdminOidcEndpoints
                 [.. descriptor.Scopes]));
     }
 
-    private static async Task<Ok<IReadOnlyList<AdminOidcAuthorizationResponse>>> ListAuthorizationsAsync(
+    private static async Task<Ok<PagedResult<AdminOidcAuthorizationResponse>>> ListAuthorizationsAsync(
         [FromServices] IOpenIddictAuthorizationManager authorizationManager,
         [FromServices] IOpenIddictApplicationManager applicationManager,
+        [FromQuery] int? page,
+        [FromQuery] int? pageSize,
         CancellationToken cancellationToken)
     {
+        (int size, int offset) = ResolvePaging(page, pageSize);
         var results = new List<AdminOidcAuthorizationResponse>();
         var clientIdCache = new Dictionary<string, string?>(StringComparer.Ordinal);
 
-        await foreach (object auth in authorizationManager.ListAsync(100, 0, cancellationToken).ConfigureAwait(false))
+        await foreach (object auth in authorizationManager.ListAsync(size, offset, cancellationToken).ConfigureAwait(false))
         {
             string? id = await authorizationManager.GetIdAsync(auth, cancellationToken).ConfigureAwait(false);
             var descriptor = new OpenIddictAuthorizationDescriptor();
@@ -645,7 +662,21 @@ internal static class AdminOidcEndpoints
                 [.. descriptor.Scopes]));
         }
 
-        return TypedResults.Ok<IReadOnlyList<AdminOidcAuthorizationResponse>>(results);
+        long total = await authorizationManager.CountAsync(cancellationToken).ConfigureAwait(false);
+        return TypedResults.Ok(new PagedResult<AdminOidcAuthorizationResponse>(
+            results, (int)total, offset + results.Count < total));
+    }
+
+    /// <summary>
+    /// Resolves 1-based <paramref name="page"/> / <paramref name="pageSize"/> query parameters into a
+    /// clamped page size (1–<see cref="MaxPageSize"/>, default <see cref="DefaultPageSize"/>) and a
+    /// zero-based row offset for the OpenIddict manager's <c>ListAsync(count, offset)</c>.
+    /// </summary>
+    private static (int Size, int Offset) ResolvePaging(int? page, int? pageSize)
+    {
+        int size = Math.Clamp(pageSize ?? DefaultPageSize, 1, MaxPageSize);
+        int pageNumber = Math.Max(page ?? 1, 1);
+        return (size, (pageNumber - 1) * size);
     }
 
     private static async Task<Results<NoContent, ProblemHttpResult>> RevokeAuthorizationAsync(

--- a/tests/Granit.OpenIddict.Endpoints.Tests/Integration/AdminOidcEndpointsIntegrationTests.cs
+++ b/tests/Granit.OpenIddict.Endpoints.Tests/Integration/AdminOidcEndpointsIntegrationTests.cs
@@ -4,6 +4,7 @@ using Granit.Identity;
 using Granit.OpenIddict.Endpoints.Dtos;
 using Granit.OpenIddict.EntityFrameworkCore.Entities;
 using Granit.OpenIddict.Extensions;
+using Granit.QueryEngine;
 using NSubstitute;
 using OpenIddict.Abstractions;
 using Shouldly;
@@ -33,11 +34,11 @@ public sealed class AdminOidcEndpointsIntegrationTests : IAsyncLifetime
 
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
 
-        List<AdminOidcApplicationResponse>? result = await response.Content
-            .ReadFromJsonAsync<List<AdminOidcApplicationResponse>>(TestContext.Current.CancellationToken);
+        PagedResult<AdminOidcApplicationResponse>? page = await response.Content
+            .ReadFromJsonAsync<PagedResult<AdminOidcApplicationResponse>>(TestContext.Current.CancellationToken);
 
-        result.ShouldNotBeNull();
-        result.ShouldBeEmpty();
+        page.ShouldNotBeNull();
+        page.Items.ShouldBeEmpty();
     }
 
     [Fact]
@@ -48,6 +49,7 @@ public sealed class AdminOidcEndpointsIntegrationTests : IAsyncLifetime
 
         _server.ApplicationManager.ListAsync(Arg.Any<int?>(), Arg.Any<int?>(), Arg.Any<CancellationToken>())
             .Returns(ToAsyncEnumerable<object>(app1, app2));
+        _server.ApplicationManager.CountAsync(Arg.Any<CancellationToken>()).Returns(2L);
 
 #pragma warning disable CA2012 // NSubstitute mock setup intentionally doesn't await ValueTask
         _server.ApplicationManager
@@ -78,16 +80,18 @@ public sealed class AdminOidcEndpointsIntegrationTests : IAsyncLifetime
 
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
 
-        List<AdminOidcApplicationResponse>? result = await response.Content
-            .ReadFromJsonAsync<List<AdminOidcApplicationResponse>>(TestContext.Current.CancellationToken);
+        PagedResult<AdminOidcApplicationResponse>? page = await response.Content
+            .ReadFromJsonAsync<PagedResult<AdminOidcApplicationResponse>>(TestContext.Current.CancellationToken);
 
-        result.ShouldNotBeNull();
+        page.ShouldNotBeNull();
+        page.TotalCount.ShouldBe(2);
+        page.HasMore.ShouldBeFalse();
+        IReadOnlyList<AdminOidcApplicationResponse> result = page.Items;
         result.Count.ShouldBe(2);
 
-        // The list must not silently cap: no count/offset is passed to the manager, so every
-        // registered application is returned.
+        // Default paging: the first page of 25 rows is requested from offset 0.
         _ = _server.ApplicationManager.Received(1)
-            .ListAsync(null, null, Arg.Any<CancellationToken>());
+            .ListAsync(25, 0, Arg.Any<CancellationToken>());
 
         result[0].ClientId.ShouldBe("client-1");
         result[0].DisplayName.ShouldBe("App One");
@@ -440,11 +444,11 @@ public sealed class AdminOidcEndpointsIntegrationTests : IAsyncLifetime
 
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
 
-        List<AdminOidcScopeResponse>? result = await response.Content
-            .ReadFromJsonAsync<List<AdminOidcScopeResponse>>(TestContext.Current.CancellationToken);
+        PagedResult<AdminOidcScopeResponse>? page = await response.Content
+            .ReadFromJsonAsync<PagedResult<AdminOidcScopeResponse>>(TestContext.Current.CancellationToken);
 
-        result.ShouldNotBeNull();
-        result.ShouldBeEmpty();
+        page.ShouldNotBeNull();
+        page.Items.ShouldBeEmpty();
     }
 
     [Fact]
@@ -455,6 +459,7 @@ public sealed class AdminOidcEndpointsIntegrationTests : IAsyncLifetime
 
         _server.ScopeManager.ListAsync(Arg.Any<int?>(), Arg.Any<int?>(), Arg.Any<CancellationToken>())
             .Returns(ToAsyncEnumerable<object>(scope1, scope2));
+        _server.ScopeManager.CountAsync(Arg.Any<CancellationToken>()).Returns(2L);
 
 #pragma warning disable CA2012
         _server.ScopeManager
@@ -482,10 +487,12 @@ public sealed class AdminOidcEndpointsIntegrationTests : IAsyncLifetime
 
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
 
-        List<AdminOidcScopeResponse>? result = await response.Content
-            .ReadFromJsonAsync<List<AdminOidcScopeResponse>>(TestContext.Current.CancellationToken);
+        PagedResult<AdminOidcScopeResponse>? page = await response.Content
+            .ReadFromJsonAsync<PagedResult<AdminOidcScopeResponse>>(TestContext.Current.CancellationToken);
 
-        result.ShouldNotBeNull();
+        page.ShouldNotBeNull();
+        page.TotalCount.ShouldBe(2);
+        IReadOnlyList<AdminOidcScopeResponse> result = page.Items;
         result.Count.ShouldBe(2);
 
         result[0].Name.ShouldBe("openid");
@@ -642,11 +649,11 @@ public sealed class AdminOidcEndpointsIntegrationTests : IAsyncLifetime
 
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
 
-        List<AdminOidcAuthorizationResponse>? result = await response.Content
-            .ReadFromJsonAsync<List<AdminOidcAuthorizationResponse>>(TestContext.Current.CancellationToken);
+        PagedResult<AdminOidcAuthorizationResponse>? page = await response.Content
+            .ReadFromJsonAsync<PagedResult<AdminOidcAuthorizationResponse>>(TestContext.Current.CancellationToken);
 
-        result.ShouldNotBeNull();
-        result.ShouldBeEmpty();
+        page.ShouldNotBeNull();
+        page.Items.ShouldBeEmpty();
     }
 
     [Fact]
@@ -656,8 +663,9 @@ public sealed class AdminOidcEndpointsIntegrationTests : IAsyncLifetime
         object auth1 = new();
         object app1 = new();
 
-        _server.AuthorizationManager.ListAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+        _server.AuthorizationManager.ListAsync(Arg.Any<int?>(), Arg.Any<int?>(), Arg.Any<CancellationToken>())
             .Returns(ToAsyncEnumerable<object>(auth1));
+        _server.AuthorizationManager.CountAsync(Arg.Any<CancellationToken>()).Returns(1L);
 
         _server.AuthorizationManager.GetIdAsync(auth1, Arg.Any<CancellationToken>())
             .Returns(authId.ToString());
@@ -688,10 +696,12 @@ public sealed class AdminOidcEndpointsIntegrationTests : IAsyncLifetime
 
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
 
-        List<AdminOidcAuthorizationResponse>? result = await response.Content
-            .ReadFromJsonAsync<List<AdminOidcAuthorizationResponse>>(TestContext.Current.CancellationToken);
+        PagedResult<AdminOidcAuthorizationResponse>? page = await response.Content
+            .ReadFromJsonAsync<PagedResult<AdminOidcAuthorizationResponse>>(TestContext.Current.CancellationToken);
 
-        result.ShouldNotBeNull();
+        page.ShouldNotBeNull();
+        page.TotalCount.ShouldBe(1);
+        IReadOnlyList<AdminOidcAuthorizationResponse> result = page.Items;
         result.Count.ShouldBe(1);
         result[0].Id.ShouldBe(authId);
         result[0].Subject.ShouldBe("user-123");


### PR DESCRIPTION
## What

The admin **application / scope / authorization list** endpoints returned bare JSON arrays, and the authorization list was **hardcoded to the first 100 rows** with no way to page further. This adopts the framework's `PagedResult<T>` envelope — already the admin-list contract for `ApiKey` / `ChatMessages` / `Workflow` endpoints — across all three OIDC admin lists.

- Accept `page` (1-based, default 1) and `pageSize` (default 25, clamped to `[1, 100]`) query parameters; offset = `(page-1)*pageSize`.
- Return `PagedResult<T> { items, totalCount, hasMore }` — `totalCount` from the manager's `CountAsync`, `hasMore` from `offset + pageLength < total`.
- Honest OpenAPI descriptions; the authorizations list no longer claims a fixed 100-row cap.

## ⚠️ Breaking

The three list responses change shape from `T[]` to `PagedResult<T>` (items move under `.items`). Pre-1.0, and this aligns the OIDC admin API with the rest of the Granit admin surface. Front-end grids consuming these lists must read `.items` / `.totalCount`.

## Verification

- `Granit.OpenIddict.Endpoints.Tests`: **132/132 green** (list tests now assert the envelope: `totalCount`, `hasMore`, default paging `ListAsync(25, 0)`).
- `ApiConvention` / `OpenApiGeneratorCompleteness` / `ValidationStatusCode` architecture tests: **12/12 green**.
- `dotnet format --verify-no-changes` clean; **no lockfile change** (`PagedResult<T>` ships in the already-referenced `Granit.QueryEngine.Abstractions`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)