### PR TITLE
feat(openiddict): server-side client secret generation on create (Phase 4)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -43160,7 +43160,7 @@
       "kind": "record",
       "project": "Granit.OpenIddict.Endpoints",
       "file": "src/Granit.OpenIddict.Endpoints/Dtos/AdminOidcApplicationResponse.cs",
-      "line": 20,
+      "line": 22,
       "members": []
     },
     {
@@ -43178,7 +43178,7 @@
       "kind": "record",
       "project": "Granit.OpenIddict.Endpoints",
       "file": "src/Granit.OpenIddict.Endpoints/Dtos/AdminOidcCreateApplicationRequest.cs",
-      "line": 22,
+      "line": 23,
       "members": []
     },
     {

--- a/src/Granit.OpenIddict.Endpoints/Dtos/AdminOidcApplicationResponse.cs
+++ b/src/Granit.OpenIddict.Endpoints/Dtos/AdminOidcApplicationResponse.cs
@@ -17,6 +17,8 @@ namespace Granit.OpenIddict.Endpoints.Dtos;
 /// <param name="ClientSide">The host/tenant policy enforced at sign-in, or <see langword="null"/> for no restriction.</param>
 /// <param name="DeviceKind">The device classification declared for this client, or <see langword="null"/> when not declared.</param>
 /// <param name="HasSigningKey">Whether a public signing key (JWK) is registered for <c>private_key_jwt</c> authentication.</param>
+/// <param name="GeneratedClientSecret">The server-minted client secret, present <em>only</em> on the create response when <c>GenerateClientSecret</c> was requested. Shown once and never stored in plaintext — the admin must capture it now. <see langword="null"/> on every other response.</param>
+#pragma warning disable GRSEC003 // GeneratedClientSecret is returned once to the admin, not stored
 public sealed record AdminOidcApplicationResponse(
     string? ClientId,
     string? DisplayName,
@@ -28,4 +30,6 @@ public sealed record AdminOidcApplicationResponse(
     string? ConsentType,
     MultiTenancySides? ClientSide,
     DeviceKind? DeviceKind,
-    bool HasSigningKey);
+    bool HasSigningKey,
+    string? GeneratedClientSecret = null);
+#pragma warning restore GRSEC003

--- a/src/Granit.OpenIddict.Endpoints/Dtos/AdminOidcCreateApplicationRequest.cs
+++ b/src/Granit.OpenIddict.Endpoints/Dtos/AdminOidcCreateApplicationRequest.cs
@@ -8,7 +8,7 @@ namespace Granit.OpenIddict.Endpoints.Dtos;
 /// </summary>
 /// <param name="ClientId">The client identifier (unique).</param>
 /// <param name="DisplayName">A human-readable display name.</param>
-/// <param name="ClientSecret">The client secret (null for public clients). Omit or set to null for public clients.</param>
+/// <param name="ClientSecret">The client secret (null for public clients). Omit or set to null for public clients. Ignored when <paramref name="GenerateClientSecret"/> is <see langword="true"/>.</param>
 /// <param name="Type">The application type (<c>web</c>, <c>native</c>). Default: <c>web</c>.</param>
 /// <param name="Permissions">OpenIddict permissions to grant (e.g. <c>ept:token</c>, <c>gt:authorization_code</c>). Null or omitted defaults to no permissions.</param>
 /// <param name="RedirectUris">Allowed redirect URIs. Null or omitted defaults to none.</param>
@@ -18,6 +18,7 @@ namespace Granit.OpenIddict.Endpoints.Dtos;
 /// <param name="ClientSide">Host/tenant policy enforced at sign-in. Null means no restriction.</param>
 /// <param name="DeviceKind">Device classification for the devices that authenticate through this client (e.g. <c>MobileApp</c>, <c>Tv</c>). Null or omitted means not declared (the session adapters fall back to a redirect-URI/grant heuristic).</param>
 /// <param name="TenantId">Owning tenant. Omit (or <see langword="null"/>) to create a global application, or to inherit the caller's active tenant when the admin API is invoked under a tenant scope. A host administrator (no active tenant) may set this explicitly to provision an application for a specific tenant; a tenant-scoped administrator may only target their own tenant (a mismatch is rejected with 403).</param>
+/// <param name="GenerateClientSecret">When <see langword="true"/>, the server mints a cryptographically strong client secret for a confidential client and returns it once in <c>GeneratedClientSecret</c> on the create response — the admin never has to invent one. Takes precedence over <paramref name="ClientSecret"/>. Default: <see langword="false"/> (public client, or the explicitly-provided secret).</param>
 #pragma warning disable GRSEC003 // ClientSecret is a DTO parameter, not a stored secret
 public sealed record AdminOidcCreateApplicationRequest(
     string ClientId,
@@ -31,5 +32,6 @@ public sealed record AdminOidcCreateApplicationRequest(
     string? SigningKeyJwk = null,
     MultiTenancySides? ClientSide = null,
     DeviceKind? DeviceKind = null,
-    Guid? TenantId = null);
+    Guid? TenantId = null,
+    bool GenerateClientSecret = false);
 #pragma warning restore GRSEC003

--- a/src/Granit.OpenIddict.Endpoints/Endpoints/AdminOidcEndpoints.cs
+++ b/src/Granit.OpenIddict.Endpoints/Endpoints/AdminOidcEndpoints.cs
@@ -48,7 +48,7 @@ internal static class AdminOidcEndpoints
         apps.MapPost("/", CreateApplicationAsync)
             .WithName("CreateOidcApplication")
             .WithSummary("Creates a new OIDC application.")
-            .WithDescription("Registers a new OIDC client with the specified permissions, redirect URIs, and consent policy. Providing a client secret creates a confidential client (the secret is stored hashed); omitting it creates a public client. Returns 409 Conflict if a client with the same client ID already exists.")
+            .WithDescription("Registers a new OIDC client with the specified permissions, redirect URIs, and consent policy. Set generateClientSecret=true to have the server mint a cryptographically strong secret and return it once in the response's generatedClientSecret field (confidential client); alternatively provide clientSecret explicitly; omitting both creates a public client. Stored secrets are hashed. Returns 409 Conflict if a client with the same client ID already exists.")
             .WithMetadata(new IdempotentAttribute { Required = false })
             .Produces<AdminOidcApplicationResponse>(StatusCodes.Status201Created)
             .ProducesValidationProblem(StatusCodes.Status422UnprocessableEntity)
@@ -241,7 +241,16 @@ internal static class AdminOidcEndpoints
             ConsentType = request.ConsentType ?? OpenIddictConstants.ConsentTypes.Implicit,
         };
 
-        if (!string.IsNullOrEmpty(request.ClientSecret))
+        // A server-minted secret (returned once below) is preferred over an admin-supplied one; the
+        // admin never has to invent secret material. Falls back to an explicit secret, else public.
+        string? generatedSecret = null;
+        if (request.GenerateClientSecret)
+        {
+            generatedSecret = Convert.ToBase64String(RandomNumberGenerator.GetBytes(32));
+            descriptor.ClientSecret = generatedSecret;
+            descriptor.ClientType = OpenIddictConstants.ClientTypes.Confidential;
+        }
+        else if (!string.IsNullOrEmpty(request.ClientSecret))
         {
             descriptor.ClientSecret = request.ClientSecret;
             descriptor.ClientType = OpenIddictConstants.ClientTypes.Confidential;
@@ -291,7 +300,7 @@ internal static class AdminOidcEndpoints
 
         return TypedResults.Created(
             $"/admin/oidc/applications/{request.ClientId}",
-            ToResponse(responseDescriptor, persistedTenantId));
+            ToResponse(responseDescriptor, persistedTenantId) with { GeneratedClientSecret = generatedSecret });
     }
 
     /// <summary>

--- a/tests/Granit.OpenIddict.Endpoints.Tests/Integration/AdminOidcEndpointsIntegrationTests.cs
+++ b/tests/Granit.OpenIddict.Endpoints.Tests/Integration/AdminOidcEndpointsIntegrationTests.cs
@@ -301,6 +301,51 @@ public sealed class AdminOidcEndpointsIntegrationTests : IAsyncLifetime
                     d.ClientSecret == "my-secret" &&
                     d.ClientType == OpenIddictConstants.ClientTypes.Confidential),
                 Arg.Any<CancellationToken>());
+
+        // An admin-supplied secret is never echoed back — only server-minted secrets are returned.
+        AdminOidcApplicationResponse? body = await response.Content
+            .ReadFromJsonAsync<AdminOidcApplicationResponse>(TestContext.Current.CancellationToken);
+        body.ShouldNotBeNull();
+        body.GeneratedClientSecret.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task CreateApplication_GenerateClientSecret_MintsSecretAndReturnsItOnce()
+    {
+        GranitOpenIddictApplication createdApp = new() { TenantId = null };
+
+        _server.ApplicationManager.CreateAsync(
+            Arg.Any<OpenIddictApplicationDescriptor>(),
+            Arg.Any<CancellationToken>())
+            .Returns(createdApp);
+        _server.ApplicationManager.GetClientIdAsync(createdApp, Arg.Any<CancellationToken>())
+            .Returns("gen-client");
+        _server.ApplicationManager.GetDisplayNameAsync(createdApp, Arg.Any<CancellationToken>())
+            .Returns("Gen App");
+        _server.ApplicationManager.GetApplicationTypeAsync(createdApp, Arg.Any<CancellationToken>())
+            .Returns("web");
+
+        // GenerateClientSecret = true; no explicit ClientSecret provided.
+        AdminOidcCreateApplicationRequest request = new(
+            "gen-client", "Gen App", Type: "web", GenerateClientSecret: true);
+
+        HttpResponseMessage response = await _server.AuthenticatedClient
+            .PostAsJsonAsync("/admin/oidc/applications", request, TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Created);
+
+        AdminOidcApplicationResponse? result = await response.Content
+            .ReadFromJsonAsync<AdminOidcApplicationResponse>(TestContext.Current.CancellationToken);
+        result.ShouldNotBeNull();
+        result.GeneratedClientSecret.ShouldNotBeNullOrWhiteSpace();
+
+        // The confidential client is created with the same server-minted secret that was returned once.
+        await _server.ApplicationManager.Received(1)
+            .CreateAsync(
+                Arg.Is<OpenIddictApplicationDescriptor>(d =>
+                    d.ClientSecret == result.GeneratedClientSecret &&
+                    d.ClientType == OpenIddictConstants.ClientTypes.Confidential),
+                Arg.Any<CancellationToken>());
     }
 
     [Fact]


### PR DESCRIPTION
## What

Creating a confidential OIDC application previously required the admin to invent and submit the client secret. This adds an **opt-in server-side path**, mirroring the existing `rotate-secret` flow:

- Request gains `generateClientSecret` (default `false`). When `true`, the server mints a cryptographically strong 256-bit secret (`RandomNumberGenerator.GetBytes(32)` → base64), marks the client confidential, and returns the plaintext **once** in the new `generatedClientSecret` response field — never stored in plaintext.
- Generation **takes precedence** over an explicitly-supplied `clientSecret` (documented), so the admin never has to invent secret material.

## Compatibility

Both additions are optional with defaults — existing create calls are unchanged, and an **admin-supplied secret is still never echoed back** (only server-minted secrets are returned). This is additive, not breaking. OpenAPI description updated.

## Verification

- `Granit.OpenIddict.Endpoints.Tests`: **133/133 green** — new test asserts the minted secret is returned and used for the confidential client; the explicit-secret test now also asserts `generatedClientSecret` is null (no echo).
- `ApiConvention` / `OpenApiGeneratorCompleteness` architecture tests green.
- `dotnet format --verify-no-changes` clean; no lockfile change.

Completes the deferred breaking/hardening backlog (PagedResult in #3132, this is the additive companion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)