### PR TITLE
feat(openiddict): server-side filtering of admin authorizations by subject/client

### DIFF
--- a/src/Granit.OpenIddict.Endpoints/Endpoints/AdminOidcEndpoints.cs
+++ b/src/Granit.OpenIddict.Endpoints/Endpoints/AdminOidcEndpoints.cs
@@ -145,7 +145,7 @@ internal static class AdminOidcEndpoints
         auths.MapGet("/", ListAuthorizationsAsync)
             .WithName("ListOidcAuthorizations")
             .WithSummary("Returns a page of OIDC authorizations.")
-            .WithDescription("Returns a page of OIDC authorizations. Each authorization represents a user's consent grant to an application, with its status (valid, revoked) and type (permanent, ad-hoc). Paginated via the 'page' (1-based, default 1) and 'pageSize' (default 25, max 100) query parameters; the envelope carries the total count and a has-more flag. Server-side filtering by user or client is not yet implemented.")
+            .WithDescription("Returns a page of OIDC authorizations. Each authorization represents a user's consent grant to an application, with its status (valid, revoked) and type (permanent, ad-hoc). Paginated via the 'page' (1-based, default 1) and 'pageSize' (default 25, max 100) query parameters; the envelope carries the total count and a has-more flag. Optionally filter server-side by 'subject' (user id) and/or 'clientId'; an unknown clientId yields an empty page.")
             .Produces<PagedResult<AdminOidcAuthorizationResponse>>()
             .RequireAuthorization(OpenIddictPermissions.Authorizations.Read);
 
@@ -633,38 +633,88 @@ internal static class AdminOidcEndpoints
         [FromServices] IOpenIddictApplicationManager applicationManager,
         [FromQuery] int? page,
         [FromQuery] int? pageSize,
+        [FromQuery] string? subject,
+        [FromQuery] string? clientId,
         CancellationToken cancellationToken)
     {
         (int size, int offset) = ResolvePaging(page, pageSize);
-        var results = new List<AdminOidcAuthorizationResponse>();
         var clientIdCache = new Dictionary<string, string?>(StringComparer.Ordinal);
 
-        await foreach (object auth in authorizationManager.ListAsync(size, offset, cancellationToken).ConfigureAwait(false))
+        async Task<AdminOidcAuthorizationResponse> BuildAsync(object auth)
         {
             string? id = await authorizationManager.GetIdAsync(auth, cancellationToken).ConfigureAwait(false);
             var descriptor = new OpenIddictAuthorizationDescriptor();
             await authorizationManager.PopulateAsync(descriptor, auth, cancellationToken).ConfigureAwait(false);
 
-            string? clientId = null;
+            string? resolvedClientId = null;
             if (descriptor.ApplicationId is not null
-                && !clientIdCache.TryGetValue(descriptor.ApplicationId, out clientId))
+                && !clientIdCache.TryGetValue(descriptor.ApplicationId, out resolvedClientId))
             {
                 object? app = await applicationManager.FindByIdAsync(descriptor.ApplicationId, cancellationToken).ConfigureAwait(false);
-                clientId = app is not null
+                resolvedClientId = app is not null
                     ? await applicationManager.GetClientIdAsync(app, cancellationToken).ConfigureAwait(false)
                     : null;
-                clientIdCache[descriptor.ApplicationId] = clientId;
+                clientIdCache[descriptor.ApplicationId] = resolvedClientId;
             }
 
-            results.Add(new AdminOidcAuthorizationResponse(
+            return new AdminOidcAuthorizationResponse(
                 Guid.TryParse(id, out Guid parsedId) ? parsedId : Guid.Empty,
-                descriptor.Subject, clientId, descriptor.Status, descriptor.Type,
-                [.. descriptor.Scopes]));
+                descriptor.Subject, resolvedClientId, descriptor.Status, descriptor.Type,
+                [.. descriptor.Scopes]);
         }
 
-        long total = await authorizationManager.CountAsync(cancellationToken).ConfigureAwait(false);
+        // A clientId filter is resolved to the internal application id — the manager filters
+        // authorizations by application id, not by the public client_id.
+        string? applicationId = null;
+        if (!string.IsNullOrEmpty(clientId))
+        {
+            object? app = await applicationManager.FindByClientIdAsync(clientId, cancellationToken).ConfigureAwait(false);
+            if (app is null)
+            {
+                return TypedResults.Ok(new PagedResult<AdminOidcAuthorizationResponse>([], 0, false));
+            }
+
+            applicationId = await applicationManager.GetIdAsync(app, cancellationToken).ConfigureAwait(false);
+        }
+
+        // Unfiltered: stream the requested page straight from the store (server-side pagination).
+        if (string.IsNullOrEmpty(subject) && applicationId is null)
+        {
+            var pageItems = new List<AdminOidcAuthorizationResponse>();
+            await foreach (object auth in authorizationManager.ListAsync(size, offset, cancellationToken).ConfigureAwait(false))
+            {
+                pageItems.Add(await BuildAsync(auth).ConfigureAwait(false));
+            }
+
+            long total = await authorizationManager.CountAsync(cancellationToken).ConfigureAwait(false);
+            return TypedResults.Ok(new PagedResult<AdminOidcAuthorizationResponse>(
+                pageItems, (int)total, offset + pageItems.Count < total));
+        }
+
+        // Filtered: the manager's Find* overloads are unpaginated, so materialise the (bounded
+        // per subject/client) match set and page it in memory.
+        IAsyncEnumerable<object> matches = (subject, applicationId) switch
+        {
+            (not null, not null) => authorizationManager.FindAsync(
+                subject, applicationId, status: null, type: null, scopes: null, cancellationToken),
+            (not null, null) => authorizationManager.FindBySubjectAsync(subject, cancellationToken),
+            _ => authorizationManager.FindByApplicationIdAsync(applicationId!, cancellationToken),
+        };
+
+        var allMatches = new List<object>();
+        await foreach (object auth in matches.ConfigureAwait(false))
+        {
+            allMatches.Add(auth);
+        }
+
+        var results = new List<AdminOidcAuthorizationResponse>();
+        foreach (object auth in allMatches.Skip(offset).Take(size))
+        {
+            results.Add(await BuildAsync(auth).ConfigureAwait(false));
+        }
+
         return TypedResults.Ok(new PagedResult<AdminOidcAuthorizationResponse>(
-            results, (int)total, offset + results.Count < total));
+            results, allMatches.Count, offset + results.Count < allMatches.Count));
     }
 
     /// <summary>

--- a/tests/Granit.OpenIddict.Endpoints.Tests/Integration/AdminOidcEndpointsIntegrationTests.cs
+++ b/tests/Granit.OpenIddict.Endpoints.Tests/Integration/AdminOidcEndpointsIntegrationTests.cs
@@ -712,6 +712,115 @@ public sealed class AdminOidcEndpointsIntegrationTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task ListAuthorizations_FilterBySubject_UsesFindBySubject()
+    {
+        object auth1 = new();
+        object app1 = new();
+
+        _server.AuthorizationManager.FindBySubjectAsync("user-123", Arg.Any<CancellationToken>())
+            .Returns(ToAsyncEnumerable<object>(auth1));
+        _server.AuthorizationManager.GetIdAsync(auth1, Arg.Any<CancellationToken>())
+            .Returns(Guid.NewGuid().ToString());
+#pragma warning disable CA2012
+        _server.AuthorizationManager
+            .PopulateAsync(Arg.Any<OpenIddictAuthorizationDescriptor>(), auth1, Arg.Any<CancellationToken>())
+            .Returns(ci =>
+            {
+                OpenIddictAuthorizationDescriptor d = ci.ArgAt<OpenIddictAuthorizationDescriptor>(0);
+                d.Subject = "user-123";
+                d.Status = "valid";
+                d.Type = "permanent";
+                d.ApplicationId = "app-internal-id";
+                return new ValueTask();
+            });
+#pragma warning restore CA2012
+        _server.ApplicationManager.FindByIdAsync("app-internal-id", Arg.Any<CancellationToken>())
+            .Returns(app1);
+        _server.ApplicationManager.GetClientIdAsync(app1, Arg.Any<CancellationToken>())
+            .Returns("my-client");
+
+        HttpResponseMessage response = await _server.AuthenticatedClient
+            .GetAsync("/admin/oidc/authorizations?subject=user-123", TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        PagedResult<AdminOidcAuthorizationResponse>? page = await response.Content
+            .ReadFromJsonAsync<PagedResult<AdminOidcAuthorizationResponse>>(TestContext.Current.CancellationToken);
+
+        page.ShouldNotBeNull();
+        page.TotalCount.ShouldBe(1);
+        page.Items[0].Subject.ShouldBe("user-123");
+
+        // The filtered path uses FindBySubjectAsync, never the unfiltered ListAsync.
+        _ = _server.AuthorizationManager.Received(1).FindBySubjectAsync("user-123", Arg.Any<CancellationToken>());
+        _ = _server.AuthorizationManager.DidNotReceive()
+            .ListAsync(Arg.Any<int?>(), Arg.Any<int?>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ListAuthorizations_FilterByClientId_ResolvesToApplicationId()
+    {
+        object auth1 = new();
+        object app1 = new();
+
+        _server.ApplicationManager.FindByClientIdAsync("my-client", Arg.Any<CancellationToken>())
+            .Returns(app1);
+        _server.ApplicationManager.GetIdAsync(app1, Arg.Any<CancellationToken>())
+            .Returns("app-internal-id");
+        _server.AuthorizationManager.FindByApplicationIdAsync("app-internal-id", Arg.Any<CancellationToken>())
+            .Returns(ToAsyncEnumerable<object>(auth1));
+        _server.AuthorizationManager.GetIdAsync(auth1, Arg.Any<CancellationToken>())
+            .Returns(Guid.NewGuid().ToString());
+#pragma warning disable CA2012
+        _server.AuthorizationManager
+            .PopulateAsync(Arg.Any<OpenIddictAuthorizationDescriptor>(), auth1, Arg.Any<CancellationToken>())
+            .Returns(ci =>
+            {
+                OpenIddictAuthorizationDescriptor d = ci.ArgAt<OpenIddictAuthorizationDescriptor>(0);
+                d.Subject = "user-9";
+                d.Status = "valid";
+                d.Type = "permanent";
+                d.ApplicationId = "app-internal-id";
+                return new ValueTask();
+            });
+#pragma warning restore CA2012
+        _server.ApplicationManager.FindByIdAsync("app-internal-id", Arg.Any<CancellationToken>())
+            .Returns(app1);
+        _server.ApplicationManager.GetClientIdAsync(app1, Arg.Any<CancellationToken>())
+            .Returns("my-client");
+
+        HttpResponseMessage response = await _server.AuthenticatedClient
+            .GetAsync("/admin/oidc/authorizations?clientId=my-client", TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        PagedResult<AdminOidcAuthorizationResponse>? page = await response.Content
+            .ReadFromJsonAsync<PagedResult<AdminOidcAuthorizationResponse>>(TestContext.Current.CancellationToken);
+
+        page.ShouldNotBeNull();
+        page.TotalCount.ShouldBe(1);
+        page.Items[0].ClientId.ShouldBe("my-client");
+        _ = _server.AuthorizationManager.Received(1)
+            .FindByApplicationIdAsync("app-internal-id", Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ListAuthorizations_FilterByUnknownClientId_ReturnsEmpty()
+    {
+        _server.ApplicationManager.FindByClientIdAsync("ghost", Arg.Any<CancellationToken>())
+            .Returns((object?)null);
+
+        HttpResponseMessage response = await _server.AuthenticatedClient
+            .GetAsync("/admin/oidc/authorizations?clientId=ghost", TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        PagedResult<AdminOidcAuthorizationResponse>? page = await response.Content
+            .ReadFromJsonAsync<PagedResult<AdminOidcAuthorizationResponse>>(TestContext.Current.CancellationToken);
+
+        page.ShouldNotBeNull();
+        page.TotalCount.ShouldBe(0);
+        page.Items.ShouldBeEmpty();
+    }
+
+    [Fact]
     public async Task ListAuthorizations_Anonymous_Returns401()
     {
         HttpResponseMessage response = await _server.AnonymousClient


### PR DESCRIPTION
## What

Follow-up #3. The admin authorizations list could only be paged, not filtered — the endpoint description previously admitted "server-side filtering by user or client is not yet implemented". This adds optional `subject` (user id) and `clientId` query parameters.

- **Unfiltered**: unchanged — streams the requested page via `ListAsync(size, offset)` + `CountAsync` (server-side pagination).
- **`subject` and/or `clientId`**: a `clientId` is first resolved to its internal application id (the OpenIddict manager filters authorizations by application id, not the public `client_id`); an unknown `clientId` yields an empty page. The manager's `Find*` overloads (`FindBySubjectAsync` / `FindByApplicationIdAsync` / `FindAsync`) are unpaginated, so the bounded per-subject / per-client match set is materialised and paged in memory, with `TotalCount` = full match count.

## Verification

- `Granit.OpenIddict.Endpoints.Tests`: **135/135 green** — 3 new tests: filter by subject (uses `FindBySubjectAsync`, not `ListAsync`), filter by clientId (resolves to app id → `FindByApplicationIdAsync`), unknown clientId → empty page.
- `dotnet format --verify-no-changes` clean; no lockfile change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)