### PR TITLE
fix(auth): add mTLS package READMEs and bind MtlsValidationOptions section

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -10910,7 +10910,7 @@
       "kind": "class",
       "project": "Granit.Authentication.Mtls",
       "file": "src/Granit.Authentication.Mtls/Extensions/MtlsJwtBearerExtensions.cs",
-      "line": 14,
+      "line": 15,
       "members": [
         {
           "name": "AddGranitMtlsValidation",

--- a/src/Granit.Authentication.Mtls/Extensions/MtlsJwtBearerExtensions.cs
+++ b/src/Granit.Authentication.Mtls/Extensions/MtlsJwtBearerExtensions.cs
@@ -4,6 +4,7 @@ using Granit.Authentication.Mtls.Options;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
 
 namespace Granit.Authentication.Mtls.Extensions;
 
@@ -25,9 +26,14 @@ public static class MtlsJwtBearerExtensions
     {
         ArgumentNullException.ThrowIfNull(services);
 
+        OptionsBuilder<MtlsValidationOptions> options = services
+            .AddOptions<MtlsValidationOptions>()
+            .BindConfiguration(MtlsValidationOptions.SectionName);
+
+        // Registered after the configuration binding so an explicit delegate wins over appsettings.
         if (configure is not null)
         {
-            services.Configure(configure);
+            options.Configure(configure);
         }
 
         services.TryAddSingleton<MtlsValidationMetrics>();

--- a/src/Granit.Authentication.Mtls/README.md
+++ b/src/Granit.Authentication.Mtls/README.md
@@ -1,0 +1,44 @@
+# Granit.Authentication.Mtls
+
+Server-side mutual-TLS certificate-bound access token validation (RFC 8705) for ASP.NET Core JWT Bearer authentication. IdP-agnostic — works with OpenIddict, Keycloak, Entra ID, Auth0, or any OIDC provider. Verifies that the presented client certificate matches the token's `cnf.x5t#S256` confirmation claim, so a leaked token cannot be replayed without the client's private key.
+
+Part of the [granit](https://granit-fx.dev) framework.
+
+## Installation
+
+```bash
+dotnet add package Granit.Authentication.Mtls
+```
+
+## Usage
+
+```csharp
+builder.Services.AddGranitMtlsValidation();
+
+app.UseAuthentication();
+app.UseGranitMtlsValidation(); // must run after UseAuthentication()
+app.UseAuthorization();
+```
+
+## Configuration
+
+```jsonc
+{
+  "Authentication": {
+    "Mtls": {
+      // true — every authenticated request must carry a certificate-bound token (FAPI 2.0).
+      // false (default) — unbound tokens pass through; bound tokens are still verified.
+      "RequireCertificateBinding": false
+    }
+  }
+}
+```
+
+## Dependencies
+
+- `Granit`
+- `Granit.Diagnostics`
+
+## Documentation
+
+See the [full documentation](https://granit-fx.dev).

--- a/src/Granit.OpenIddict.Server.DPoP/README.md
+++ b/src/Granit.OpenIddict.Server.DPoP/README.md
@@ -26,5 +26,5 @@ dotnet add package Granit.OpenIddict.Server.DPoP
 }
 ```
 
-`WithFapi2Profile()` sets `SenderConstraining = DPoP` automatically. A future
-`Granit.OpenIddict.Server.Mtls` package will provide the `Mtls` mode (RFC 8705).
+`WithFapi2Profile()` sets `SenderConstraining = DPoP` automatically. The `Mtls` mode (RFC 8705) is
+provided by `Granit.OpenIddict.Server.Mtls`.

--- a/src/Granit.OpenIddict.Server.Mtls/README.md
+++ b/src/Granit.OpenIddict.Server.Mtls/README.md
@@ -1,0 +1,33 @@
+# Granit.OpenIddict.Server.Mtls
+
+Opt-in mutual-TLS (RFC 8705) sender-constraining for the Granit OpenIddict server. Reference this
+package to bind issued access tokens to the client's TLS certificate (`cnf.x5t#S256`) at the token
+endpoint and to satisfy FAPI 2.0 sender-constraining.
+
+The core `Granit.OpenIddict.Server` package carries no mTLS dependency, so DPoP-only or Bearer-only
+deployments do not pull it in. Referencing this package auto-wires the certificate token-binding
+handler into the server pipeline via the Granit module system.
+
+Part of the [granit](https://granit-fx.dev) framework.
+
+## Installation
+
+```bash
+dotnet add package Granit.OpenIddict.Server.Mtls
+```
+
+## Configuration
+
+```jsonc
+{
+  "OpenIddict": {
+    "SenderConstraining": "Mtls" // fails fast at startup if this package is not referenced
+  }
+}
+```
+
+`WithFapi2Profile()` only falls back to `DPoP` when no mechanism is set — configure
+`SenderConstraining = Mtls` to pick mTLS instead.
+
+Resource servers validate the resulting binding with `Granit.Authentication.Mtls`. The `DPoP` mode
+(RFC 9449) is provided by `Granit.OpenIddict.Server.DPoP`.


### PR DESCRIPTION
As a Backend Developer, I want the mTLS packages to satisfy the framework conventions so that `develop` is green again and `Authentication:Mtls` configuration is actually honoured.

## Context

The RFC 8705 packages merged in #3136 broke two architecture tests on `develop`:

- `TestProjectConventionTests.Every_src_package_should_have_a_README` — `Granit.Authentication.Mtls` and `Granit.OpenIddict.Server.Mtls` shipped without a `README.md`.
- `OptionsBindingConventionTests.Every_SectionName_is_bound_somewhere_in_src` — `MtlsValidationOptions` declared `SectionName = "Authentication:Mtls"` but nothing ever bound it, so `RequireCertificateBinding` from `appsettings.json` was silently ignored.

## Changes

- Add `README.md` for both mTLS packages (installation, usage, configuration), mirroring the DPoP siblings.
- Bind the options in `AddGranitMtlsValidation` via `AddOptions<MtlsValidationOptions>().BindConfiguration(SectionName)`; the optional `configure` delegate is registered after the binding so an explicit delegate still wins over configuration.
- Drop the now-stale "a future `Granit.OpenIddict.Server.Mtls` package will provide the `Mtls` mode" note from the DPoP README.

No exemption was added to `OptionsBindingConventionTests` — the section is genuinely bindable, so it is bound rather than waived.

## Validation

- `dotnet build src/Granit.Authentication.Mtls` — 0 warnings, 0 errors
- `dotnet test tests/Granit.Authentication.Mtls.Tests` — 6/6 passed
- `dotnet test tests/Granit.ArchitectureTests --filter "OptionsBindingConventionTests|TestProjectConventionTests"` — 3/3 passed
- `dotnet format .github/shard-filters/architecture.slnf --verify-no-changes` — clean
- `npx markdownlint-cli2` on the three READMEs — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)