### PR TITLE
fix(persistence)!: audit findings batch — DependsOn archi-guard, options binding, DI hygiene, SOC tag

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -44489,7 +44489,7 @@
         {
           "name": "RecordCrossTenantQuery",
           "kind": "method",
-          "signature": "RecordCrossTenantQuery(string entityName, string origin)",
+          "signature": "RecordCrossTenantQuery(string entityName, string origin, string? tenantId = null)",
           "returnType": "void"
         }
       ]
@@ -44689,10 +44689,16 @@
       "line": 21,
       "members": [
         {
+          "name": "nameof",
+          "kind": "method",
+          "signature": "nameof(MultiTenancy.TenantIsolationOptions.HostSchema)",
+          "returnType": "string? DbSchema { get; set; } public string? HostDbSchema { get; set; } internal string HostSchemaConfigurationKey = $\"{MultiTenancy.TenantIsolationOptions.SectionName}:{"
+        },
+        {
           "name": "EnsureFromConfiguration",
           "kind": "method",
           "signature": "EnsureFromConfiguration(Microsoft.Extensions.Configuration.IConfiguration configuration)",
-          "returnType": "string? DbSchema { get; set; } public string? HostDbSchema { get; set; } public void"
+          "returnType": "void"
         }
       ]
     },
@@ -44767,7 +44773,7 @@
       "kind": "class",
       "project": "Granit.Persistence.EntityFrameworkCore",
       "file": "src/Granit.Persistence.EntityFrameworkCore/GranitPersistenceEntityFrameworkCoreModule.cs",
-      "line": 19,
+      "line": 24,
       "members": [
         {
           "name": "ConfigureServices",
@@ -45140,9 +45146,9 @@
       "line": 13,
       "members": [
         {
-          "name": "AddMetadataInfrastructure",
+          "name": "AddGranitMetadataInfrastructure",
           "kind": "method",
-          "signature": "AddMetadataInfrastructure(this IServiceCollection services)",
+          "signature": "AddGranitMetadataInfrastructure(this IServiceCollection services)",
           "returnType": "IServiceCollection"
         }
       ]
@@ -45623,7 +45629,7 @@
         {
           "name": "AddGranitPostgresHealthCheck",
           "kind": "method",
-          "signature": "AddGranitPostgresHealthCheck(this IHealthChecksBuilder builder, string connectionString, string name = \"postgres\", HealthStatus failureStatus = HealthStatus.Unhealthy, IEnumerable<string>? tags = null)",
+          "signature": "AddGranitPostgresHealthCheck(this IHealthChecksBuilder builder, string connectionString, string name = \"postgres\", HealthStatus failureStatus = HealthStatus.Unhealthy, IEnumerable<string>? tags = null, TimeSpan? timeout = null)",
           "returnType": "IHealthChecksBuilder"
         }
       ]
@@ -45650,7 +45656,7 @@
       "kind": "class",
       "project": "Granit.Persistence.EntityFrameworkCore.Postgres",
       "file": "src/Granit.Persistence.EntityFrameworkCore.Postgres/GranitPersistenceEntityFrameworkCorePostgresModule.cs",
-      "line": 24,
+      "line": 26,
       "members": [
         {
           "name": "ConfigureServices",
@@ -45753,7 +45759,7 @@
         {
           "name": "AddGranitSqlServerHealthCheck",
           "kind": "method",
-          "signature": "AddGranitSqlServerHealthCheck(this IHealthChecksBuilder builder, string connectionString, string name = \"sqlserver\", HealthStatus failureStatus = HealthStatus.Unhealthy, IEnumerable<string>? tags = null)",
+          "signature": "AddGranitSqlServerHealthCheck(this IHealthChecksBuilder builder, string connectionString, string name = \"sqlserver\", HealthStatus failureStatus = HealthStatus.Unhealthy, IEnumerable<string>? tags = null, TimeSpan? timeout = null)",
           "returnType": "IHealthChecksBuilder"
         }
       ]

--- a/src/Granit.Bff.Endpoints/GranitBffEndpointsModule.cs
+++ b/src/Granit.Bff.Endpoints/GranitBffEndpointsModule.cs
@@ -28,8 +28,8 @@ namespace Granit.Bff.Endpoints;
     typeof(GranitCachingModule),
     typeof(GranitHttpApiDocumentationModule),
     typeof(GranitHttpCookiesModule),
-    typeof(GranitIpGeolocationModule),
     typeof(GranitIdentityAbstractionsModule),
+    typeof(GranitIpGeolocationModule),
     typeof(GranitValidationModule))]
 public sealed class GranitBffEndpointsModule : GranitModule
 {

--- a/src/Granit.Http.RateLimiting/GranitHttpRateLimitingModule.cs
+++ b/src/Granit.Http.RateLimiting/GranitHttpRateLimitingModule.cs
@@ -16,8 +16,8 @@ namespace Granit.Http.RateLimiting;
 /// (see <see cref="RateLimitEndpointExtensions"/>).
 /// </remarks>
 [DependsOn(
-    typeof(GranitRateLimitingModule),
-    typeof(GranitHttpExceptionHandlingModule))]
+    typeof(GranitHttpExceptionHandlingModule),
+    typeof(GranitRateLimitingModule))]
 public sealed class GranitHttpRateLimitingModule : GranitModule
 {
     /// <inheritdoc/>

--- a/src/Granit.Identity.Endpoints/GranitIdentityEndpointsModule.cs
+++ b/src/Granit.Identity.Endpoints/GranitIdentityEndpointsModule.cs
@@ -30,9 +30,9 @@ namespace Granit.Identity.Endpoints;
 [DependsOn(
     typeof(GranitAuthorizationModule),
     typeof(GranitHttpApiDocumentationModule),
+    typeof(GranitIdentityAbstractionsModule),
     typeof(GranitIdentityModule),
     typeof(GranitIpGeolocationModule),
-    typeof(GranitIdentityAbstractionsModule),
     typeof(GranitValidationModule),
     typeof(GranitWorkspacesAbstractionsModule))]
 public sealed class GranitIdentityEndpointsModule : GranitModule

--- a/src/Granit.Identity.Local.EntityFrameworkCore/GranitIdentityLocalEntityFrameworkCoreModule.cs
+++ b/src/Granit.Identity.Local.EntityFrameworkCore/GranitIdentityLocalEntityFrameworkCoreModule.cs
@@ -29,8 +29,8 @@ public sealed class GranitIdentityLocalEntityFrameworkCoreModule : GranitModule
         context.Services.TryAddScoped<ILocalIdentityGroupStore, IdentityLocalGroupStore>();
 
         // LocalIdentity implements IHasMetadata — apps can extend user properties by calling
-        // AddMetadataMappings<LocalIdentity> in their own module. AddMetadataInfrastructure registers
+        // AddGranitMetadataMappings<LocalIdentity> in their own module. AddGranitMetadataInfrastructure registers
         // MetadataSyncInterceptor as IGranitAutoInterceptor so UseGranitInterceptors picks it up.
-        context.Services.AddMetadataInfrastructure();
+        context.Services.AddGranitMetadataInfrastructure();
     }
 }

--- a/src/Granit.Persistence.EntityFrameworkCore.Migrations/Internal/MigrationStartupService.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore.Migrations/Internal/MigrationStartupService.cs
@@ -95,7 +95,7 @@ internal sealed partial class MigrationStartupService(
         }
 
         List<Guid> tenantIds = [];
-        await foreach (Guid tenantId in tenantEnumerator.GetActiveTenantIdsAsync(cancellationToken))
+        await foreach (Guid tenantId in tenantEnumerator.GetActiveTenantIdsAsync(cancellationToken).ConfigureAwait(false))
         {
             tenantIds.Add(tenantId);
         }

--- a/src/Granit.Persistence.EntityFrameworkCore.Postgres/Extensions/NpgsqlHealthChecksBuilderExtensions.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore.Postgres/Extensions/NpgsqlHealthChecksBuilderExtensions.cs
@@ -14,8 +14,16 @@ public static class NpgsqlHealthChecksBuilderExtensions
     /// and executes <c>SELECT 1</c>.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// Uses a direct <see cref="NpgsqlConnection"/> (not EF Core) to avoid adding ORM overhead
     /// to the health-check path. The connection is opened and closed on every probe.
+    /// </para>
+    /// <para>
+    /// The probe is bounded by <paramref name="timeout"/> (default 10 seconds) so a hung TCP
+    /// connect cannot block the readiness endpoint for the driver's default connect timeout.
+    /// Failure results carry a sanitized description only — the raw driver exception (which
+    /// leaks host/port/database to any verbose health writer) is never attached (ISO 27001).
+    /// </para>
     /// </remarks>
     /// <param name="builder">The health checks builder.</param>
     /// <param name="connectionString">The PostgreSQL connection string.</param>
@@ -25,35 +33,50 @@ public static class NpgsqlHealthChecksBuilderExtensions
     /// Defaults to <see cref="HealthStatus.Unhealthy"/>.
     /// </param>
     /// <param name="tags">Optional tags for filtering health checks.</param>
+    /// <param name="timeout">Per-probe ceiling. Defaults to 10 seconds.</param>
     /// <returns>The health checks builder for chaining.</returns>
     public static IHealthChecksBuilder AddGranitPostgresHealthCheck(
         this IHealthChecksBuilder builder,
         string connectionString,
         string name = "postgres",
         HealthStatus failureStatus = HealthStatus.Unhealthy,
-        IEnumerable<string>? tags = null)
+        IEnumerable<string>? tags = null,
+        TimeSpan? timeout = null)
     {
         tags ??= ["readiness", "startup"];
+        TimeSpan probeTimeout = timeout ?? TimeSpan.FromSeconds(10);
         return builder.AddAsyncCheck(
             name,
             async ct =>
             {
+                using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+                timeoutCts.CancelAfter(probeTimeout);
                 try
                 {
                     await using NpgsqlConnection connection = new(connectionString);
-                    await connection.OpenAsync(ct).ConfigureAwait(false);
+                    await connection.OpenAsync(timeoutCts.Token).ConfigureAwait(false);
                     await using NpgsqlCommand cmd = connection.CreateCommand();
                     cmd.CommandText = "SELECT 1";
-                    await cmd.ExecuteScalarAsync(ct).ConfigureAwait(false);
+                    await cmd.ExecuteScalarAsync(timeoutCts.Token).ConfigureAwait(false);
                     return HealthCheckResult.Healthy();
                 }
-                catch (OperationCanceledException oce) when (ct.IsCancellationRequested)
+                catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !ct.IsCancellationRequested)
                 {
-                    return new HealthCheckResult(failureStatus, description: "PostgreSQL health check was canceled.", exception: oce);
+                    return new HealthCheckResult(
+                        failureStatus,
+                        description: $"PostgreSQL health check timed out after {probeTimeout.TotalSeconds:0}s.");
+                }
+                catch (OperationCanceledException) when (ct.IsCancellationRequested)
+                {
+                    return new HealthCheckResult(failureStatus, description: "PostgreSQL health check was canceled.");
                 }
                 catch (Exception ex)
                 {
-                    return new HealthCheckResult(failureStatus, exception: ex);
+                    // Sanitized on purpose: the raw exception message can contain host, port,
+                    // database, and user — do not attach it to the probe result.
+                    return new HealthCheckResult(
+                        failureStatus,
+                        description: $"PostgreSQL connection failed ({ex.GetType().Name}).");
                 }
             },
             tags);

--- a/src/Granit.Persistence.EntityFrameworkCore.Postgres/Extensions/PersistencePostgresHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore.Postgres/Extensions/PersistencePostgresHostApplicationBuilderExtensions.cs
@@ -26,7 +26,7 @@ public static class PersistencePostgresHostApplicationBuilderExtensions
     /// The migration lock uses <c>AddSingleton</c> (replace), so it wins over the
     /// <c>NullMigrationLock</c> fallback regardless of registration order. The schema
     /// activator and tenant isolator remain <c>TryAdd</c> — call this before any
-    /// <c>AddTenantPerSchemaDbContext</c> call so those are not overridden by
+    /// <c>AddGranitTenantPerSchemaDbContext</c> call so those are not overridden by
     /// no-op fallbacks.
     /// </remarks>
     /// <param name="builder">The host application builder.</param>

--- a/src/Granit.Persistence.EntityFrameworkCore.Postgres/GranitPersistenceEntityFrameworkCorePostgresModule.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore.Postgres/GranitPersistenceEntityFrameworkCorePostgresModule.cs
@@ -20,7 +20,9 @@ namespace Granit.Persistence.EntityFrameworkCore.Postgres;
 /// Must be declared before <c>GranitPersistenceEntityFrameworkCoreHostingModule</c> in the dependency graph so
 /// <c>TryAdd</c> registrations win over the no-op fallbacks.
 /// </remarks>
-[DependsOn(typeof(GranitPersistenceEntityFrameworkCoreHostingModule))]
+[DependsOn(
+    typeof(GranitObservabilityModule),
+    typeof(GranitPersistenceEntityFrameworkCoreHostingModule))]
 public sealed class GranitPersistenceEntityFrameworkCorePostgresModule : GranitModule
 {
     /// <inheritdoc/>

--- a/src/Granit.Persistence.EntityFrameworkCore.Postgres/Internal/NpgsqlTenantSchemaActivator.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore.Postgres/Internal/NpgsqlTenantSchemaActivator.cs
@@ -11,7 +11,7 @@ namespace Granit.Persistence.EntityFrameworkCore.Postgres.Internal;
 /// <remarks>
 /// <para>
 /// Registered by <c>AddGranitPostgres()</c>. Call that method before
-/// <c>AddTenantPerSchemaDbContext</c> to ensure this implementation is used.
+/// <c>AddGranitTenantPerSchemaDbContext</c> to ensure this implementation is used.
 /// </para>
 /// <para>
 /// Safety is ensured by two layers:

--- a/src/Granit.Persistence.EntityFrameworkCore.Postgres/README.md
+++ b/src/Granit.Persistence.EntityFrameworkCore.Postgres/README.md
@@ -13,7 +13,7 @@ PostgreSQL-specific persistence extensions for Granit applications.
 // In Program.cs or host module — order relative to AddGranitMigrateSupport() does not
 // matter for the migration lock (the real lock always replaces the NullMigrationLock
 // fallback). Only tenant-per-schema setups still need AddGranitPostgres() before
-// AddTenantPerSchemaDbContext() so the schema activator is not overridden by a no-op.
+// AddGranitTenantPerSchemaDbContext() so the schema activator is not overridden by a no-op.
 builder.AddGranitPostgres();
 builder.AddGranitMigrateSupport();
 ```

--- a/src/Granit.Persistence.EntityFrameworkCore.SqlServer/Extensions/SqlServerHealthChecksBuilderExtensions.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore.SqlServer/Extensions/SqlServerHealthChecksBuilderExtensions.cs
@@ -14,8 +14,16 @@ public static class SqlServerHealthChecksBuilderExtensions
     /// and executes <c>SELECT 1</c>.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// Uses a direct <see cref="SqlConnection"/> (not EF Core) to avoid adding ORM overhead
     /// to the health-check path. The connection is opened and closed on every probe.
+    /// </para>
+    /// <para>
+    /// The probe is bounded by <paramref name="timeout"/> (default 10 seconds) so a hung TCP
+    /// connect cannot block the readiness endpoint for the driver's default connect timeout.
+    /// Failure results carry a sanitized description only — the raw driver exception (which
+    /// leaks host/port/database to any verbose health writer) is never attached (ISO 27001).
+    /// </para>
     /// </remarks>
     /// <param name="builder">The health checks builder.</param>
     /// <param name="connectionString">The SQL Server connection string.</param>
@@ -25,35 +33,50 @@ public static class SqlServerHealthChecksBuilderExtensions
     /// Defaults to <see cref="HealthStatus.Unhealthy"/>.
     /// </param>
     /// <param name="tags">Optional tags for filtering health checks.</param>
+    /// <param name="timeout">Per-probe ceiling. Defaults to 10 seconds.</param>
     /// <returns>The health checks builder for chaining.</returns>
     public static IHealthChecksBuilder AddGranitSqlServerHealthCheck(
         this IHealthChecksBuilder builder,
         string connectionString,
         string name = "sqlserver",
         HealthStatus failureStatus = HealthStatus.Unhealthy,
-        IEnumerable<string>? tags = null)
+        IEnumerable<string>? tags = null,
+        TimeSpan? timeout = null)
     {
         tags ??= ["readiness", "startup"];
+        TimeSpan probeTimeout = timeout ?? TimeSpan.FromSeconds(10);
         return builder.AddAsyncCheck(
             name,
             async ct =>
             {
+                using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+                timeoutCts.CancelAfter(probeTimeout);
                 try
                 {
                     await using SqlConnection connection = new(connectionString);
-                    await connection.OpenAsync(ct).ConfigureAwait(false);
+                    await connection.OpenAsync(timeoutCts.Token).ConfigureAwait(false);
                     await using SqlCommand cmd = connection.CreateCommand();
                     cmd.CommandText = "SELECT 1";
-                    await cmd.ExecuteScalarAsync(ct).ConfigureAwait(false);
+                    await cmd.ExecuteScalarAsync(timeoutCts.Token).ConfigureAwait(false);
                     return HealthCheckResult.Healthy();
                 }
-                catch (OperationCanceledException oce) when (ct.IsCancellationRequested)
+                catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !ct.IsCancellationRequested)
                 {
-                    return new HealthCheckResult(failureStatus, description: "SQL Server health check was canceled.", exception: oce);
+                    return new HealthCheckResult(
+                        failureStatus,
+                        description: $"SQL Server health check timed out after {probeTimeout.TotalSeconds:0}s.");
+                }
+                catch (OperationCanceledException) when (ct.IsCancellationRequested)
+                {
+                    return new HealthCheckResult(failureStatus, description: "SQL Server health check was canceled.");
                 }
                 catch (Exception ex)
                 {
-                    return new HealthCheckResult(failureStatus, exception: ex);
+                    // Sanitized on purpose: the raw exception message can contain host, port,
+                    // database, and user — do not attach it to the probe result.
+                    return new HealthCheckResult(
+                        failureStatus,
+                        description: $"SQL Server connection failed ({ex.GetType().Name}).");
                 }
             },
             tags);

--- a/src/Granit.Persistence.EntityFrameworkCore/Diagnostics/EfStoreBaseLog.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/Diagnostics/EfStoreBaseLog.cs
@@ -1,0 +1,18 @@
+using Microsoft.Extensions.Logging;
+
+namespace Granit.Persistence.EntityFrameworkCore.Diagnostics;
+
+/// <summary>
+/// Source-generated log messages for <see cref="EfStoreBase{TEntity, TContext}"/>.
+/// Lives in a non-generic host class because <c>[LoggerMessage]</c> source generation
+/// does not support generic containing types.
+/// </summary>
+internal static partial class EfStoreBaseLog
+{
+    [LoggerMessage(
+        EventId = 8102,
+        Level = LogLevel.Information,
+        Message = "Explicit cross-tenant query on {Entity} from {CallerMember} ({CallerFile}:{CallerLine}).")]
+    public static partial void ExplicitCrossTenantQuery(
+        ILogger logger, string entity, string callerMember, string callerFile, int callerLine);
+}

--- a/src/Granit.Persistence.EntityFrameworkCore/Diagnostics/PersistenceMetrics.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/Diagnostics/PersistenceMetrics.cs
@@ -35,10 +35,12 @@ public sealed class PersistenceMetrics
             "granit.persistence.cross_tenant_query",
             description:
                 "Number of EfStoreBase queries that bypassed the multi-tenant filter. "
-                + "Tagged with `entity` (CLR name) and `origin` (`host_endpoint` = served "
+                + "Tagged with `entity` (CLR name), `origin` (`host_endpoint` = served "
                 + "via a route marked .AllowHostAccess(); `explicit` = caller used "
                 + "QueryAcrossTenants(); `implicit_unsignaled` = bypass without host-access "
-                + "signal — alert-worthy, may indicate a tenant-context leak in flight).");
+                + "signal — alert-worthy, may indicate a tenant-context leak in flight) and "
+                + "`tenant_id` (the active tenant at the call site, `global` when no tenant "
+                + "context was available — always the case for the implicit origins).");
     }
 
     public void RecordEntitiesPurged(string? tenantId, int count) =>
@@ -59,10 +61,17 @@ public sealed class PersistenceMetrics
     /// <c>"implicit_unsignaled"</c> when the bypass occurred without any host-access
     /// signal — this is the alert-worthy origin that may indicate a tenant-context leak.
     /// </param>
-    public void RecordCrossTenantQuery(string entityName, string origin) =>
+    /// <param name="tenantId">
+    /// The active tenant at the call site, or <c>null</c> when no tenant context is
+    /// available (coalesced to <c>"global"</c>). The host/implicit origins fire precisely
+    /// because the tenant is absent, so they always report <c>"global"</c>; the
+    /// <c>explicit</c> origin reports the tenant whose scope issued the cross-tenant read.
+    /// </param>
+    public void RecordCrossTenantQuery(string entityName, string origin, string? tenantId = null) =>
         _crossTenantQueries.Add(1, new TagList
         {
             { TagEntity, entityName },
             { TagOrigin, origin },
+            { TagTenantId, tenantId ?? DefaultTenant },
         });
 }

--- a/src/Granit.Persistence.EntityFrameworkCore/EfStoreBase.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/EfStoreBase.cs
@@ -156,18 +156,13 @@ public abstract class EfStoreBase<TEntity, TContext>
         [CallerLineNumber] int callerLine = 0)
     {
         string entity = typeof(TEntity).Name;
-        _metrics?.RecordCrossTenantQuery(entity, "explicit");
-        LogExplicitCrossTenantQuery(entity, callerMember, callerFile, callerLine);
+        string? tenantId = _currentTenant is { IsAvailable: true } tenant ? tenant.Id?.ToString() : null;
+        _metrics?.RecordCrossTenantQuery(entity, "explicit", tenantId);
+        EfStoreBaseLog.ExplicitCrossTenantQuery(_logger, entity, callerMember, callerFile, callerLine);
         return s_isMultiTenantEntity
             ? db.Set<TEntity>().IgnoreQueryFilters([GranitFilterNames.MultiTenant])
             : db.Set<TEntity>();
     }
-
-    private void LogExplicitCrossTenantQuery(
-        string entity, string callerMember, string callerFile, int callerLine) =>
-        _logger.LogInformation(
-            "Explicit cross-tenant query on {Entity} from {CallerMember} ({CallerFile}:{CallerLine}).",
-            entity, callerMember, callerFile, callerLine);
 
     // ── Read helpers ────────────────────────────────────────────────────
     //

--- a/src/Granit.Persistence.EntityFrameworkCore/Extensions/PersistenceDbContextServiceCollectionExtensions.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/Extensions/PersistenceDbContextServiceCollectionExtensions.cs
@@ -56,7 +56,7 @@ public static class PersistenceDbContextServiceCollectionExtensions
             var configuration = services
                 .FirstOrDefault(d => d.ServiceType == typeof(IConfiguration))
                 ?.ImplementationInstance as IConfiguration;
-            string? hostSchema = configuration?["MultiTenancy:TenantIsolation:HostSchema"];
+            string? hostSchema = configuration?[GranitDbDefaults.HostSchemaConfigurationKey];
             if (hostSchema is not null)
             {
                 GranitDbDefaults.HostDbSchema = hostSchema;

--- a/src/Granit.Persistence.EntityFrameworkCore/Extensions/PersistenceServiceCollectionExtensions.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/Extensions/PersistenceServiceCollectionExtensions.cs
@@ -59,22 +59,27 @@ public static class PersistenceServiceCollectionExtensions
         // tenant-context loss on an IQueryableSource<T> can never leak every tenant's rows.
         services.TryAddScoped<ITenantQueryScope, TenantQueryScope>();
 
-        services.AddScoped<AuditedEntityInterceptor>();
-        services.AddScoped<VersioningInterceptor>();
-        services.AddScoped<ConcurrencyStampInterceptor>();
-        services.AddScoped<SoftDeleteInterceptor>();
-        services.AddScoped<DomainEventDispatcherInterceptor>();
-        services.AddScoped<EntityLifecycleEventInterceptor>();
+        // TryAdd throughout: AddGranitPersistence is a public entry point that may run more
+        // than once (module + explicit host call) — a second call must not duplicate the
+        // interceptors, and consumers keep the ability to pre-register overrides.
+        services.TryAddScoped<AuditedEntityInterceptor>();
+        services.TryAddScoped<VersioningInterceptor>();
+        services.TryAddScoped<ConcurrencyStampInterceptor>();
+        services.TryAddScoped<SoftDeleteInterceptor>();
+        services.TryAddScoped<DomainEventDispatcherInterceptor>();
+        services.TryAddScoped<EntityLifecycleEventInterceptor>();
         services.TryAddSingleton<IDomainEventDispatcher, NullDomainEventDispatcher>();
         services.TryAddSingleton<IIntegrationEventDispatcher, NullIntegrationEventDispatcher>();
-        services.AddSingleton<IDataFilter, DataFilter>();
+        services.TryAddSingleton<IDataFilter, DataFilter>();
 
         // Register the EF Core exception mapper only when Granit.Http.ExceptionHandling
         // has been configured (IExceptionStatusCodeMapper already in the container).
-        // This avoids a hard dependency on ExceptionHandling for consumers that don't use it.
+        // TryAddEnumerable keys on the implementation type, so repeated calls stay
+        // idempotent while other mapper implementations remain registrable.
         if (services.Any(d => d.ServiceType == typeof(IExceptionStatusCodeMapper)))
         {
-            services.AddSingleton<IExceptionStatusCodeMapper, EfCoreExceptionStatusCodeMapper>();
+            services.TryAddEnumerable(ServiceDescriptor.Singleton<
+                IExceptionStatusCodeMapper, EfCoreExceptionStatusCodeMapper>());
         }
 
         return services;

--- a/src/Granit.Persistence.EntityFrameworkCore/Extensions/PersistenceTenantExtensions.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/Extensions/PersistenceTenantExtensions.cs
@@ -37,7 +37,7 @@ public static class PersistenceTenantExtensions
     /// custom factory without being overridden.
     /// </para>
     /// </remarks>
-    public static IServiceCollection AddTenantPerDatabaseDbContext<TContext>(
+    public static IServiceCollection AddGranitTenantPerDatabaseDbContext<TContext>(
         this IServiceCollection services,
         Action<DbContextOptionsBuilder<TContext>, string> configureOptions)
         where TContext : DbContext
@@ -91,13 +91,14 @@ public static class PersistenceTenantExtensions
     /// <see cref="ITenantSchemaActivator"/> for a different database provider.
     /// </para>
     /// </remarks>
-    public static IServiceCollection AddTenantPerSchemaDbContext<TContext>(
+    public static IServiceCollection AddGranitTenantPerSchemaDbContext<TContext>(
         this IServiceCollection services,
         Action<DbContextOptionsBuilder<TContext>> configureOptions,
         Action<TenantSchemaOptions>? configureTenantSchema = null)
         where TContext : DbContext
     {
         services.AddOptions<TenantSchemaOptions>()
+            .BindConfiguration(TenantSchemaOptions.SectionName)
             .Configure(configureTenantSchema ?? (_ => { }))
             .ValidateDataAnnotations()
             .ValidateOnStart();
@@ -175,6 +176,7 @@ public static class PersistenceTenantExtensions
         // factory delegate for the active strategy (see TenantIsolationFactoryRegistrationValidator).
         services.AddOptions<TenantIsolationOptions>()
             .BindConfiguration(TenantIsolationOptions.SectionName)
+            .ValidateDataAnnotations()
             .Validate(
                 opts => Enum.IsDefined(opts.Strategy),
                 "MultiTenancy:TenantIsolation:Strategy is not a valid TenantIsolationStrategy value. " +
@@ -227,6 +229,7 @@ public static class PersistenceTenantExtensions
         if (configureSchemaPerTenant is not null)
         {
             services.AddOptions<TenantSchemaOptions>()
+                .BindConfiguration(TenantSchemaOptions.SectionName)
                 .Configure(configureTenantSchema ?? (_ => { }))
                 .ValidateDataAnnotations()
                 .ValidateOnStart();

--- a/src/Granit.Persistence.EntityFrameworkCore/GranitDbDefaults.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/GranitDbDefaults.cs
@@ -32,12 +32,21 @@ public static class GranitDbDefaults
     /// Database schema for host-level modules (identity, audit, tenants, background
     /// jobs, features, settings, BFF sessions…). When set, host module
     /// <c>*DbProperties</c> use this instead of <see cref="DbSchema"/>.
-    /// Configurable via <c>TenantIsolation:HostSchema</c> in <c>appsettings.json</c>.
+    /// Configurable via <c>MultiTenancy:TenantIsolation:HostSchema</c> in <c>appsettings.json</c>
+    /// (see <see cref="MultiTenancy.TenantIsolationOptions"/>).
     /// </summary>
     public static string? HostDbSchema { get; set; }
 
     /// <summary>
-    /// Sets <see cref="HostDbSchema"/> from <c>TenantIsolation:HostSchema</c> in
+    /// Configuration key for <see cref="HostDbSchema"/> — derived from
+    /// <see cref="MultiTenancy.TenantIsolationOptions.SectionName"/> so an options-section
+    /// rename cannot silently detach this static from its configuration source.
+    /// </summary>
+    internal static readonly string HostSchemaConfigurationKey =
+        $"{MultiTenancy.TenantIsolationOptions.SectionName}:{nameof(MultiTenancy.TenantIsolationOptions.HostSchema)}";
+
+    /// <summary>
+    /// Sets <see cref="HostDbSchema"/> from <c>MultiTenancy:TenantIsolation:HostSchema</c> in
     /// configuration if not already set. Idempotent — first call wins.
     /// </summary>
     /// <remarks>
@@ -49,15 +58,7 @@ public static class GranitDbDefaults
     /// <param name="configuration">The application configuration.</param>
     public static void EnsureFromConfiguration(Microsoft.Extensions.Configuration.IConfiguration configuration)
     {
-        if (HostDbSchema is not null)
-        {
-            System.Diagnostics.Trace.TraceInformation("[GranitDbDefaults] EnsureFromConfiguration SKIPPED — already '{0}'", HostDbSchema);
-            return;
-        }
-
-        string? hostSchema = configuration["MultiTenancy:TenantIsolation:HostSchema"];
-        System.Diagnostics.Trace.TraceInformation("[GranitDbDefaults] EnsureFromConfiguration read '{0}' from config", hostSchema ?? "(null)");
-        if (hostSchema is not null)
+        if (HostDbSchema is null && configuration[HostSchemaConfigurationKey] is { } hostSchema)
         {
             HostDbSchema = hostSchema;
         }

--- a/src/Granit.Persistence.EntityFrameworkCore/GranitPersistenceEntityFrameworkCoreModule.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/GranitPersistenceEntityFrameworkCoreModule.cs
@@ -2,19 +2,24 @@ using Granit.Guids;
 using Granit.Http.ExceptionHandling;
 using Granit.Modularity;
 using Granit.Persistence.EntityFrameworkCore.Extensions;
+using Granit.QueryEngine;
 using Granit.Timing;
 
 namespace Granit.Persistence.EntityFrameworkCore;
 
 /// <summary>
 /// Granit module for EF Core interceptors (ISO 27001 audit trail + GDPR soft delete).
-/// Depends on Timing (IClock), Guids (IGuidGenerator), and Security (ICurrentUserService).
+/// Depends on Timing (IClock), Guids (IGuidGenerator), Http.ExceptionHandling
+/// (EF Core → HTTP status mapping), QueryEngine.Abstractions (PagedResult) and the
+/// Persistence abstractions (Specification).
 /// ICurrentTenant is resolved via Granit.MultiTenancy — Granit.MultiTenancy
 /// is not a direct dependency of this module.
 /// </summary>
 [DependsOn(
     typeof(GranitGuidsModule),
     typeof(GranitHttpExceptionHandlingModule),
+    typeof(GranitPersistenceModule),
+    typeof(GranitQueryEngineAbstractionsModule),
     typeof(GranitTimingModule))]
 public sealed class GranitPersistenceEntityFrameworkCoreModule : GranitModule
 {

--- a/src/Granit.Persistence.EntityFrameworkCore/Metadata/MetadataServiceCollectionExtensions.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/Metadata/MetadataServiceCollectionExtensions.cs
@@ -18,7 +18,7 @@ public static class MetadataServiceCollectionExtensions
     /// </summary>
     /// <param name="services">The service collection.</param>
     /// <returns>The service collection for chaining.</returns>
-    public static IServiceCollection AddMetadataInfrastructure(this IServiceCollection services)
+    public static IServiceCollection AddGranitMetadataInfrastructure(this IServiceCollection services)
     {
         ArgumentNullException.ThrowIfNull(services);
 
@@ -41,7 +41,7 @@ public static class MetadataServiceCollectionExtensions
     /// <param name="services">The service collection.</param>
     /// <param name="configure">Action to configure the property mappings.</param>
     /// <returns>The service collection for chaining.</returns>
-    public static IServiceCollection AddMetadataMappings<TEntity>(
+    public static IServiceCollection AddGranitMetadataMappings<TEntity>(
         this IServiceCollection services,
         Action<MetadataMappingOptions<TEntity>> configure)
         where TEntity : class, IHasMetadata
@@ -49,7 +49,7 @@ public static class MetadataServiceCollectionExtensions
         ArgumentNullException.ThrowIfNull(services);
         ArgumentNullException.ThrowIfNull(configure);
 
-        services.AddMetadataInfrastructure();
+        services.AddGranitMetadataInfrastructure();
 
         var options = new MetadataMappingOptions<TEntity>();
         configure(options);
@@ -76,7 +76,7 @@ public static class MetadataServiceCollectionExtensions
     /// Function that extracts <see cref="MetadataMapping"/> instances from the options.
     /// </param>
     /// <returns>The service collection for chaining.</returns>
-    public static IServiceCollection AddMetadataMappingsFromOptions<TEntity, TOptions>(
+    public static IServiceCollection AddGranitMetadataMappingsFromOptions<TEntity, TOptions>(
         this IServiceCollection services,
         Func<TOptions, List<MetadataMapping>> extractor)
         where TEntity : class, IHasMetadata
@@ -85,7 +85,7 @@ public static class MetadataServiceCollectionExtensions
         ArgumentNullException.ThrowIfNull(services);
         ArgumentNullException.ThrowIfNull(extractor);
 
-        services.AddMetadataInfrastructure();
+        services.AddGranitMetadataInfrastructure();
 
         services.AddSingleton<IConfigureMetadataRegistry>(sp =>
         {

--- a/src/Granit.Persistence.EntityFrameworkCore/MultiTenancy/ITenantSchemaActivator.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/MultiTenancy/ITenantSchemaActivator.cs
@@ -29,7 +29,7 @@ namespace Granit.Persistence.EntityFrameworkCore.MultiTenancy;
 /// The default is <c>PostgresqlTenantSchemaActivator</c>, registered via
 /// <see cref="Extensions.PersistenceTenantExtensions"/> with <c>TryAddSingleton</c>.
 /// To use a different provider, register your <see cref="ITenantSchemaActivator"/>
-/// before calling <c>AddTenantPerSchemaDbContext</c>.
+/// before calling <c>AddGranitTenantPerSchemaDbContext</c>.
 /// </para>
 /// <para>
 /// <strong>Connection pool safety (critical)</strong> — implementations MUST execute the

--- a/src/Granit.Persistence.EntityFrameworkCore/MultiTenancy/TenantPerDatabaseDbContextFactory.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/MultiTenancy/TenantPerDatabaseDbContextFactory.cs
@@ -13,7 +13,7 @@ namespace Granit.Persistence.EntityFrameworkCore.MultiTenancy;
 /// Reads <see cref="ICurrentTenant.Id"/> and delegates connection string resolution to
 /// <see cref="ITenantConnectionStringProvider"/>. The database provider (Npgsql, SQL Server…)
 /// is configured by the <c>Action&lt;DbContextOptionsBuilder, string&gt;</c> delegate
-/// registered at startup via <c>AddTenantPerDatabaseDbContext&lt;TContext&gt;()</c>.
+/// registered at startup via <c>AddGranitTenantPerDatabaseDbContext&lt;TContext&gt;()</c>.
 /// </para>
 /// <para>
 /// Throws <see cref="InvalidOperationException"/> when no tenant is active.

--- a/src/Granit.Persistence.EntityFrameworkCore/MultiTenancy/TenantPerDatabaseDbContextOptions.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/MultiTenancy/TenantPerDatabaseDbContextOptions.cs
@@ -4,7 +4,7 @@ namespace Granit.Persistence.EntityFrameworkCore.MultiTenancy;
 
 /// <summary>
 /// Carries the provider configuration delegate for <see cref="TenantPerDatabaseDbContextFactory{TContext}"/>.
-/// Registered in DI by <c>AddTenantPerDatabaseDbContext&lt;TContext&gt;()</c>.
+/// Registered in DI by <c>AddGranitTenantPerDatabaseDbContext&lt;TContext&gt;()</c>.
 /// </summary>
 internal sealed class TenantPerDatabaseDbContextOptions<TContext>
     where TContext : DbContext

--- a/src/Granit.Persistence.EntityFrameworkCore/MultiTenancy/TenantPerSchemaDbContextOptions.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/MultiTenancy/TenantPerSchemaDbContextOptions.cs
@@ -4,7 +4,7 @@ namespace Granit.Persistence.EntityFrameworkCore.MultiTenancy;
 
 /// <summary>
 /// Carries the provider configuration delegate for <see cref="TenantPerSchemaDbContextFactory{TContext}"/>.
-/// Registered in DI by <c>AddTenantPerSchemaDbContext&lt;TContext&gt;()</c>.
+/// Registered in DI by <c>AddGranitTenantPerSchemaDbContext&lt;TContext&gt;()</c>.
 /// </summary>
 internal sealed class TenantPerSchemaDbContextOptions<TContext>
     where TContext : DbContext

--- a/src/Granit.Presence.EntityFrameworkCore/GranitPresenceEntityFrameworkCoreModule.cs
+++ b/src/Granit.Presence.EntityFrameworkCore/GranitPresenceEntityFrameworkCoreModule.cs
@@ -12,6 +12,6 @@ namespace Granit.Presence.EntityFrameworkCore;
 /// <c>AddGranitPresenceEntityFrameworkCore(opts =&gt; opts.UseNpgsql(connectionString))</c>.
 /// </remarks>
 [DependsOn(
-    typeof(GranitPresenceModule),
-    typeof(GranitPersistenceEntityFrameworkCoreModule))]
+    typeof(GranitPersistenceEntityFrameworkCoreModule),
+    typeof(GranitPresenceModule))]
 public sealed class GranitPresenceEntityFrameworkCoreModule : GranitModule;

--- a/src/Granit.Presence.Notifications/GranitPresenceNotificationsModule.cs
+++ b/src/Granit.Presence.Notifications/GranitPresenceNotificationsModule.cs
@@ -11,8 +11,8 @@ namespace Granit.Presence.Notifications;
 /// suppressed for users in <c>DoNotDisturb</c> or <c>Offline</c>.
 /// </summary>
 [DependsOn(
-    typeof(GranitPresenceModule),
-    typeof(GranitNotificationsAbstractionsModule))]
+    typeof(GranitNotificationsAbstractionsModule),
+    typeof(GranitPresenceModule))]
 public sealed class GranitPresenceNotificationsModule : GranitModule
 {
     /// <inheritdoc />

--- a/src/Granit.Privacy.EntityFrameworkCore/GranitPrivacyEntityFrameworkCoreModule.cs
+++ b/src/Granit.Privacy.EntityFrameworkCore/GranitPrivacyEntityFrameworkCoreModule.cs
@@ -5,6 +5,6 @@ namespace Granit.Privacy.EntityFrameworkCore;
 
 /// <summary>EF Core persistence for Granit.Privacy.</summary>
 [DependsOn(
-    typeof(GranitPrivacyModule),
-    typeof(GranitPersistenceEntityFrameworkCoreModule))]
+    typeof(GranitPersistenceEntityFrameworkCoreModule),
+    typeof(GranitPrivacyModule))]
 public sealed class GranitPrivacyEntityFrameworkCoreModule : GranitModule;

--- a/src/Granit.Settings.EntityFrameworkCore/GranitSettingsEntityFrameworkCoreModule.cs
+++ b/src/Granit.Settings.EntityFrameworkCore/GranitSettingsEntityFrameworkCoreModule.cs
@@ -15,6 +15,6 @@ namespace Granit.Settings.EntityFrameworkCore;
 /// </code>
 /// </remarks>
 [DependsOn(
-    typeof(GranitSettingsModule),
-    typeof(GranitPersistenceEntityFrameworkCoreModule))]
+    typeof(GranitPersistenceEntityFrameworkCoreModule),
+    typeof(GranitSettingsModule))]
 public sealed class GranitSettingsEntityFrameworkCoreModule : GranitModule;

--- a/src/Granit.Templating.Endpoints/GranitTemplatingEndpointsModule.cs
+++ b/src/Granit.Templating.Endpoints/GranitTemplatingEndpointsModule.cs
@@ -25,8 +25,8 @@ namespace Granit.Templating.Endpoints;
 /// Permission definition providers are auto-discovered by <c>GranitAuthorizationModule</c>.
 /// </remarks>
 [DependsOn(
-    typeof(GranitHttpApiDocumentationModule),
     typeof(GranitAuthorizationModule),
+    typeof(GranitHttpApiDocumentationModule),
     typeof(GranitQueryEngineEndpointsModule),
     typeof(GranitTemplatingModule),
     typeof(GranitValidationModule),

--- a/src/Granit.Timeline.Auditing/GranitTimelineAuditingModule.cs
+++ b/src/Granit.Timeline.Auditing/GranitTimelineAuditingModule.cs
@@ -15,8 +15,8 @@ namespace Granit.Timeline.Auditing;
 /// by the audit log.
 /// </remarks>
 [DependsOn(
-    typeof(GranitTimelineModule),
-    typeof(GranitAuditingModule))]
+    typeof(GranitAuditingModule),
+    typeof(GranitTimelineModule))]
 public sealed class GranitTimelineAuditingModule : GranitModule
 {
     /// <inheritdoc/>

--- a/src/Granit.Webhooks.EntityFrameworkCore/GranitWebhooksEntityFrameworkCoreModule.cs
+++ b/src/Granit.Webhooks.EntityFrameworkCore/GranitWebhooksEntityFrameworkCoreModule.cs
@@ -12,6 +12,6 @@ namespace Granit.Webhooks.EntityFrameworkCore;
 /// <c>AddGranitWebhooksEntityFrameworkCore(opts => opts.UseNpgsql(connectionString))</c>.
 /// </remarks>
 [DependsOn(
-    typeof(GranitWebhooksModule),
-    typeof(GranitPersistenceEntityFrameworkCoreModule))]
+    typeof(GranitPersistenceEntityFrameworkCoreModule),
+    typeof(GranitWebhooksModule))]
 public sealed class GranitWebhooksEntityFrameworkCoreModule : GranitModule;

--- a/src/Granit.Wolverine.Postgresql/Extensions/WolverinePostgresqlHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Wolverine.Postgresql/Extensions/WolverinePostgresqlHostApplicationBuilderExtensions.cs
@@ -95,7 +95,7 @@ public static class WolverinePostgresqlHostApplicationBuilderExtensions
     {
         // Register the per-tenant factory and DbContext as Scoped via Granit.Persistence.
         // TryAdd semantics preserve any existing registration (e.g., overrides from integration tests).
-        builder.Services.AddTenantPerDatabaseDbContext<TContext>(
+        builder.Services.AddGranitTenantPerDatabaseDbContext<TContext>(
             static (opts, connectionString) => opts.UseNpgsql(connectionString));
 
         return AddGranitWolverineWithPostgresqlCore(builder, configure);

--- a/src/Granit.Wolverine.SqlServer/Extensions/WolverineSqlServerHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Wolverine.SqlServer/Extensions/WolverineSqlServerHostApplicationBuilderExtensions.cs
@@ -95,7 +95,7 @@ public static class WolverineSqlServerHostApplicationBuilderExtensions
     {
         // Register the per-tenant factory and DbContext as Scoped via Granit.Persistence.
         // TryAdd semantics preserve any existing registration (e.g., overrides from integration tests).
-        builder.Services.AddTenantPerDatabaseDbContext<TContext>(
+        builder.Services.AddGranitTenantPerDatabaseDbContext<TContext>(
             static (opts, connectionString) => opts.UseSqlServer(connectionString));
 
         return AddGranitWolverineWithSqlServerCore(builder, configure);

--- a/src/Granit.Workflow.Scheduling/GranitWorkflowSchedulingModule.cs
+++ b/src/Granit.Workflow.Scheduling/GranitWorkflowSchedulingModule.cs
@@ -15,8 +15,8 @@ namespace Granit.Workflow.Scheduling;
 /// <c>ScheduledActionStatusMiddleware</c> from that provider automatically wraps this handler.
 /// </remarks>
 [DependsOn(
-    typeof(GranitWorkflowModule),
-    typeof(GranitSchedulingModule))]
+    typeof(GranitSchedulingModule),
+    typeof(GranitWorkflowModule))]
 public sealed class GranitWorkflowSchedulingModule : GranitModule
 {
     /// <inheritdoc/>

--- a/tests/Granit.ArchitectureTests/DependsOnProjectReferenceConventionTests.cs
+++ b/tests/Granit.ArchitectureTests/DependsOnProjectReferenceConventionTests.cs
@@ -1,0 +1,223 @@
+using System.Reflection;
+using System.Text.RegularExpressions;
+using Granit.Modularity;
+using Shouldly;
+using Xunit;
+
+namespace Granit.ArchitectureTests;
+
+/// <summary>
+/// Cross-checks every module's <c>[DependsOn]</c> declaration against its project's direct
+/// <c>&lt;ProjectReference&gt;</c> graph (CLAUDE.md §[DependsOn] rules): a direct project
+/// reference that exposes a <see cref="GranitModule"/> MUST be declared; transitive-only
+/// modules MUST NOT be; <c>Granit</c> is the implicit base and is never declared; the
+/// argument list is alphabetical. Before this guard, omissions were invisible to CI — the
+/// 2026-08-04 persistence audit found three in the Persistence family alone (#3153).
+/// </summary>
+public sealed partial class DependsOnProjectReferenceConventionTests
+{
+    [GeneratedRegex("""<ProjectReference\s+Include="(?<path>[^"]+)"\s*/?>""")]
+    private static partial Regex ProjectReferenceRegex();
+
+    /// <summary>
+    /// RATCHET (#3172) — projects whose <c>[DependsOn]</c> predates this guard and still omits
+    /// modules exposed by direct project references (overwhelmingly <c>*AbstractionsModule</c>
+    /// deps). The missing-declaration assertion is skipped for these; the no-transitive and
+    /// alphabetical assertions still apply. DO NOT add entries — fix the module's
+    /// <c>[DependsOn]</c> instead. Remove an entry once its module declares its direct refs.
+    /// </summary>
+    private static readonly HashSet<string> KnownMissingDeclarations = new(StringComparer.Ordinal)
+    {
+        // Baseline frozen 2026-08-04 from the first repo-wide run (74 projects) — see #3172.
+        "Granit.AI",
+        "Granit.AI.Chat",
+        "Granit.AI.Chat.Endpoints",
+        "Granit.AI.Endpoints",
+        "Granit.AI.Prompts",
+        "Granit.AI.Prompts.Endpoints",
+        "Granit.AI.Prompts.EntityFrameworkCore",
+        "Granit.Authentication.ApiKeys",
+        "Granit.Authentication.ApiKeys.Endpoints",
+        "Granit.Authentication.Mtls",
+        "Granit.Authorization",
+        "Granit.Authorization.Endpoints",
+        "Granit.Authorization.EntityFrameworkCore",
+        "Granit.BackgroundJobs",
+        "Granit.BackgroundJobs.EntityFrameworkCore",
+        "Granit.Bff.Endpoints",
+        "Granit.Bff.EntityFrameworkCore",
+        "Granit.Bff.Yarp",
+        "Granit.BlobStorage",
+        "Granit.BlobStorage.GoogleCloud",
+        "Granit.BlobStorage.Proxy",
+        "Granit.BlobStorage.S3",
+        "Granit.Browsing",
+        "Granit.Caching.StackExchangeRedis",
+        "Granit.DataLookup.EntityFrameworkCore",
+        "Granit.Entities.Abstractions",
+        "Granit.EntityMerge.EntityFrameworkCore",
+        "Granit.Features.EntityFrameworkCore",
+        "Granit.Hostnames",
+        "Granit.Hostnames.Endpoints",
+        "Granit.Http.Cookies.Endpoints",
+        "Granit.Http.Idempotency.StackExchangeRedis",
+        "Granit.Http.ODataExposure",
+        "Granit.Http.OutputCaching.StackExchangeRedis",
+        "Granit.Identity",
+        "Granit.Identity.Abstractions",
+        "Granit.Identity.Endpoints",
+        "Granit.Identity.EntityFrameworkCore",
+        "Granit.Identity.Federated",
+        "Granit.Identity.Federated.Cognito",
+        "Granit.Identity.Federated.EntraId",
+        "Granit.Identity.Federated.Keycloak",
+        "Granit.Identity.Local",
+        "Granit.Identity.Local.AspNetIdentity",
+        "Granit.Identity.Local.Endpoints",
+        "Granit.Indexing.Elasticsearch",
+        "Granit.Indexing.EntityFrameworkCore",
+        "Granit.Localization",
+        "Granit.Localization.Endpoints",
+        "Granit.Localization.EntityFrameworkCore",
+        "Granit.Mcp.Server",
+        "Granit.Mentions",
+        "Granit.MultiTenancy.Auditing",
+        "Granit.MultiTenancy.Authorization",
+        "Granit.Notifications.Abstractions",
+        "Granit.Notifications.Sse",
+        "Granit.Notifications.WhatsApp",
+        "Granit.Presence.Endpoints",
+        "Granit.Privacy",
+        "Granit.Privacy.Endpoints",
+        "Granit.Privacy.EntityFrameworkCore",
+        "Granit.QueryEngine.AI",
+        "Granit.QueryEngine.Abstractions",
+        "Granit.QueryEngine.Endpoints",
+        "Granit.Scheduling",
+        "Granit.Scheduling.EntityFrameworkCore",
+        "Granit.Settings",
+        "Granit.Settings.EntityFrameworkCore",
+        "Granit.Templating",
+        "Granit.Templating.EntityFrameworkCore",
+        "Granit.Testing",
+        "Granit.Webhooks",
+        "Granit.Webhooks.Endpoints",
+        "Granit.Workflow",
+    };
+
+    public static TheoryData<string> ModuleProjects()
+    {
+        TheoryData<string> data = [];
+        foreach (string csproj in EnumerateSrcProjects())
+        {
+            if (LoadModules(Path.GetFileNameWithoutExtension(csproj)).Count > 0)
+            {
+                data.Add(Path.GetFileNameWithoutExtension(csproj));
+            }
+        }
+
+        return data;
+    }
+
+    [Theory]
+    [MemberData(nameof(ModuleProjects))]
+    public void DependsOn_matches_direct_project_references(string projectName)
+    {
+        string csproj = EnumerateSrcProjects()
+            .Single(p => Path.GetFileNameWithoutExtension(p) == projectName);
+
+        // Expected: every DIRECT ProjectReference whose assembly exposes a GranitModule,
+        // except the implicit base assembly "Granit".
+        List<Type> expected = [];
+        foreach (string referencedProject in DirectProjectReferences(csproj))
+        {
+            if (referencedProject == "Granit")
+            {
+                continue;
+            }
+
+            expected.AddRange(LoadModules(referencedProject));
+        }
+
+        // Actual: union of [DependsOn] across the project's module classes (almost always one).
+        IReadOnlyList<Type> modules = LoadModules(projectName);
+        List<Type> declared = [.. modules
+            .SelectMany(m => m.GetCustomAttributes<DependsOnAttribute>(inherit: false))
+            .SelectMany(a => a.DependedTypes)];
+
+        string moduleNames = string.Join(", ", modules.Select(m => m.Name));
+
+        List<string> missing = [.. expected
+            .Where(e => !declared.Contains(e))
+            .Select(e => e.Name)
+            .Order(StringComparer.Ordinal)];
+        List<string> extra = [.. declared
+            .Where(d => !expected.Contains(d))
+            .Select(d => d.Name)
+            .Order(StringComparer.Ordinal)];
+
+        if (KnownMissingDeclarations.Contains(projectName))
+        {
+            // Ratchet (#3172): tolerate pre-existing omissions, but flag a resolved entry so
+            // the baseline shrinks as modules are fixed.
+            missing.ShouldNotBeEmpty(
+                $"{projectName} no longer has missing [DependsOn] declarations — remove it from "
+                + "KnownMissingDeclarations (ratchet #3172).");
+            missing = [];
+        }
+
+        missing.ShouldBeEmpty(
+            $"{moduleNames}: direct ProjectReferences expose these modules but [DependsOn] omits them "
+            + $"(declare direct refs, CLAUDE.md §[DependsOn]): {string.Join(", ", missing)}");
+        extra.ShouldBeEmpty(
+            $"{moduleNames}: [DependsOn] declares modules with no matching direct ProjectReference "
+            + $"(transitive deps must be omitted): {string.Join(", ", extra)}");
+
+        // Alphabetical order, per attribute.
+        foreach (Type module in modules)
+        {
+            foreach (DependsOnAttribute attribute in module.GetCustomAttributes<DependsOnAttribute>(inherit: false))
+            {
+                string[] names = [.. attribute.DependedTypes.Select(x => x.Name)];
+                names.ShouldBe([.. names.Order(StringComparer.Ordinal)],
+                    $"{module.Name}: [DependsOn] arguments must be alphabetical.");
+            }
+        }
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────────
+
+    private static IEnumerable<string> EnumerateSrcProjects()
+    {
+        string srcDir = Path.Combine(ArchitectureTestHelpers.FindRepoRoot(), "src");
+        return Directory.EnumerateFiles(srcDir, "*.csproj", SearchOption.AllDirectories);
+    }
+
+    private static IEnumerable<string> DirectProjectReferences(string csproj)
+    {
+        string content = File.ReadAllText(csproj);
+        foreach (Match match in ProjectReferenceRegex().Matches(content))
+        {
+            yield return Path.GetFileNameWithoutExtension(
+                match.Groups["path"].Value.Replace('\\', Path.DirectorySeparatorChar));
+        }
+    }
+
+    /// <summary>
+    /// Loads the public, non-abstract <see cref="GranitModule"/> subclasses of a src assembly.
+    /// Assemblies absent from the test output (netstandard analyzers, bundles, exe tools — see
+    /// <see cref="ArchitectureTestCoverageTests"/> exemptions) yield an empty list and are skipped.
+    /// </summary>
+    private static IReadOnlyList<Type> LoadModules(string assemblyName)
+    {
+        string path = Path.Combine(AppContext.BaseDirectory, $"{assemblyName}.dll");
+        if (!File.Exists(path))
+        {
+            return [];
+        }
+
+        var assembly = Assembly.Load(new AssemblyName(assemblyName));
+        return [.. assembly.GetExportedTypes()
+            .Where(t => t is { IsClass: true, IsAbstract: false } && typeof(GranitModule).IsAssignableFrom(t))];
+    }
+}

--- a/tests/Granit.ArchitectureTests/OptionsBindingConventionTests.cs
+++ b/tests/Granit.ArchitectureTests/OptionsBindingConventionTests.cs
@@ -60,7 +60,6 @@ public sealed partial class OptionsBindingConventionTests
         ["SmtpOptions"] = "#3010 — pre-existing unbound section 'Notifications:Smtp'",
         ["SseRedisBackplaneOptions"] = "#3010 — pre-existing unbound section 'Notifications:Sse:StackExchangeRedis'",
         ["TemplatingEndpointsOptions"] = "#3010 — pre-existing unbound section 'Templating:Endpoints'",
-        ["TenantSchemaOptions"] = "#3010 — pre-existing unbound section 'MultiTenancy:TenantSchema'",
         ["TimelineEndpointsOptions"] = "#3010 — pre-existing unbound section 'Timeline:Endpoints'",
         ["TokenManagementOptions"] = "#3010 — pre-existing unbound section 'Oidc:TokenManagement'",
         ["TwilioOptions"] = "#3010 — pre-existing unbound section 'Notifications:Twilio'",

--- a/tests/Granit.Persistence.EntityFrameworkCore.Hosting.Tests/GranitMigrateOptionsTests.cs
+++ b/tests/Granit.Persistence.EntityFrameworkCore.Hosting.Tests/GranitMigrateOptionsTests.cs
@@ -4,7 +4,7 @@ using Xunit;
 
 namespace Granit.Persistence.EntityFrameworkCore.Hosting.Tests;
 
-public class GranitMigrateOptionsTests
+public sealed class GranitMigrateOptionsTests
 {
     [Fact]
     public void Defaults_should_be_production_safe()

--- a/tests/Granit.Persistence.EntityFrameworkCore.Tests/MultiTenancy/PersistenceTenantExtensionsTests.cs
+++ b/tests/Granit.Persistence.EntityFrameworkCore.Tests/MultiTenancy/PersistenceTenantExtensionsTests.cs
@@ -12,15 +12,15 @@ public sealed class PersistenceTenantExtensionsTests
     private sealed class TestDbContext(DbContextOptions<TestDbContext> options) : DbContext(options);
 
     // -------------------------------------------------------------------------
-    // AddTenantPerDatabaseDbContext
+    // AddGranitTenantPerDatabaseDbContext
     // -------------------------------------------------------------------------
 
     [Fact]
-    public void AddTenantPerDatabaseDbContext_RegistersFactory_Scoped()
+    public void AddGranitTenantPerDatabaseDbContext_RegistersFactory_Scoped()
     {
         ServiceCollection services = new();
 
-        services.AddTenantPerDatabaseDbContext<TestDbContext>((opts, cs) =>
+        services.AddGranitTenantPerDatabaseDbContext<TestDbContext>((opts, cs) =>
             opts.UseInMemoryDatabase(cs));
 
         services.ShouldContain(d =>
@@ -29,11 +29,11 @@ public sealed class PersistenceTenantExtensionsTests
     }
 
     [Fact]
-    public void AddTenantPerDatabaseDbContext_RegistersContext_Scoped()
+    public void AddGranitTenantPerDatabaseDbContext_RegistersContext_Scoped()
     {
         ServiceCollection services = new();
 
-        services.AddTenantPerDatabaseDbContext<TestDbContext>((opts, cs) =>
+        services.AddGranitTenantPerDatabaseDbContext<TestDbContext>((opts, cs) =>
             opts.UseInMemoryDatabase(cs));
 
         services.ShouldContain(d =>
@@ -42,12 +42,12 @@ public sealed class PersistenceTenantExtensionsTests
     }
 
     [Fact]
-    public void AddTenantPerDatabaseDbContext_TryAdd_DoesNotOverridePreRegistered()
+    public void AddGranitTenantPerDatabaseDbContext_TryAdd_DoesNotOverridePreRegistered()
     {
         ServiceCollection services = new();
         services.AddScoped<IDbContextFactory<TestDbContext>>(
             _ => null!); // pre-register
-        services.AddTenantPerDatabaseDbContext<TestDbContext>((opts, cs) =>
+        services.AddGranitTenantPerDatabaseDbContext<TestDbContext>((opts, cs) =>
             opts.UseInMemoryDatabase(cs));
 
         services.Count(d => d.ServiceType == typeof(IDbContextFactory<TestDbContext>))
@@ -55,26 +55,26 @@ public sealed class PersistenceTenantExtensionsTests
     }
 
     [Fact]
-    public void AddTenantPerDatabaseDbContext_ReturnsServiceCollection_ForChaining()
+    public void AddGranitTenantPerDatabaseDbContext_ReturnsServiceCollection_ForChaining()
     {
         ServiceCollection services = new();
 
-        IServiceCollection result = services.AddTenantPerDatabaseDbContext<TestDbContext>(
+        IServiceCollection result = services.AddGranitTenantPerDatabaseDbContext<TestDbContext>(
             (opts, cs) => opts.UseInMemoryDatabase(cs));
 
         result.ShouldBeSameAs(services);
     }
 
     // -------------------------------------------------------------------------
-    // AddTenantPerSchemaDbContext
+    // AddGranitTenantPerSchemaDbContext
     // -------------------------------------------------------------------------
 
     [Fact]
-    public void AddTenantPerSchemaDbContext_RegistersFactory_Scoped()
+    public void AddGranitTenantPerSchemaDbContext_RegistersFactory_Scoped()
     {
         ServiceCollection services = new();
 
-        services.AddTenantPerSchemaDbContext<TestDbContext>(opts =>
+        services.AddGranitTenantPerSchemaDbContext<TestDbContext>(opts =>
             opts.UseInMemoryDatabase("shared-db"));
 
         services.ShouldContain(d =>
@@ -83,11 +83,11 @@ public sealed class PersistenceTenantExtensionsTests
     }
 
     [Fact]
-    public void AddTenantPerSchemaDbContext_RegistersDefaultSchemaProvider()
+    public void AddGranitTenantPerSchemaDbContext_RegistersDefaultSchemaProvider()
     {
         ServiceCollection services = new();
 
-        services.AddTenantPerSchemaDbContext<TestDbContext>(opts =>
+        services.AddGranitTenantPerSchemaDbContext<TestDbContext>(opts =>
             opts.UseInMemoryDatabase("shared-db"));
 
         services.ShouldContain(d =>
@@ -96,11 +96,11 @@ public sealed class PersistenceTenantExtensionsTests
     }
 
     [Fact]
-    public void AddTenantPerSchemaDbContext_WithSchemaOptions_RegistersOptions()
+    public void AddGranitTenantPerSchemaDbContext_WithSchemaOptions_RegistersOptions()
     {
         ServiceCollection services = new();
 
-        services.AddTenantPerSchemaDbContext<TestDbContext>(
+        services.AddGranitTenantPerSchemaDbContext<TestDbContext>(
             opts => opts.UseInMemoryDatabase("shared-db"),
             schema => schema.Prefix = "t_");
 
@@ -108,25 +108,25 @@ public sealed class PersistenceTenantExtensionsTests
     }
 
     [Fact]
-    public void AddTenantPerSchemaDbContext_DoesNotRegisterDefaultSchemaActivator()
+    public void AddGranitTenantPerSchemaDbContext_DoesNotRegisterDefaultSchemaActivator()
     {
         // No default ITenantSchemaActivator since Granit.Persistence.EntityFrameworkCore.Postgres was
         // decoupled from the generic persistence package. Callers must invoke
         // AddGranitPostgres() (or register their own implementation) before this call.
         ServiceCollection services = new();
 
-        services.AddTenantPerSchemaDbContext<TestDbContext>(opts =>
+        services.AddGranitTenantPerSchemaDbContext<TestDbContext>(opts =>
             opts.UseInMemoryDatabase("shared-db"));
 
         services.ShouldNotContain(d => d.ServiceType == typeof(ITenantSchemaActivator));
     }
 
     [Fact]
-    public void AddTenantPerSchemaDbContext_ReturnsServiceCollection_ForChaining()
+    public void AddGranitTenantPerSchemaDbContext_ReturnsServiceCollection_ForChaining()
     {
         ServiceCollection services = new();
 
-        IServiceCollection result = services.AddTenantPerSchemaDbContext<TestDbContext>(
+        IServiceCollection result = services.AddGranitTenantPerSchemaDbContext<TestDbContext>(
             opts => opts.UseInMemoryDatabase("shared-db"));
 
         result.ShouldBeSameAs(services);

--- a/tests/Granit.Persistence.EntityFrameworkCore.Tests/MultiTenancy/TenantIsolationOptionsTests.cs
+++ b/tests/Granit.Persistence.EntityFrameworkCore.Tests/MultiTenancy/TenantIsolationOptionsTests.cs
@@ -14,4 +14,7 @@ public sealed class TenantIsolationOptionsTests
         options.Strategy.ShouldBe(TenantIsolationStrategy.SharedDatabase);
     }
 
+    [Fact]
+    public void SectionName_HasExpectedValue() =>
+        TenantIsolationOptions.SectionName.ShouldBe("MultiTenancy:TenantIsolation");
 }


### PR DESCRIPTION
Closes #3153 (story of #3144, epic #3143). Companion tech-debt: #3172.

## What this does

Batches the 12 convention-level findings from the 2026-08-04 persistence audit, anchored by a **new repo-wide architecture guard**.

### The guard (the load-bearing piece)

`DependsOnProjectReferenceConventionTests` cross-checks every module's `[DependsOn]` against its project's direct `<ProjectReference>` graph: missing declarations, superfluous transitive declarations, and alphabetical ordering (CLAUDE.md §[DependsOn]). Findings from the first repo-wide run:

- **74 modules** omit declarations for directly-referenced modules (overwhelmingly `*AbstractionsModule` deps). Frozen in a `KnownMissingDeclarations` ratchet baseline — new drift fails CI, the backlog is tracked in #3172, and the test flags any entry that becomes resolved so the baseline can only shrink.
- **11 modules** had non-alphabetical `[DependsOn]` argument lists — all fixed in this PR.
- **Zero** modules declare superfluous transitive deps — that assertion is enforced un-ratcheted from day one.

The 3 Persistence-family omissions from the audit are fixed (EFCore: `GranitPersistenceModule` + `GranitQueryEngineAbstractionsModule`; Postgres: `GranitObservabilityModule`) with the module XML docs corrected.

### The findings batch

- **`TenantSchemaOptions` was decorative**: `SectionName` existed and was unit-tested, but neither registration site called `BindConfiguration` — `MultiTenancy:TenantSchema` in appsettings was silently ignored. Now bound at both sites (config first, delegate override second); #3010 ratchet exemption removed. `TenantIsolationOptions` gains `ValidateDataAnnotations()` + the missing `SectionName` test.
- **`AddGranitPersistence` idempotent**: `TryAdd*` throughout (a second call no longer duplicates the six interceptors; consumers can pre-register overrides); the EF Core exception mapper uses `TryAddEnumerable`.
- **SOC counter attribution**: `granit.persistence.cross_tenant_query` now carries `tenant_id` (coalesced to `"global"`); the `explicit` origin reports the tenant whose scope issued the cross-tenant read.
- **`[LoggerMessage]` completion**: the family's only runtime-formatted log call (`EfStoreBase`, hot path) moved to source-generated `EfStoreBaseLog` (generic types cannot host the generator).
- **Health checks hardened** (both providers): 10s default per-probe timeout via linked CTS (a hung TCP connect no longer blocks readiness for the driver's 15–30s default), and sanitized failure descriptions — the raw driver exception (host/port/database/user) is no longer attached to probe results (ISO 27001).
- **`GranitDbDefaults` cleanup**: leftover `Trace.TraceInformation` debugging removed; the `MultiTenancy:TenantIsolation:HostSchema` path is derived from `TenantIsolationOptions.SectionName` instead of duplicated magic strings; XML doc drift fixed.
- Missing `ConfigureAwait(false)` on `MigrationStartupService`'s `await foreach`.

## Breaking

DI extensions renamed for the `Granit` prefix convention (collision safety in shared namespaces): `AddMetadataInfrastructure` → `AddGranitMetadataInfrastructure`, `AddMetadataMappings` → `AddGranitMetadataMappings`, `AddMetadataMappingsFromOptions` → `AddGranitMetadataMappingsFromOptions`, `AddTenantPerDatabaseDbContext` → `AddGranitTenantPerDatabaseDbContext`, `AddTenantPerSchemaDbContext` → `AddGranitTenantPerSchemaDbContext`. All repo call sites migrated. Health-check failure results no longer expose the driver exception.

## Verification

- Architecture shard: **605/605** green (263 pre-existing + 342 new theory cases).
- Persistence family: 560 tests green (EFCore 393, Migrations 72, Hosting 37, Postgres 43, SqlServer 15).
- All touched src projects build individually; `dotnet format --verify-no-changes` clean on every modified file (including projects outside the api-data shard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)