### PR TITLE
test(persistence): close unit blind spots — MetadataSyncInterceptor, soft-delete on SQLite, factories off InMemory

### DIFF
--- a/tests/Granit.Persistence.EntityFrameworkCore.Tests/MetadataSyncInterceptorTests.cs
+++ b/tests/Granit.Persistence.EntityFrameworkCore.Tests/MetadataSyncInterceptorTests.cs
@@ -1,0 +1,177 @@
+// =============================================================================
+// Tests - MetadataSyncInterceptor
+// =============================================================================
+// Verifies JSON-bag → shadow-property promotion on save: mapped keys move to
+// their shadow column and leave the JSON, unmapped keys stay, and the mapping
+// lookup is cached per entity type. SQLite in-memory (relational) so shadow
+// columns and the round-trip are real.
+// =============================================================================
+
+using Granit.Domain;
+using Granit.Persistence.EntityFrameworkCore.Metadata;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Persistence.EntityFrameworkCore.Tests;
+
+public sealed class MetadataSyncInterceptorTests : IDisposable
+{
+    private readonly SqliteConnection _connection = new("Data Source=:memory:");
+    private readonly IMetadataMappingRegistry _registry;
+
+    public MetadataSyncInterceptorTests()
+    {
+        _connection.Open();
+        _registry = Substitute.For<IMetadataMappingRegistry>();
+        _registry.GetMappedPropertyNames(typeof(MetadataEntity)).Returns(["Priority"]);
+    }
+
+    public void Dispose() => _connection.Dispose();
+
+    private MetadataDbContext CreateContext()
+    {
+        DbContextOptions<MetadataDbContext> options = new DbContextOptionsBuilder<MetadataDbContext>()
+            .UseSqlite(_connection)
+            .AddInterceptors(new MetadataSyncInterceptor(_registry))
+            .Options;
+        MetadataDbContext context = new(options);
+        context.Database.EnsureCreated();
+        return context;
+    }
+
+    [Fact]
+    public async Task SaveChangesAsync_MappedKey_PromotedToShadowPropertyAndRemovedFromJson()
+    {
+        await using MetadataDbContext context = CreateContext();
+        MetadataEntity entity = new()
+        {
+            Id = Guid.NewGuid(),
+            MetadataJson = """{"Priority":"High","Color":"Red"}""",
+        };
+        context.Entities.Add(entity);
+
+        await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        context.Entry(entity).Property("Priority").CurrentValue.ShouldBe("High");
+        entity.MetadataJson.ShouldBe("""{"Color":"Red"}""");
+    }
+
+    [Fact]
+    public async Task SaveChangesAsync_ShadowColumn_RoundtripsThroughTheDatabase()
+    {
+        var id = Guid.NewGuid();
+        await using (MetadataDbContext context = CreateContext())
+        {
+            context.Entities.Add(new MetadataEntity
+            {
+                Id = id,
+                MetadataJson = """{"Priority":"Urgent"}""",
+            });
+            await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await using (MetadataDbContext context = CreateContext())
+        {
+            string? stored = await context.Entities
+                .Where(e => e.Id == id)
+                .Select(e => EF.Property<string>(e, "Priority"))
+                .SingleAsync(TestContext.Current.CancellationToken);
+            stored.ShouldBe("Urgent");
+        }
+    }
+
+    [Fact]
+    public async Task SaveChangesAsync_AllKeysMapped_JsonBecomesNull()
+    {
+        await using MetadataDbContext context = CreateContext();
+        MetadataEntity entity = new()
+        {
+            Id = Guid.NewGuid(),
+            MetadataJson = """{"Priority":"Low"}""",
+        };
+        context.Entities.Add(entity);
+
+        await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        entity.MetadataJson.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task SaveChangesAsync_OnlyUnmappedKeys_JsonUntouchedAndShadowStaysNull()
+    {
+        await using MetadataDbContext context = CreateContext();
+        MetadataEntity entity = new()
+        {
+            Id = Guid.NewGuid(),
+            MetadataJson = """{"Color":"Blue"}""",
+        };
+        context.Entities.Add(entity);
+
+        await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        entity.MetadataJson.ShouldBe("""{"Color":"Blue"}""");
+        context.Entry(entity).Property("Priority").CurrentValue.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task SaveChangesAsync_NullOrWhitespaceJson_IsNoOp()
+    {
+        await using MetadataDbContext context = CreateContext();
+        MetadataEntity entity = new() { Id = Guid.NewGuid(), MetadataJson = null };
+        context.Entities.Add(entity);
+
+        await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        entity.MetadataJson.ShouldBeNull();
+        context.Entry(entity).Property("Priority").CurrentValue.ShouldBeNull();
+    }
+
+    [Fact]
+    public void SaveChanges_SyncPath_PromotesLikeTheAsyncPath()
+    {
+        using MetadataDbContext context = CreateContext();
+        MetadataEntity entity = new()
+        {
+            Id = Guid.NewGuid(),
+            MetadataJson = """{"Priority":"Sync","Color":"Green"}""",
+        };
+        context.Entities.Add(entity);
+
+        context.SaveChanges();
+
+        context.Entry(entity).Property("Priority").CurrentValue.ShouldBe("Sync");
+        entity.MetadataJson.ShouldBe("""{"Color":"Green"}""");
+    }
+
+    [Fact]
+    public async Task SaveChangesAsync_MappingLookup_IsCachedPerEntityType()
+    {
+        await using MetadataDbContext context = CreateContext();
+        context.Entities.Add(new MetadataEntity { Id = Guid.NewGuid(), MetadataJson = """{"Priority":"A"}""" });
+        await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+        context.Entities.Add(new MetadataEntity { Id = Guid.NewGuid(), MetadataJson = """{"Priority":"B"}""" });
+        await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        _registry.Received(1).GetMappedPropertyNames(typeof(MetadataEntity));
+    }
+
+    private sealed class MetadataEntity : Entity, IHasMetadata
+    {
+        public string? MetadataJson { get; set; }
+    }
+
+    private sealed class MetadataDbContext(DbContextOptions<MetadataDbContext> options) : DbContext(options)
+    {
+        public DbSet<MetadataEntity> Entities => Set<MetadataEntity>();
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder) =>
+            modelBuilder.Entity<MetadataEntity>(entity =>
+            {
+                entity.Property(e => e.Id).ValueGeneratedNever();
+                entity.Property<string?>("Priority");
+            });
+    }
+}

--- a/tests/Granit.Persistence.EntityFrameworkCore.Tests/MultiTenancy/TenantPerDatabaseDbContextFactoryTests.cs
+++ b/tests/Granit.Persistence.EntityFrameworkCore.Tests/MultiTenancy/TenantPerDatabaseDbContextFactoryTests.cs
@@ -2,9 +2,9 @@
 // Tests - TenantPerDatabaseDbContextFactory<TContext>
 // =============================================================================
 // Verifies tenant routing, missing-tenant guard, provider call correctness,
-// and async isolation between concurrent tenant contexts.
-// No real database connection required: DbContextOptions are built but the
-// connection is never opened (only happens on query execution, not construction).
+// async isolation between concurrent tenant contexts, and PHYSICAL data
+// isolation between per-tenant databases (SQLite named in-memory databases —
+// the InMemory provider proved nothing about isolation).
 // =============================================================================
 
 using Granit.MultiTenancy;
@@ -22,15 +22,24 @@ namespace Granit.Persistence.EntityFrameworkCore.Tests.MultiTenancy;
 // by TenantPerDatabaseDbContextFactory<T>'s Activator.CreateInstance path.
 // ---------------------------------------------------------------------------
 internal sealed class StubPerTenantDbContext(DbContextOptions<StubPerTenantDbContext> options)
-    : DbContext(options);
+    : DbContext(options)
+{
+    public DbSet<StubTenantRow> Rows => Set<StubTenantRow>();
+}
+
+internal sealed class StubTenantRow
+{
+    public Guid Id { get; set; }
+    public string Label { get; set; } = string.Empty;
+}
 
 public sealed class TenantPerDatabaseDbContextFactoryTests
 {
     private static readonly Guid TenantA = Guid.NewGuid();
     private static readonly Guid TenantB = Guid.NewGuid();
 
-    private const string ConnA = "Host=host-a;Database=db_a;Username=usr;Password=pwd";
-    private const string ConnB = "Host=host-b;Database=db_b;Username=usr;Password=pwd";
+    private const string ConnA = "Data Source=file:tenant_a?mode=memory&cache=shared";
+    private const string ConnB = "Data Source=file:tenant_b?mode=memory&cache=shared";
 
     // -----------------------------------------------------------------------
     // Helper — builds a factory with fully controlled dependencies.
@@ -54,7 +63,7 @@ public sealed class TenantPerDatabaseDbContextFactoryTests
 
         TenantPerDatabaseDbContextOptions<StubPerTenantDbContext> options = new()
         {
-            Configure = static (opts, cs) => opts.UseInMemoryDatabase(cs),
+            Configure = static (opts, cs) => opts.UseSqlite(cs),
         };
 
         return (new TenantPerDatabaseDbContextFactory<StubPerTenantDbContext>(
@@ -198,7 +207,7 @@ public sealed class TenantPerDatabaseDbContextFactoryTests
             Configure = (opts, cs) =>
             {
                 capturedConnections.Add(cs);
-                opts.UseInMemoryDatabase(cs);
+                opts.UseSqlite(cs);
             },
         };
 
@@ -215,5 +224,50 @@ public sealed class TenantPerDatabaseDbContextFactoryTests
         capturedConnections.ShouldContain(ConnA);
         capturedConnections.ShouldContain(ConnB);
         capturedConnections.Distinct().Count().ShouldBe(capturedConnections.Count);
+    }
+
+    // -----------------------------------------------------------------------
+    // Physical isolation — tenant A's rows never appear in tenant B's database
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task CreateDbContextAsync_TenantData_IsPhysicallyIsolatedPerDatabase()
+    {
+        // Keep-alive connections pin the two named in-memory databases for the
+        // duration of the test (cache=shared makes them addressable by name).
+        await using Microsoft.Data.Sqlite.SqliteConnection keepAliveA = new(ConnA);
+        await using Microsoft.Data.Sqlite.SqliteConnection keepAliveB = new(ConnB);
+        await keepAliveA.OpenAsync(TestContext.Current.CancellationToken);
+        await keepAliveB.OpenAsync(TestContext.Current.CancellationToken);
+
+        string label = $"iso-{Guid.NewGuid():N}";
+
+        TenantPerDatabaseDbContextFactory<StubPerTenantDbContext> factoryA =
+            BuildFactory(TenantA, ConnA);
+        await using (StubPerTenantDbContext ctxA =
+            await factoryA.CreateDbContextAsync(TestContext.Current.CancellationToken))
+        {
+            await ctxA.Database.EnsureCreatedAsync(TestContext.Current.CancellationToken);
+            ctxA.Rows.Add(new StubTenantRow { Id = Guid.NewGuid(), Label = label });
+            await ctxA.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        TenantPerDatabaseDbContextFactory<StubPerTenantDbContext> factoryB =
+            BuildFactory(TenantB, ConnB);
+        await using (StubPerTenantDbContext ctxB =
+            await factoryB.CreateDbContextAsync(TestContext.Current.CancellationToken))
+        {
+            await ctxB.Database.EnsureCreatedAsync(TestContext.Current.CancellationToken);
+            (await ctxB.Rows.CountAsync(r => r.Label == label, TestContext.Current.CancellationToken))
+                .ShouldBe(0, "tenant B's database must not contain tenant A's rows");
+        }
+
+        // Sanity: the row does exist in tenant A's database.
+        TenantPerDatabaseDbContextFactory<StubPerTenantDbContext> factoryA2 =
+            BuildFactory(TenantA, ConnA);
+        await using StubPerTenantDbContext ctxA2 =
+            await factoryA2.CreateDbContextAsync(TestContext.Current.CancellationToken);
+        (await ctxA2.Rows.CountAsync(r => r.Label == label, TestContext.Current.CancellationToken))
+            .ShouldBe(1);
     }
 }

--- a/tests/Granit.Persistence.EntityFrameworkCore.Tests/MultiTenancy/TenantPerSchemaDbContextFactoryTests.cs
+++ b/tests/Granit.Persistence.EntityFrameworkCore.Tests/MultiTenancy/TenantPerSchemaDbContextFactoryTests.cs
@@ -1,8 +1,10 @@
 // =============================================================================
 // Tests - TenantPerSchemaDbContextFactory<TContext>
 // =============================================================================
-// Vérifie le guard tenant manquant et la construction correcte du DbContext.
-// Aucune connexion PostgreSQL réelle n'est requise.
+// Verifies the missing-tenant guard, DbContext construction, and that opening
+// a real (SQLite) connection triggers schema activation with the resolved
+// schema name via TenantSchemaConnectionInterceptor — the behavior the former
+// InMemory setup could not exercise (no connection ever opened).
 // =============================================================================
 
 using Granit.MultiTenancy;
@@ -16,7 +18,15 @@ using Xunit;
 namespace Granit.Persistence.EntityFrameworkCore.Tests.MultiTenancy;
 
 internal sealed class StubSchemaDbContext(DbContextOptions<StubSchemaDbContext> options)
-    : DbContext(options);
+    : DbContext(options)
+{
+    public DbSet<StubSchemaRow> Rows => Set<StubSchemaRow>();
+}
+
+internal sealed class StubSchemaRow
+{
+    public Guid Id { get; set; }
+}
 
 public sealed class TenantPerSchemaDbContextFactoryTests
 {
@@ -30,8 +40,9 @@ public sealed class TenantPerSchemaDbContextFactoryTests
         return tenant;
     }
 
-    private static TenantPerSchemaDbContextFactory<StubSchemaDbContext> BuildFactory(
-        ICurrentTenant currentTenant)
+    private static (TenantPerSchemaDbContextFactory<StubSchemaDbContext> factory,
+                    ITenantSchemaActivator activator)
+        BuildFactoryWithActivator(ICurrentTenant currentTenant)
     {
         ITenantSchemaProvider schemaProvider = Substitute.For<ITenantSchemaProvider>();
 #pragma warning disable CA2012 // NSubstitute setup pattern — ValueTask not consumed directly
@@ -46,12 +57,15 @@ public sealed class TenantPerSchemaDbContextFactoryTests
 
         TenantPerSchemaDbContextOptions<StubSchemaDbContext> opts = new()
         {
-            Configure = static builder => builder.UseInMemoryDatabase("schema_test"),
+            Configure = static builder => builder.UseSqlite("Data Source=:memory:"),
         };
 
-        return new TenantPerSchemaDbContextFactory<StubSchemaDbContext>(
-            currentTenant, schemaProvider, schemaActivator, sp, opts);
+        return (new TenantPerSchemaDbContextFactory<StubSchemaDbContext>(
+            currentTenant, schemaProvider, schemaActivator, sp, opts), schemaActivator);
     }
+
+    private static TenantPerSchemaDbContextFactory<StubSchemaDbContext> BuildFactory(
+        ICurrentTenant currentTenant) => BuildFactoryWithActivator(currentTenant).factory;
 
     // -----------------------------------------------------------------------
     // Happy path
@@ -105,5 +119,25 @@ public sealed class TenantPerSchemaDbContextFactoryTests
         Action act = () => factory.CreateDbContext();
 
         Should.Throw<InvalidOperationException>(act).Message.ShouldContain("No active tenant context");
+    }
+
+    // -----------------------------------------------------------------------
+    // Schema activation — opening a real connection activates the tenant schema
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task OpeningConnection_ActivatesResolvedTenantSchema()
+    {
+        (TenantPerSchemaDbContextFactory<StubSchemaDbContext> factory,
+         ITenantSchemaActivator activator) = BuildFactoryWithActivator(MakeTenant(TenantA));
+
+        await using StubSchemaDbContext ctx =
+            await factory.CreateDbContextAsync(TestContext.Current.CancellationToken);
+        await ctx.Database.OpenConnectionAsync(TestContext.Current.CancellationToken);
+
+        await activator.Received(1).ActivateSchemaAsync(
+            Arg.Any<System.Data.Common.DbConnection>(),
+            "tenant_stub",
+            Arg.Any<CancellationToken>());
     }
 }

--- a/tests/Granit.Persistence.EntityFrameworkCore.Tests/SoftDeleteInterceptorTests.cs
+++ b/tests/Granit.Persistence.EntityFrameworkCore.Tests/SoftDeleteInterceptorTests.cs
@@ -1,19 +1,21 @@
 // =============================================================================
 // Tests - SoftDeleteInterceptor
 // =============================================================================
-// Verifies that physical deletion is converted to logical deletion
-// for ISoftDeletable entities (GDPR compliance).
-//
-// Approach: the interceptor is registered in the DbContext and
-// SaveChangesAsync is called directly. IClock is mocked for exact assertions.
+// Verifies that physical deletion is converted to logical deletion for
+// ISoftDeletable entities (GDPR compliance) — on SQLite (relational), with the
+// real named soft-delete filter from ApplyGranitConventions, so both the
+// UPDATE-instead-of-DELETE conversion and the filter's SQL behavior are proven
+// (the InMemory provider fakes both).
 // =============================================================================
 
 using Granit.Domain;
 using Granit.Guids;
 using Granit.MultiTenancy;
+using Granit.Persistence.EntityFrameworkCore.Extensions;
 using Granit.Persistence.EntityFrameworkCore.Interceptors;
 using Granit.Timing;
 using Granit.Users;
+using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using NSubstitute;
 using Shouldly;
@@ -21,15 +23,18 @@ using Xunit;
 
 namespace Granit.Persistence.EntityFrameworkCore.Tests;
 
-public sealed class SoftDeleteInterceptorTests
+public sealed class SoftDeleteInterceptorTests : IDisposable
 {
     private static readonly DateTimeOffset FixedNow = new(2026, 6, 15, 10, 30, 0, TimeSpan.Zero);
 
+    private readonly SqliteConnection _connection = new("Data Source=:memory:");
     private readonly ICurrentUserService _currentUserService;
     private readonly IClock _clock;
 
     public SoftDeleteInterceptorTests()
     {
+        _connection.Open();
+
         _currentUserService = Substitute.For<ICurrentUserService>();
         _currentUserService.UserId.Returns("user-test-123");
 
@@ -37,61 +42,97 @@ public sealed class SoftDeleteInterceptorTests
         _clock.Now.Returns(FixedNow);
     }
 
+    public void Dispose() => _connection.Dispose();
+
     [Fact]
     public async Task SaveChangesAsync_OnDelete_ConvertToSoftDelete()
     {
-        // Arrange
         await using TestDbContext context = CreateContext();
-        var entity = new TestSoftDeletableEntity
-        {
-            Id = Guid.NewGuid(),
-            Name = "ToDelete",
-            CreatedAt = FixedNow.AddDays(-1),
-            CreatedBy = "user-test-123"
-        };
-        context.Entities.Add(entity);
+        TestSoftDeletableEntity entity = AddEntity(context, "ToDelete");
         await context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-        // Delete the entity
         context.Entities.Remove(entity);
-
-        // Act
         await context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-        // Assert — the entity is soft-deleted (not physically removed)
         entity.IsDeleted.ShouldBeTrue();
         entity.DeletedAt.ShouldBe(FixedNow);
         entity.DeletedBy.ShouldBe("user-test-123");
+    }
 
-        // Verify the entity still exists in the database (not physically deleted)
-        int count = await context.Entities.IgnoreQueryFilters().CountAsync(TestContext.Current.CancellationToken);
-        count.ShouldBe(1);
+    [Fact]
+    public async Task SaveChangesAsync_OnDelete_RowPhysicallySurvives()
+    {
+        await using TestDbContext context = CreateContext();
+        TestSoftDeletableEntity entity = AddEntity(context, "Survivor");
+        await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        context.Entities.Remove(entity);
+        await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        // Raw count outside EF filters: the DELETE became an UPDATE, the row is still there.
+        int rawCount = await context.Database
+            .SqlQuery<int>($"SELECT COUNT(*) AS \"Value\" FROM \"Entities\"")
+            .SingleAsync(TestContext.Current.CancellationToken);
+        rawCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task NamedSoftDeleteFilter_ExcludesSoftDeletedRows_FromStandardQueries()
+    {
+        await using TestDbContext context = CreateContext();
+        TestSoftDeletableEntity entity = AddEntity(context, "Filtered");
+        await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        context.Entities.Remove(entity);
+        await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        (await context.Entities.CountAsync(TestContext.Current.CancellationToken))
+            .ShouldBe(0, "the named soft-delete filter must hide the tombstone");
+    }
+
+    [Fact]
+    public async Task NamedSoftDeleteFilter_PerQueryBypass_RevealsTombstone()
+    {
+        await using TestDbContext context = CreateContext();
+        TestSoftDeletableEntity entity = AddEntity(context, "Tombstone");
+        await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        context.Entities.Remove(entity);
+        await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        TestSoftDeletableEntity tombstone = await context.Entities
+            .IgnoreQueryFilters([GranitFilterNames.SoftDelete])
+            .SingleAsync(TestContext.Current.CancellationToken);
+        tombstone.IsDeleted.ShouldBeTrue();
+        tombstone.DeletedAt.ShouldBe(FixedNow);
+        tombstone.DeletedBy.ShouldBe("user-test-123");
     }
 
     [Fact]
     public async Task SaveChangesAsync_OnModify_DoesNotTriggerSoftDelete()
     {
-        // Arrange
         await using TestDbContext context = CreateContext();
-        var entity = new TestSoftDeletableEntity
-        {
-            Id = Guid.NewGuid(),
-            Name = "Original",
-            CreatedAt = FixedNow.AddDays(-1),
-            CreatedBy = "user-test-123"
-        };
-        context.Entities.Add(entity);
+        TestSoftDeletableEntity entity = AddEntity(context, "Original");
         await context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-        // Modify the entity (not delete)
         entity.Name = "Modified";
-
-        // Act
         await context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-        // Assert — no soft delete
         entity.IsDeleted.ShouldBeFalse();
         entity.DeletedAt.ShouldBeNull();
+    }
+
+    private static TestSoftDeletableEntity AddEntity(TestDbContext context, string name)
+    {
+        TestSoftDeletableEntity entity = new()
+        {
+            Id = Guid.NewGuid(),
+            Name = name,
+            CreatedAt = FixedNow.AddDays(-1),
+            CreatedBy = "user-test-123",
+        };
+        context.Entities.Add(entity);
+        return entity;
     }
 
     private TestDbContext CreateContext()
@@ -102,10 +143,12 @@ public sealed class SoftDeleteInterceptorTests
         var auditInterceptor = new AuditedEntityInterceptor(_currentUserService, _clock, guidGenerator, currentTenant);
         var softDeleteInterceptor = new SoftDeleteInterceptor(_currentUserService, _clock);
         DbContextOptions<TestDbContext> options = new DbContextOptionsBuilder<TestDbContext>()
-            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .UseSqlite(_connection)
             .AddInterceptors(auditInterceptor, softDeleteInterceptor)
             .Options;
-        return new TestDbContext(options);
+        TestDbContext context = new(options);
+        context.Database.EnsureCreated();
+        return context;
     }
 
     private sealed class TestSoftDeletableEntity : AuditedEntity, ISoftDeletable
@@ -120,6 +163,12 @@ public sealed class SoftDeleteInterceptorTests
     {
         public DbSet<TestSoftDeletableEntity> Entities => Set<TestSoftDeletableEntity>();
 
-        protected override void OnModelCreating(ModelBuilder modelBuilder) => modelBuilder.Entity<TestSoftDeletableEntity>().Property(e => e.Id).ValueGeneratedNever();
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<TestSoftDeletableEntity>().Property(e => e.Id).ValueGeneratedNever();
+
+            // Real named filters (soft-delete included) — the behavior under test.
+            modelBuilder.ApplyGranitConventions();
+        }
     }
 }


### PR DESCRIPTION
Closes #3156 — last story of #3145 (epic #3143).

## What this does

Closes the three unit-test blind spots from the 2026-08-04 audit, asserting behavior where it can actually fail (relational SQLite) instead of the InMemory provider:

- **`MetadataSyncInterceptorTests` (new)** — the interceptor had **zero tests** repo-wide. Covers JSON-bag → shadow-property promotion on both sync and async save paths, promoted keys removed from the JSON (`null` when emptied), unmapped keys untouched, the real column roundtrip (`EF.Property` through SQLite), and the per-entity-type registry cache (single lookup across saves).
- **`SoftDeleteInterceptorTests`** — rewritten on SQLite with the real named filters from `ApplyGranitConventions`. The former 2 facts only asserted `EntityState` flips on InMemory; now: the row **physically survives** (raw SQL count — the DELETE became an UPDATE), the named soft-delete filter hides the tombstone from standard queries, and `IgnoreQueryFilters([GranitFilterNames.SoftDelete])` reveals it with `DeletedAt`/`DeletedBy`.
- **`TenantPerDatabaseDbContextFactoryTests`** — provider switched to SQLite named in-memory databases, plus a real **physical isolation** test: tenant A's rows never appear through tenant B's factory (and do exist through A's). The old suite never proved isolation at all.
- **`TenantPerSchemaDbContextFactoryTests`** — off InMemory; opening a real connection now proves `TenantSchemaConnectionInterceptor` activates the **resolved schema name** via `ITenantSchemaActivator` — unreachable before (InMemory never opens a connection).

Remaining `UseInMemoryDatabase` in the MultiTenancy test folder is construction-only (DI-shape/dispatch assertions, connection never opened); filter and isolation *semantics* now run on SQLite here and on real PostgreSQL/SQL Server via the conformance kit (#3175/#3176).

## Verification

- `Granit.Persistence.EntityFrameworkCore.Tests`: **405/405 green** (+13 net new tests).
- `dotnet format --verify-no-changes` clean; no dependency changes (no lock-file impact).

Merging this completes Feature #3145 (Phase 1 — provider conformance kit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)