### PR TITLE
fix(persistence)!: context-bound bypass flags — IDataFilter.Disable<T>() reaches SQL

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -44680,12 +44680,42 @@
       "kind": "class",
       "project": "Granit.Persistence.EntityFrameworkCore",
       "file": "src/Granit.Persistence.EntityFrameworkCore/GranitDbContext.cs",
-      "line": 47,
+      "line": 48,
       "members": [
         {
           "name": "IsMultiTenantFilterEnabled",
           "kind": "property",
           "signature": "bool IsMultiTenantFilterEnabled",
+          "returnType": "bool"
+        },
+        {
+          "name": "IsSoftDeleteFilterEnabled",
+          "kind": "property",
+          "signature": "bool IsSoftDeleteFilterEnabled",
+          "returnType": "bool"
+        },
+        {
+          "name": "IsActiveFilterEnabled",
+          "kind": "property",
+          "signature": "bool IsActiveFilterEnabled",
+          "returnType": "bool"
+        },
+        {
+          "name": "IsProcessingRestrictionFilterEnabled",
+          "kind": "property",
+          "signature": "bool IsProcessingRestrictionFilterEnabled",
+          "returnType": "bool"
+        },
+        {
+          "name": "IsPublishableFilterEnabled",
+          "kind": "property",
+          "signature": "bool IsPublishableFilterEnabled",
+          "returnType": "bool"
+        },
+        {
+          "name": "IsMergeTombstoneFilterEnabled",
+          "kind": "property",
+          "signature": "bool IsMergeTombstoneFilterEnabled",
           "returnType": "bool"
         }
       ]

--- a/src/Granit.Persistence.EntityFrameworkCore/Extensions/ModelBuilderExtensions.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/Extensions/ModelBuilderExtensions.cs
@@ -105,13 +105,30 @@ public static class ModelBuilderExtensions
     public static ModelBuilder ApplyGranitConventions(
         this ModelBuilder modelBuilder,
         ICurrentTenant? currentTenant = null,
-        IDataFilter? dataFilter = null)
+        IDataFilter? dataFilter = null) =>
+        modelBuilder.ApplyGranitConventionsCore(currentTenant, dataFilter, registerConventionFilters: true);
+
+    /// <summary>
+    /// Core overload. <paramref name="registerConventionFilters"/> is <c>false</c> when called
+    /// from <see cref="GranitDbContext"/>, which registers every named filter itself with
+    /// <c>this</c>-bound bypass flags: the proxy-captured flags below are constant-folded into
+    /// the cached query plan, making <c>IDataFilter.Disable&lt;T&gt;()</c> a silent no-op on
+    /// relational providers (#3174). The legacy proxy path remains for contexts that call the
+    /// public overload directly — per-query bypass (<c>IgnoreQueryFilters</c>) works there;
+    /// flow-scoped disable does not.
+    /// </summary>
+    internal static ModelBuilder ApplyGranitConventionsCore(
+        this ModelBuilder modelBuilder,
+        ICurrentTenant? currentTenant,
+        IDataFilter? dataFilter,
+        bool registerConventionFilters)
     {
-        // FilterProxy wraps IDataFilter? and exposes simple boolean properties.
-        // EF Core extracts property access on a ConstantExpression as a query parameter
-        // re-evaluated on each query — the same mechanism used by currentTenant.Id in
-        // the multi-tenant filter. This avoids the risk of EF Core attempting SQL
-        // translation of a generic method call (IsEnabled<T>()).
+        // FilterProxy wraps IDataFilter? and exposes simple boolean properties. KNOWN
+        // LIMITATION (#3174): EF Core constant-folds property access on a non-DbContext
+        // captured constant at plan compilation — the bypass never becomes a query
+        // parameter, so flow-scoped IDataFilter.Disable<T>() has no effect through this
+        // path. Only DbContext instance members are re-bound per query, which is why
+        // GranitDbContext owns the filters and skips this pass.
         FilterProxy proxy = new(dataFilter);
 
         foreach (Type clrType in modelBuilder.Model.GetEntityTypes().Select(entityType => entityType.ClrType))
@@ -124,7 +141,8 @@ public static class ModelBuilderExtensions
             bool hasPublishable = typeof(IPublishable).IsAssignableFrom(clrType);
             bool hasMergeTombstone = typeof(IHasMergeTombstone).IsAssignableFrom(clrType);
 
-            if (!hasSoftDelete && !hasActive && !hasProcessingRestriction && !hasMultiTenant && !hasPublishable && !hasMergeTombstone)
+            if (!registerConventionFilters
+                || (!hasSoftDelete && !hasActive && !hasProcessingRestriction && !hasMultiTenant && !hasPublishable && !hasMergeTombstone))
             {
                 continue;
             }
@@ -192,7 +210,7 @@ public static class ModelBuilderExtensions
             typeof(ModelBuilderExtensions)
                 .GetMethod(nameof(ConfigureTranslation), BindingFlags.Static | BindingFlags.NonPublic)! // NOSONAR S3011 - intentional: generic EF Core convention pattern requires reflection
                 .MakeGenericMethod(clrType, parentType)
-                .Invoke(null, [modelBuilder, proxy]);
+                .Invoke(null, [modelBuilder, proxy, registerConventionFilters]);
         }
 
         // --- Value object conventions ---
@@ -671,8 +689,10 @@ public static class ModelBuilderExtensions
     // Also mirrors the parent's ISoftDeletable / IActive query filters onto the translation so
     // that EF Core's filter consistency check (required principal end with a global query filter)
     // is satisfied. Without these mirrors, EF Core warns that querying translations directly may
-    // return rows whose parent would be filtered out.
-    private static void ConfigureTranslation<TTranslation, TParent>(ModelBuilder modelBuilder, FilterProxy proxy)
+    // return rows whose parent would be filtered out. `registerFilterMirrors` is false on the
+    // GranitDbContext path, which registers this-bound mirrors itself (#3174).
+    private static void ConfigureTranslation<TTranslation, TParent>(
+        ModelBuilder modelBuilder, FilterProxy proxy, bool registerFilterMirrors)
         where TTranslation : class, ITranslation<TParent>
         where TParent : Entity
     {
@@ -698,6 +718,11 @@ public static class ModelBuilderExtensions
         // matching filters on both ends of a required relationship when the principal end has
         // a global query filter. The filters navigate through the Parent reference so that
         // direct DbSet<TTranslation> queries apply the same visibility rules as the parent.
+        if (!registerFilterMirrors)
+        {
+            return;
+        }
+
         ParameterExpression param = Expression.Parameter(typeof(TTranslation), "t");
         MemberExpression parentProp = Expression.Property(param, nameof(ITranslation<TParent>.Parent));
         // Guard against a null navigation in the SQL expression tree (required FK in practice,

--- a/src/Granit.Persistence.EntityFrameworkCore/GranitDbContext.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/GranitDbContext.cs
@@ -35,13 +35,14 @@ namespace Granit.Persistence.EntityFrameworkCore;
 /// parameter (<c>@ef_filter__CurrentTenantId</c>) re-bound on every command.
 /// </para>
 /// <para>
-/// <b>Compatibility.</b> The non-tenant filters (soft-delete, active, processing restriction,
-/// publishable, merge tombstone) are still wired by
-/// <see cref="ModelBuilderExtensions.ApplyGranitConventions"/> — those bypass values depend
-/// on per-DbContext singletons and are unaffected by the per-request constant-folding issue.
-/// Derived contexts should call <c>modelBuilder.ApplyGranitConventions(currentTenant: null, dataFilter)</c>
-/// from their <see cref="OnGranitModelCreating"/> override (or let the default
-/// <see cref="OnModelCreating"/> here do it).
+/// <b>All named filters are context-bound.</b> The convention filters (soft-delete, active,
+/// processing restriction, publishable, merge tombstone) and the translation mirrors are
+/// registered here with bypass flags read via <c>this</c> — NOT by
+/// <see cref="ModelBuilderExtensions.ApplyGranitConventions"/>, whose proxy-captured flags
+/// are constant-folded into the cached query plan and made
+/// <c>IDataFilter.Disable&lt;T&gt;()</c> a silent no-op on relational providers (#3174).
+/// The base class calls <c>ApplyGranitConventions</c> with the filter pass disabled;
+/// derived contexts override <see cref="OnGranitModelCreating"/> and never call it themselves.
 /// </para>
 /// </remarks>
 public abstract class GranitDbContext : DbContext
@@ -50,6 +51,16 @@ public abstract class GranitDbContext : DbContext
         typeof(GranitDbContext).GetMethod(
             nameof(ConfigureMultiTenantFilter),
             BindingFlags.Instance | BindingFlags.NonPublic)!; // NOSONAR S3011 - intentional: ConfigureMultiTenantFilter must stay private to keep its `this`-binding (load-bearing for EF Core parameter extraction); reflection is the only way to invoke a generic instance method per-entity-type.
+
+    private static readonly MethodInfo ConfigureConventionFiltersMethod =
+        typeof(GranitDbContext).GetMethod(
+            nameof(ConfigureConventionFilters),
+            BindingFlags.Instance | BindingFlags.NonPublic)!; // NOSONAR S3011 - same `this`-binding requirement as ConfigureMultiTenantFilter (#3174).
+
+    private static readonly MethodInfo ConfigureTranslationFiltersMethod =
+        typeof(GranitDbContext).GetMethod(
+            nameof(ConfigureTranslationFilters),
+            BindingFlags.Instance | BindingFlags.NonPublic)!; // NOSONAR S3011 - same `this`-binding requirement as ConfigureMultiTenantFilter (#3174).
 
     /// <summary>
     /// The tenant context for this scope, captured at construction time.
@@ -74,6 +85,33 @@ public abstract class GranitDbContext : DbContext
     /// </summary>
     public virtual bool IsMultiTenantFilterEnabled
         => DataFilter?.IsEnabled<IMultiTenant>() ?? true;
+
+    // The five convention-filter bypass flags below are instance members for the same
+    // load-bearing reason as IsMultiTenantFilterEnabled: EF Core only re-evaluates filter
+    // values per query (@ef_filter__* parameters) when they are read from a member of the
+    // current DbContext. Reading them from any other captured object gets constant-folded
+    // into the cached query plan — which made IDataFilter.Disable<T>() a silent no-op on
+    // relational providers for every FilterProxy-backed filter (#3174).
+
+    /// <summary><c>true</c> when the <see cref="ISoftDeletable"/> filter is active.</summary>
+    public virtual bool IsSoftDeleteFilterEnabled
+        => DataFilter?.IsEnabled<ISoftDeletable>() ?? true;
+
+    /// <summary><c>true</c> when the <see cref="IActive"/> filter is active.</summary>
+    public virtual bool IsActiveFilterEnabled
+        => DataFilter?.IsEnabled<IActive>() ?? true;
+
+    /// <summary><c>true</c> when the <see cref="IProcessingRestrictable"/> filter is active.</summary>
+    public virtual bool IsProcessingRestrictionFilterEnabled
+        => DataFilter?.IsEnabled<IProcessingRestrictable>() ?? true;
+
+    /// <summary><c>true</c> when the <see cref="IPublishable"/> filter is active.</summary>
+    public virtual bool IsPublishableFilterEnabled
+        => DataFilter?.IsEnabled<IPublishable>() ?? true;
+
+    /// <summary><c>true</c> when the <see cref="IHasMergeTombstone"/> filter is active.</summary>
+    public virtual bool IsMergeTombstoneFilterEnabled
+        => DataFilter?.IsEnabled<IHasMergeTombstone>() ?? true;
 
     /// <summary>
     /// Builds a <see cref="GranitDbContext"/>. Derived classes forward their DI-injected
@@ -122,13 +160,46 @@ public abstract class GranitDbContext : DbContext
                 .Invoke(this, [modelBuilder]);
         }
 
-        // 3) Non-tenant filters (soft-delete, active, processing restriction,
-        //    publishable, merge tombstone) + concurrency + merge tombstone columns
-        //    + translation FKs + SVO entity removal & converters. `currentTenant: null`
-        //    skips the IMultiTenant block in this overload — this class owns that
-        //    filter separately, with parameterised SQL. Runs LAST so the SVO cleanup
-        //    is the final pass over the model surface.
-        modelBuilder.ApplyGranitConventions(currentTenant: null, DataFilter);
+        // 2-bis) Convention filters (soft-delete, active, processing restriction,
+        //    publishable, merge tombstone) + translation mirrors, built inside members
+        //    of THIS DbContext so the bypass flags are re-bound per query
+        //    (@ef_filter__*). The proxy-based registration in ApplyGranitConventions
+        //    is constant-folded into the cached plan and made IDataFilter.Disable<T>()
+        //    a silent no-op on relational providers (#3174) — step 3 skips it.
+        //    Runs BEFORE step 3 because Entity<TEntity>() re-fires navigation
+        //    discovery, and the SVO cleanup at the end of step 3 must stay the final
+        //    pass over the model surface.
+        foreach (IMutableEntityType entityType in modelBuilder.Model.GetEntityTypes()
+            .Where(et => ConventionFilterInterfaces.Any(i => i.IsAssignableFrom(et.ClrType)))
+            .ToList())
+        {
+            ConfigureConventionFiltersMethod
+                .MakeGenericMethod(entityType.ClrType)
+                .Invoke(this, [modelBuilder]);
+        }
+
+        foreach (IMutableEntityType entityType in modelBuilder.Model.GetEntityTypes().ToList())
+        {
+            Type? translationInterface = entityType.ClrType
+                .GetInterfaces()
+                .FirstOrDefault(i => i.IsGenericType
+                    && i.GetGenericTypeDefinition() == typeof(ITranslation<>));
+
+            if (translationInterface is not null)
+            {
+                ConfigureTranslationFiltersMethod
+                    .MakeGenericMethod(entityType.ClrType, translationInterface.GetGenericArguments()[0])
+                    .Invoke(this, [modelBuilder]);
+            }
+        }
+
+        // 3) Non-filter conventions: concurrency + merge tombstone columns + ownership
+        //    indexes + translation FKs + enum-as-string + SVO entity removal & converters.
+        //    `currentTenant: null` skips the IMultiTenant block; `registerConventionFilters:
+        //    false` skips the proxy-based named filters — this class owns ALL filters,
+        //    with parameterised bypass flags (steps 2 / 2-bis). Runs LAST so the SVO
+        //    cleanup is the final pass over the model surface.
+        modelBuilder.ApplyGranitConventionsCore(currentTenant: null, DataFilter, registerConventionFilters: false);
 
         // 4) External, opt-in model extensions registered in DI by separate packages — applied LAST so they
         //    get the final say (after conventions). Lets e.g. a PostGIS package add a generated geography
@@ -204,5 +275,91 @@ public abstract class GranitDbContext : DbContext
 
         modelBuilder.Entity<TEntity>()
             .HasQueryFilter(GranitFilterNames.MultiTenant, filter);
+    }
+
+    private static readonly Type[] ConventionFilterInterfaces =
+    [
+        typeof(ISoftDeletable),
+        typeof(IActive),
+        typeof(IProcessingRestrictable),
+        typeof(IPublishable),
+        typeof(IHasMergeTombstone),
+    ];
+
+    /// <summary>
+    /// Registers the named convention filters for <typeparamref name="TEntity"/> with
+    /// bypass flags read via <c>this</c> — the sole shape EF Core re-binds per query
+    /// (<c>@ef_filter__*</c>). Same registration names as the legacy proxy path, so
+    /// per-query bypass (<c>IgnoreQueryFilters([GranitFilterNames.X])</c>) is unchanged.
+    /// </summary>
+    private void ConfigureConventionFilters<TEntity>(ModelBuilder modelBuilder)
+        where TEntity : class
+    {
+        Microsoft.EntityFrameworkCore.Metadata.Builders.EntityTypeBuilder<TEntity> builder =
+            modelBuilder.Entity<TEntity>();
+
+        if (typeof(ISoftDeletable).IsAssignableFrom(typeof(TEntity)))
+        {
+            builder.HasQueryFilter(GranitFilterNames.SoftDelete,
+                e => !IsSoftDeleteFilterEnabled
+                    || !EF.Property<bool>(e, nameof(ISoftDeletable.IsDeleted)));
+        }
+
+        if (typeof(IActive).IsAssignableFrom(typeof(TEntity)))
+        {
+            builder.HasQueryFilter(GranitFilterNames.Active,
+                e => !IsActiveFilterEnabled
+                    || EF.Property<bool>(e, nameof(IActive.Activated)));
+        }
+
+        if (typeof(IProcessingRestrictable).IsAssignableFrom(typeof(TEntity)))
+        {
+            builder.HasQueryFilter(GranitFilterNames.ProcessingRestrictable,
+                e => !IsProcessingRestrictionFilterEnabled
+                    || !EF.Property<bool>(e, nameof(IProcessingRestrictable.IsProcessingRestricted)));
+        }
+
+        if (typeof(IPublishable).IsAssignableFrom(typeof(TEntity)))
+        {
+            builder.HasQueryFilter(GranitFilterNames.Publishable,
+                e => !IsPublishableFilterEnabled
+                    || EF.Property<bool>(e, nameof(IPublishable.IsPublished)));
+        }
+
+        if (typeof(IHasMergeTombstone).IsAssignableFrom(typeof(TEntity)))
+        {
+            builder.HasQueryFilter(GranitFilterNames.MergeTombstone,
+                e => !IsMergeTombstoneFilterEnabled
+                    || EF.Property<Guid?>(e, nameof(IHasMergeTombstone.MergedIntoId)) == null);
+        }
+    }
+
+    /// <summary>
+    /// Mirrors the parent's soft-delete / active filters onto a translation entity (EF Core
+    /// filter-consistency requirement on required principals), with <c>this</c>-bound bypass
+    /// flags — same shapes as the legacy proxy mirrors in <c>ConfigureTranslation</c>.
+    /// </summary>
+    private void ConfigureTranslationFilters<TTranslation, TParent>(ModelBuilder modelBuilder)
+        where TTranslation : class, ITranslation<TParent>
+        where TParent : Entity
+    {
+        Microsoft.EntityFrameworkCore.Metadata.Builders.EntityTypeBuilder<TTranslation> builder =
+            modelBuilder.Entity<TTranslation>();
+
+        if (typeof(ISoftDeletable).IsAssignableFrom(typeof(TParent)))
+        {
+            builder.HasQueryFilter(GranitFilterNames.SoftDelete,
+                t => !IsSoftDeleteFilterEnabled
+                    || t.Parent == null
+                    || !EF.Property<bool>(t.Parent, nameof(ISoftDeletable.IsDeleted)));
+        }
+
+        if (typeof(IActive).IsAssignableFrom(typeof(TParent)))
+        {
+            builder.HasQueryFilter(GranitFilterNames.Active,
+                t => !IsActiveFilterEnabled
+                    || t.Parent == null
+                    || EF.Property<bool>(t.Parent, nameof(IActive.Activated)));
+        }
     }
 }

--- a/src/Granit.Testing.Persistence/Suites/QueryFilterSqlConformanceSuite.cs
+++ b/src/Granit.Testing.Persistence/Suites/QueryFilterSqlConformanceSuite.cs
@@ -70,9 +70,7 @@ public abstract class QueryFilterSqlConformanceSuite(IRelationalConformanceFixtu
         }
     }
 
-    [Fact(Skip = "Repro of #3174: IDataFilter.Disable<T>() is folded into the cached plan for "
-        + "proxy-backed filters on relational providers — the bypass never reaches SQL. "
-        + "Un-skip when the flags become GranitDbContext instance members.")]
+    [Fact]
     public async Task Flow_scoped_disable_reveals_inactive_rows()
     {
         await using ConformanceHarness harness = await ConformanceHarness.CreateAsync(fixture);


### PR DESCRIPTION
Closes #3174 (P1, found by the conformance kit on its first real-database run — #3175). Epic #3143.

## The bug

The five convention filters (soft-delete, active, processing restriction, publishable, merge tombstone) and the translation mirrors read their bypass flags from a captured `FilterProxy`. EF Core **constant-folds property access on any non-DbContext captured object at plan compilation** — the bypass never became an `@ef_filter__*` parameter, so `IDataFilter.Disable<T>()` was a **silent no-op on relational providers** for every proxy-backed filter. Only the tenant filter escaped: its flag is a context instance member. Production impact: `EfAIWorkspaceStore` ×4 `Disable<IActive>()` sites, and any downstream `Disable<ISoftDeletable>()` purge scan.

## The fix

Generalize the proven tenant-filter mechanism:

- **`GranitDbContext` gains five instance bypass flags** and registers all convention filters + translation mirrors itself, `this`-bound, in a new step 2-bis of `OnModelCreating` — placed **before** the conventions pass to preserve the load-bearing "SVO cleanup runs last" ordering. Same filter names and shapes: per-query `IgnoreQueryFilters` bypass is unchanged.
- `ApplyGranitConventions` delegates to an internal `ApplyGranitConventionsCore(registerConventionFilters: false)` on the `GranitDbContext` path. The legacy proxy path remains for contexts calling the public overload directly, now with an honest KNOWN-LIMITATION comment — that path dies in overhaul Phase 3 (#3147) when `GranitDbContext` becomes mandatory.

This also pre-validates the Phase 2/3 direction: every filter is now context-bound in the base class.

## Empirical proof

The conformance kit's flow-scoped-disable repro is **un-skipped** and passes on real databases:

- PostgreSQL suite: **15/15, zero skips** (was 14 + 1 skip)
- SQL Server suite: **15/15, zero skips**

## Verification

- `Granit.Persistence.EntityFrameworkCore.Tests` 405/405; `Granit.AI.EntityFrameworkCore.Tests` 9/9 (the production `Disable<IActive>` consumers); full **api-data shard green** (63 projects — every `GranitDbContext`-derived model revalidated); architecture shard 606/606; format clean.

## Breaking

`GranitDbContext` derivatives must not call `ApplyGranitConventions` from `OnGranitModelCreating` (the base owns the full pass — repo-wide this was already the case); five new `virtual` members could collide with identically-named members in derived contexts (none in-repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)