### PR TITLE
test(persistence): golden-model snapshot harness over every DbContext (Phase 2 prerequisite)

### DIFF
--- a/tests/Granit.ArchitectureTests/Granit.ArchitectureTests.csproj
+++ b/tests/Granit.ArchitectureTests/Granit.ArchitectureTests.csproj
@@ -15,6 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
     <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="Shouldly" />

--- a/tests/Granit.ArchitectureTests/ModelSnapshotTests.cs
+++ b/tests/Granit.ArchitectureTests/ModelSnapshotTests.cs
@@ -1,0 +1,267 @@
+using System.Reflection;
+using Granit.DataFiltering;
+using Granit.MultiTenancy;
+using Granit.Persistence.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Shouldly;
+using Xunit;
+
+namespace Granit.ArchitectureTests;
+
+/// <summary>
+/// Golden-model harness (#3157, overhaul Phase 2 — epic #3143): every DbContext in
+/// <c>src/</c> builds its EF Core model offline (Npgsql, no connection) and the full
+/// <c>ToDebugString</c> is compared against a committed baseline under
+/// <c>ModelSnapshots/</c>. The Phase 2 convention-engine rewrite (#3158/#3159) must keep
+/// every snapshot bit-identical; any deliberate model change regenerates its baseline with:
+/// <code>
+/// GRANIT_MODEL_SNAPSHOTS=regen dotnet test tests/Granit.ArchitectureTests --filter ModelSnapshot
+/// </code>
+/// </summary>
+public sealed class ModelSnapshotTests
+{
+    private const string RegenEnvVar = "GRANIT_MODEL_SNAPSHOTS";
+
+    /// <summary>
+    /// Contexts that cannot be built by the harness, with the reason. Every entry must be
+    /// justified — an unbuildable context escapes the Phase 2 equivalence guarantee.
+    /// </summary>
+    private static readonly Dictionary<string, string> Unbuildable = new(StringComparer.Ordinal)
+    {
+        // (empty — add "Full.Type.Name" => reason)
+    };
+
+    public static TheoryData<string> DiscoveredContexts()
+    {
+        TheoryData<string> data = [];
+        foreach (Type type in EnumerateContextTypes())
+        {
+            if (!Unbuildable.ContainsKey(type.FullName!))
+            {
+                data.Add(type.FullName!);
+            }
+        }
+
+        return data;
+    }
+
+    [Theory]
+    [MemberData(nameof(DiscoveredContexts))]
+    public void Model_matches_committed_snapshot(string contextTypeName)
+    {
+        Type contextType = EnumerateContextTypes().Single(t => t.FullName == contextTypeName);
+        string snapshot = BuildSnapshot(contextType);
+        string path = SnapshotPath(contextTypeName);
+
+        if (string.Equals(
+                Environment.GetEnvironmentVariable(RegenEnvVar), "regen", StringComparison.OrdinalIgnoreCase))
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+            File.WriteAllText(path, snapshot);
+            return;
+        }
+
+        File.Exists(path).ShouldBeTrue(
+            $"no committed baseline for {contextTypeName} — regenerate with "
+            + $"{RegenEnvVar}=regen dotnet test tests/Granit.ArchitectureTests --filter ModelSnapshot");
+
+        string baseline = Normalize(File.ReadAllText(path));
+        snapshot.ShouldBe(baseline,
+            $"the EF Core model of {contextTypeName} drifted from its committed baseline. "
+            + "If the change is deliberate, regenerate with "
+            + $"{RegenEnvVar}=regen dotnet test tests/Granit.ArchitectureTests --filter ModelSnapshot "
+            + "and review the snapshot diff; if not, the conventions produced a different model.");
+    }
+
+    [Fact]
+    public void Model_build_is_deterministic()
+    {
+        // One representative full double-build guards against non-deterministic
+        // ToDebugString content (hash codes, unordered sets) invalidating the harness.
+        Type contextType = EnumerateContextTypes()
+            .First(t => typeof(GranitDbContext).IsAssignableFrom(t));
+
+        BuildSnapshot(contextType).ShouldBe(BuildSnapshot(contextType));
+    }
+
+    [Fact]
+    public void Every_unbuildable_exemption_still_exists()
+    {
+        HashSet<string> discovered = [.. EnumerateContextTypes().Select(t => t.FullName!)];
+        List<string> stale = [.. Unbuildable.Keys.Where(name => !discovered.Contains(name))];
+
+        stale.ShouldBeEmpty(
+            $"exempt contexts no longer exist — remove from Unbuildable: {string.Join(", ", stale)}");
+    }
+
+    [Fact]
+    public void No_orphan_snapshot_files()
+    {
+        string dir = Path.Combine(SnapshotsDirectory());
+        if (!Directory.Exists(dir))
+        {
+            return;
+        }
+
+        HashSet<string> expected = [.. EnumerateContextTypes()
+            .Where(t => !Unbuildable.ContainsKey(t.FullName!))
+            .Select(t => $"{t.FullName}.snap")];
+
+        List<string> orphans = [.. Directory.EnumerateFiles(dir, "*.snap")
+            .Select(Path.GetFileName)
+            .OfType<string>()
+            .Where(name => !expected.Contains(name))
+            .Order(StringComparer.Ordinal)];
+
+        orphans.ShouldBeEmpty(
+            $"snapshot files without a matching context (renamed/deleted?): {string.Join(", ", orphans)}");
+    }
+
+    // ── Harness ─────────────────────────────────────────────────────────
+
+    private static string BuildSnapshot(Type contextType)
+    {
+        using DbContext context = CreateContext(contextType);
+
+        // ToDebugString prints only the query-filter collection TYPE, not the expressions —
+        // and the named filters are half the convention surface Phase 2 must keep identical.
+        // Append every named filter's expression explicitly, deterministically ordered.
+        System.Text.StringBuilder snapshot = new(
+            context.Model.ToDebugString(MetadataDebugStringOptions.LongDefault, indent: 0));
+        snapshot.AppendLine().AppendLine().AppendLine("Query filters:");
+
+        foreach (Microsoft.EntityFrameworkCore.Metadata.IEntityType entityType in context.Model
+            .GetEntityTypes()
+            .OrderBy(et => et.Name, StringComparer.Ordinal))
+        {
+            foreach (Microsoft.EntityFrameworkCore.Metadata.IQueryFilter filter in entityType.GetDeclaredQueryFilters()
+                .OrderBy(f => f.Key, StringComparer.Ordinal))
+            {
+                snapshot.Append("  ").Append(entityType.ShortName())
+                    .Append('[').Append(filter.Key).Append("]: ")
+                    .AppendLine(filter.Expression?.ToString() ?? "(null)");
+            }
+        }
+
+        return Normalize(snapshot.ToString());
+    }
+
+    private static DbContext CreateContext(Type contextType)
+    {
+        var optionsBuilder = (DbContextOptionsBuilder)Activator.CreateInstance(
+            typeof(DbContextOptionsBuilder<>).MakeGenericType(contextType))!;
+        optionsBuilder
+            .UseNpgsql("Host=snapshot;Database=snapshot;Username=snapshot;Password=snapshot")
+            .ConfigureWarnings(w => w.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning));
+
+        ConstructorInfo constructor = contextType
+            .GetConstructors(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+            .Where(c => c.GetParameters().Any(p => typeof(DbContextOptions).IsAssignableFrom(p.ParameterType)))
+            .OrderByDescending(c => c.GetParameters().Length)
+            .First();
+
+        object?[] arguments = [.. constructor.GetParameters().Select(parameter =>
+            TryResolveConstructorArgument(parameter, optionsBuilder.Options, out object? value)
+                ? value
+                : throw new InvalidOperationException(
+                    $"{contextType.Name}: cannot resolve constructor parameter "
+                    + $"'{parameter.ParameterType.Name} {parameter.Name}' — add the context to "
+                    + "Unbuildable with a justification, or teach the harness the new dependency."))];
+
+        return (DbContext)constructor.Invoke(arguments);
+    }
+
+    private static bool TryResolveConstructorArgument(
+        ParameterInfo parameter, DbContextOptions options, out object? value)
+    {
+        if (typeof(DbContextOptions).IsAssignableFrom(parameter.ParameterType))
+        {
+            value = options;
+            return true;
+        }
+
+        if (parameter.ParameterType == typeof(ICurrentTenant))
+        {
+            value = GranitDesignTime.CurrentTenant;
+            return true;
+        }
+
+        if (parameter.ParameterType == typeof(IDataFilter))
+        {
+            value = GranitDesignTime.DataFilter;
+            return true;
+        }
+
+        // Encrypted-column contexts (Identity, Privacy, Notifications*, …): the service only
+        // feeds value converters, whose model shape is instance-independent — a passthrough
+        // stub keeps those models inside the golden guarantee instead of exempting them.
+        if (parameter.ParameterType == typeof(Granit.Encryption.IStringEncryptionService))
+        {
+            value = SnapshotStringEncryptionService.Instance;
+            return true;
+        }
+
+        // IndexingDbContext's model is parameterised by host config; snapshot a canonical
+        // deterministic shape (single Guid key set, default dictionary, no embeddings).
+        if (parameter.ParameterType == typeof(Granit.Indexing.EntityFrameworkCore.IndexingDbContextSchema))
+        {
+            value = new Granit.Indexing.EntityFrameworkCore.IndexingDbContextSchema(
+                [typeof(Guid)], "english");
+            return true;
+        }
+
+        // Optional dependency (e.g. `IDataFilter? dataFilter = null`) — design-time default.
+        if (parameter.HasDefaultValue)
+        {
+            value = parameter.DefaultValue;
+            return true;
+        }
+
+        value = null;
+        return false;
+    }
+
+    private sealed class SnapshotStringEncryptionService : Granit.Encryption.IStringEncryptionService
+    {
+        public static readonly SnapshotStringEncryptionService Instance = new();
+
+        public string Encrypt(string plainText) => plainText;
+
+        public string? Decrypt(string cipherText) => cipherText;
+    }
+
+    private static IEnumerable<Type> EnumerateContextTypes() =>
+        Directory.EnumerateFiles(AppContext.BaseDirectory, "Granit.*.dll")
+            .Select(Path.GetFileNameWithoutExtension)
+            .Order(StringComparer.Ordinal)
+            .Select(name => Assembly.Load(new AssemblyName(name!)))
+            .SelectMany(GetLoadableTypes)
+            .Where(t => t is { IsClass: true, IsAbstract: false }
+                && typeof(DbContext).IsAssignableFrom(t))
+            .OrderBy(t => t.FullName, StringComparer.Ordinal);
+
+    private static Type[] GetLoadableTypes(Assembly assembly)
+    {
+        try
+        {
+            return assembly.GetTypes();
+        }
+        catch (ReflectionTypeLoadException ex)
+        {
+            return [.. ex.Types.OfType<Type>()];
+        }
+    }
+
+    private static string SnapshotPath(string contextTypeName) =>
+        Path.Combine(SnapshotsDirectory(), $"{contextTypeName}.snap");
+
+    private static string SnapshotsDirectory() =>
+        Path.Combine(
+            ArchitectureTestHelpers.FindRepoRoot(),
+            "tests", "Granit.ArchitectureTests", "ModelSnapshots");
+
+    private static string Normalize(string value) =>
+        value.Replace("\r\n", "\n", StringComparison.Ordinal).TrimEnd('\n') + "\n";
+}

--- a/tests/Granit.ArchitectureTests/ModelSnapshots/Granit.AI.Chat.EntityFrameworkCore.Internal.AIChatDbContext.snap
+++ b/tests/Granit.ArchitectureTests/ModelSnapshots/Granit.AI.Chat.EntityFrameworkCore.Internal.AIChatDbContext.snap
@@ -1,0 +1,166 @@
+Model: 
+  EntityType: Conversation
+    Properties: 
+      Id (Guid) Required PK AfterSave:Throw ValueGenerated.OnAdd
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      CreatedAt (DateTimeOffset) Required Index
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      CreatedBy (string) Required MaxLength(256)
+        Annotations: 
+          MaxLength: 256
+          Npgsql:ValueGenerationStrategy: None
+      DeletedAt (DateTimeOffset?)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      DeletedBy (string) MaxLength(256)
+        Annotations: 
+          MaxLength: 256
+          Npgsql:ValueGenerationStrategy: None
+      IsDeleted (bool) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      IsFavorite (bool) Required ValueGenerated.OnAdd
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+          Relational:DefaultValue: False
+      ModifiedAt (DateTimeOffset?)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      ModifiedBy (string) MaxLength(256)
+        Annotations: 
+          MaxLength: 256
+          Npgsql:ValueGenerationStrategy: None
+      OwnerId (Guid) Required Index
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      TenantId (Guid?) Index
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      Title (string) Required MaxLength(500)
+        Annotations: 
+          MaxLength: 500
+          Npgsql:ValueGenerationStrategy: None
+      WorkspaceKey (string) MaxLength(256)
+        Annotations: 
+          MaxLength: 256
+          Npgsql:ValueGenerationStrategy: None
+    Navigations: 
+      Messages (_messages, IReadOnlyList<Message>) Collection ToDependent Message
+    Keys: 
+      Id PK
+    Indexes: 
+      TenantId, OwnerId
+        Annotations: 
+          Relational:Name: ix_ai_chat_conversations_tenant_owner
+      TenantId, OwnerId, CreatedAt
+        Annotations: 
+          Relational:Name: ix_ai_chat_conversations_tenant_owner_created
+    Annotations: 
+      QueryFilter: Microsoft.EntityFrameworkCore.Metadata.Internal.QueryFilterCollection
+      Relational:FunctionName: 
+      Relational:Schema: 
+      Relational:SqlQuery: 
+      Relational:TableName: ai_chat_conversations
+      Relational:ViewName: 
+      Relational:ViewSchema: 
+  EntityType: Message
+    Properties: 
+      Id (Guid) Required PK AfterSave:Throw ValueGenerated.OnAdd
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      Content (string) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      ConversationId (Guid) Required FK Index
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      CreatedAt (DateTimeOffset) Required Index
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      CreatedBy (string) Required MaxLength(256)
+        Annotations: 
+          MaxLength: 256
+          Npgsql:ValueGenerationStrategy: None
+      Role (MessageRole) Required MaxLength(20)
+        Annotations: 
+          MaxLength: 20
+          Npgsql:ValueGenerationStrategy: None
+      WorkspaceKey (string) MaxLength(256)
+        Annotations: 
+          MaxLength: 256
+          Npgsql:ValueGenerationStrategy: None
+    Keys: 
+      Id PK
+    Foreign keys: 
+      Message {'ConversationId'} -> Conversation {'Id'} Required Cascade ToDependent: Messages
+    Indexes: 
+      ConversationId, CreatedAt
+        Annotations: 
+          Relational:Name: ix_ai_chat_messages_conversation_created
+    Annotations: 
+      Relational:FunctionName: 
+      Relational:Schema: 
+      Relational:SqlQuery: 
+      Relational:TableName: ai_chat_messages
+      Relational:ViewName: 
+      Relational:ViewSchema: 
+  EntityType: MessageReport
+    Properties: 
+      Id (Guid) Required PK AfterSave:Throw ValueGenerated.OnAdd
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      Category (MessageReportCategory?) MaxLength(20)
+        Annotations: 
+          MaxLength: 20
+          Npgsql:ValueGenerationStrategy: None
+      ConversationId (Guid) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      CreatedAt (DateTimeOffset) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      CreatedBy (string) Required MaxLength(256)
+        Annotations: 
+          MaxLength: 256
+          Npgsql:ValueGenerationStrategy: None
+      MessageId (Guid) Required Index
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      OwnerId (Guid) Required Index
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      Reason (string) Required MaxLength(2000)
+        Annotations: 
+          MaxLength: 2000
+          Npgsql:ValueGenerationStrategy: None
+      TenantId (Guid?) Index
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+    Keys: 
+      Id PK
+    Indexes: 
+      TenantId, MessageId
+        Annotations: 
+          Relational:Name: ix_ai_chat_message_reports_tenant_message
+      TenantId, OwnerId
+        Annotations: 
+          Relational:Name: ix_ai_chat_message_reports_tenant_owner
+    Annotations: 
+      QueryFilter: Microsoft.EntityFrameworkCore.Metadata.Internal.QueryFilterCollection
+      Relational:FunctionName: 
+      Relational:Schema: 
+      Relational:SqlQuery: 
+      Relational:TableName: ai_chat_message_reports
+      Relational:ViewName: 
+      Relational:ViewSchema: 
+Annotations: 
+  Npgsql:ValueGenerationStrategy: IdentityByDefaultColumn
+  ProductVersion: 10.0.10
+  Relational:MaxIdentifierLength: 63
+
+Query filters:
+  Conversation[MultiTenant]: e => (Not(value(Granit.AI.Chat.EntityFrameworkCore.Internal.AIChatDbContext).IsMultiTenantFilterEnabled) OrElse (Property(e, "TenantId") == value(Granit.AI.Chat.EntityFrameworkCore.Internal.AIChatDbContext).CurrentTenantId))
+  Conversation[SoftDelete]: e => (Not(value(Granit.AI.Chat.EntityFrameworkCore.Internal.AIChatDbContext).IsSoftDeleteFilterEnabled) OrElse Not(Property(e, "IsDeleted")))
+  MessageReport[MultiTenant]: e => (Not(value(Granit.AI.Chat.EntityFrameworkCore.Internal.AIChatDbContext).IsMultiTenantFilterEnabled) OrElse (Property(e, "TenantId") == value(Granit.AI.Chat.EntityFrameworkCore.Internal.AIChatDbContext).CurrentTenantId))

--- a/tests/Granit.ArchitectureTests/ModelSnapshots/Granit.AI.EntityFrameworkCore.Internal.AIDbContext.snap
+++ b/tests/Granit.ArchitectureTests/ModelSnapshots/Granit.AI.EntityFrameworkCore.Internal.AIDbContext.snap
@@ -1,0 +1,178 @@
+Model: 
+  EntityType: AIUsageRecordEntity
+    Properties: 
+      Id (Guid) Required PK AfterSave:Throw ValueGenerated.OnAdd
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      ConversationId (Guid?) Index
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      CostCurrency (string) MaxLength(3)
+        Annotations: 
+          MaxLength: 3
+          Npgsql:ValueGenerationStrategy: None
+      CreatedAt (DateTimeOffset) Required Index
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      CreatedBy (string) Required MaxLength(256)
+        Annotations: 
+          MaxLength: 256
+          Npgsql:ValueGenerationStrategy: None
+      Duration (TimeSpan?)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      EstimatedCost (decimal?)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+          Precision: 18
+          Scale: 8
+      InputTokens (int) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      Model (string) Required Index MaxLength(100)
+        Annotations: 
+          MaxLength: 100
+          Npgsql:ValueGenerationStrategy: None
+      OutputTokens (int) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      PromptTemplateName (string) MaxLength(200)
+        Annotations: 
+          MaxLength: 200
+          Npgsql:ValueGenerationStrategy: None
+      PromptTemplateVersion (int?)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      PromptVersion (string) MaxLength(50)
+        Annotations: 
+          MaxLength: 50
+          Npgsql:ValueGenerationStrategy: None
+      Provider (string) Required Index MaxLength(50)
+        Annotations: 
+          MaxLength: 50
+          Npgsql:ValueGenerationStrategy: None
+      TenantId (Guid?) Index
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      UserId (Guid?)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      WorkspaceName (string) Required Index MaxLength(100)
+        Annotations: 
+          MaxLength: 100
+          Npgsql:ValueGenerationStrategy: None
+    Keys: 
+      Id PK
+    Indexes: 
+      TenantId, ConversationId
+        Annotations: 
+          Relational:Name: ix_ai_usage_records_tenant_conversation
+      TenantId, Provider, Model
+        Annotations: 
+          Relational:Name: ix_ai_usage_records_tenant_provider_model
+      TenantId, WorkspaceName, CreatedAt
+        Annotations: 
+          Relational:Name: ix_ai_usage_records_tenant_workspace_date
+    Annotations: 
+      QueryFilter: Microsoft.EntityFrameworkCore.Metadata.Internal.QueryFilterCollection
+      Relational:FunctionName: 
+      Relational:Schema: 
+      Relational:SqlQuery: 
+      Relational:TableName: ai_usage_records
+      Relational:ViewName: 
+      Relational:ViewSchema: 
+  EntityType: AIWorkspaceEntity
+    Properties: 
+      Id (Guid) Required PK AfterSave:Throw ValueGenerated.OnAdd
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      Activated (bool) Required Sentinel:True ValueGenerated.OnAdd
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+          Relational:DefaultValue: True
+      ApiKey (string) MaxLength(2000)
+        Annotations: 
+          MaxLength: 2000
+          Npgsql:ValueGenerationStrategy: None
+      CreatedAt (DateTimeOffset) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      CreatedBy (string) Required MaxLength(256)
+        Annotations: 
+          MaxLength: 256
+          Npgsql:ValueGenerationStrategy: None
+      DeletedAt (DateTimeOffset?)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      DeletedBy (string) MaxLength(256)
+        Annotations: 
+          MaxLength: 256
+          Npgsql:ValueGenerationStrategy: None
+      DisplayName (string) MaxLength(64)
+        Annotations: 
+          MaxLength: 64
+          Npgsql:ValueGenerationStrategy: None
+      Endpoint (string) MaxLength(2000)
+        Annotations: 
+          MaxLength: 2000
+          Npgsql:ValueGenerationStrategy: None
+      IsDeleted (bool) Required ValueGenerated.OnAdd
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+          Relational:DefaultValue: False
+      Key (string) Required Index MaxLength(100)
+        Annotations: 
+          MaxLength: 100
+          Npgsql:ValueGenerationStrategy: None
+      MaxOutputTokens (int?)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      Model (string) Required MaxLength(100)
+        Annotations: 
+          MaxLength: 100
+          Npgsql:ValueGenerationStrategy: None
+      ModifiedAt (DateTimeOffset?)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      ModifiedBy (string) MaxLength(256)
+        Annotations: 
+          MaxLength: 256
+          Npgsql:ValueGenerationStrategy: None
+      Provider (string) Required MaxLength(50)
+        Annotations: 
+          MaxLength: 50
+          Npgsql:ValueGenerationStrategy: None
+      SystemPrompt (string) MaxLength(10000)
+        Annotations: 
+          MaxLength: 10000
+          Npgsql:ValueGenerationStrategy: None
+      Temperature (float?)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      TenantId (Guid?) Index
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+    Keys: 
+      Id PK
+    Indexes: 
+      TenantId, Key Unique
+        Annotations: 
+          Relational:Name: uq_ai_workspaces_tenant_name
+    Annotations: 
+      QueryFilter: Microsoft.EntityFrameworkCore.Metadata.Internal.QueryFilterCollection
+      Relational:FunctionName: 
+      Relational:Schema: 
+      Relational:SqlQuery: 
+      Relational:TableName: ai_workspaces
+      Relational:ViewName: 
+      Relational:ViewSchema: 
+Annotations: 
+  Npgsql:ValueGenerationStrategy: IdentityByDefaultColumn
+  ProductVersion: 10.0.10
+  Relational:MaxIdentifierLength: 63
+
+Query filters:
+  AIUsageRecordEntity[MultiTenant]: e => (Not(value(Granit.AI.EntityFrameworkCore.Internal.AIDbContext).IsMultiTenantFilterEnabled) OrElse (Property(e, "TenantId") == value(Granit.AI.EntityFrameworkCore.Internal.AIDbContext).CurrentTenantId))
+  AIWorkspaceEntity[Active]: e => (Not(value(Granit.AI.EntityFrameworkCore.Internal.AIDbContext).IsActiveFilterEnabled) OrElse Property(e, "Activated"))
+  AIWorkspaceEntity[MultiTenant]: e => (Not(value(Granit.AI.EntityFrameworkCore.Internal.AIDbContext).IsMultiTenantFilterEnabled) OrElse (Property(e, "TenantId") == value(Granit.AI.EntityFrameworkCore.Internal.AIDbContext).CurrentTenantId))
+  AIWorkspaceEntity[SoftDelete]: e => (Not(value(Granit.AI.EntityFrameworkCore.Internal.AIDbContext).IsSoftDeleteFilterEnabled) OrElse Not(Property(e, "IsDeleted")))

--- a/tests/Granit.ArchitectureTests/ModelSnapshots/Granit.AI.Prompts.EntityFrameworkCore.Internal.AIPromptsDbContext.snap
+++ b/tests/Granit.ArchitectureTests/ModelSnapshots/Granit.AI.Prompts.EntityFrameworkCore.Internal.AIPromptsDbContext.snap
@@ -1,0 +1,179 @@
+Model: 
+  EntityType: PromptCategory
+    Properties: 
+      Id (Guid) Required PK AfterSave:Throw ValueGenerated.OnAdd
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      CreatedAt (DateTimeOffset) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      CreatedBy (string) Required MaxLength(256)
+        Annotations: 
+          MaxLength: 256
+          Npgsql:ValueGenerationStrategy: None
+      DeletedAt (DateTimeOffset?)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      DeletedBy (string) MaxLength(256)
+        Annotations: 
+          MaxLength: 256
+          Npgsql:ValueGenerationStrategy: None
+      IsDeleted (bool) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      IsSystem (bool) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      ModifiedAt (DateTimeOffset?)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      ModifiedBy (string) MaxLength(256)
+        Annotations: 
+          MaxLength: 256
+          Npgsql:ValueGenerationStrategy: None
+      Name (string) Required Index MaxLength(200)
+        Annotations: 
+          MaxLength: 200
+          Npgsql:ValueGenerationStrategy: None
+      TenantId (Guid?) Index
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+    Keys: 
+      Id PK
+    Indexes: 
+      TenantId, Name Unique
+        Annotations: 
+          Relational:Name: ix_ai_prompts_categories_tenant_name
+    Annotations: 
+      QueryFilter: Microsoft.EntityFrameworkCore.Metadata.Internal.QueryFilterCollection
+      Relational:FunctionName: 
+      Relational:Schema: 
+      Relational:SqlQuery: 
+      Relational:TableName: ai_prompts_categories
+      Relational:ViewName: 
+      Relational:ViewSchema: 
+  EntityType: PromptTemplate
+    Properties: 
+      Id (Guid) Required PK AfterSave:Throw ValueGenerated.OnAdd
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      Content (string) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      CreatedAt (DateTimeOffset) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      CreatedBy (string) Required MaxLength(256)
+        Annotations: 
+          MaxLength: 256
+          Npgsql:ValueGenerationStrategy: None
+      DeletedAt (DateTimeOffset?)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      DeletedBy (string) MaxLength(256)
+        Annotations: 
+          MaxLength: 256
+          Npgsql:ValueGenerationStrategy: None
+      Icon (string) MaxLength(100)
+        Annotations: 
+          MaxLength: 100
+          Npgsql:ValueGenerationStrategy: None
+      IconColor (HexColor) MaxLength(9)
+        Annotations: 
+          MaxLength: 9
+          Npgsql:ValueGenerationStrategy: None
+      IsDeleted (bool) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      IsSystem (bool) Required Index
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      ModifiedAt (DateTimeOffset?)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      ModifiedBy (string) MaxLength(256)
+        Annotations: 
+          MaxLength: 256
+          Npgsql:ValueGenerationStrategy: None
+      Name (string) Required Index MaxLength(200)
+        Annotations: 
+          MaxLength: 200
+          Npgsql:ValueGenerationStrategy: None
+      OwnerId (Guid) Required Index
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      ShortDescription (string) Required MaxLength(500)
+        Annotations: 
+          MaxLength: 500
+          Npgsql:ValueGenerationStrategy: None
+      TenantId (Guid?) Index
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      Version (int) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+    Navigations: 
+      CategoryLinks (List<PromptTemplateCategory>) Collection ToDependent PromptTemplateCategory
+    Keys: 
+      Id PK
+    Indexes: 
+      TenantId, OwnerId
+        Annotations: 
+          Relational:Name: ix_ai_prompts_templates_tenant_owner
+      TenantId, IsSystem, OwnerId, Name
+        Annotations: 
+          Relational:Name: ix_ai_prompts_templates_tenant_system_owner_name
+    Annotations: 
+      QueryFilter: Microsoft.EntityFrameworkCore.Metadata.Internal.QueryFilterCollection
+      Relational:FunctionName: 
+      Relational:Schema: 
+      Relational:SqlQuery: 
+      Relational:TableName: ai_prompts_templates
+      Relational:ViewName: 
+      Relational:ViewSchema: 
+  EntityType: PromptTemplateCategory
+    Properties: 
+      Id (Guid) Required PK AfterSave:Throw
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      CategoryId (Guid) Required Index
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      CreatedAt (DateTimeOffset) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      CreatedBy (string) Required MaxLength(256)
+        Annotations: 
+          MaxLength: 256
+          Npgsql:ValueGenerationStrategy: None
+      PromptTemplateId (Guid) Required FK Index
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+    Keys: 
+      Id PK
+    Foreign keys: 
+      PromptTemplateCategory {'PromptTemplateId'} -> PromptTemplate {'Id'} Required Cascade ToDependent: CategoryLinks
+    Indexes: 
+      CategoryId
+        Annotations: 
+          Relational:Name: ix_ai_prompts_template_categories_category
+      PromptTemplateId, CategoryId Unique
+        Annotations: 
+          Relational:Name: ix_ai_prompts_template_categories_prompt_category
+    Annotations: 
+      Relational:FunctionName: 
+      Relational:Schema: 
+      Relational:SqlQuery: 
+      Relational:TableName: ai_prompts_template_categories
+      Relational:ViewName: 
+      Relational:ViewSchema: 
+Annotations: 
+  Npgsql:ValueGenerationStrategy: IdentityByDefaultColumn
+  ProductVersion: 10.0.10
+  Relational:MaxIdentifierLength: 63
+
+Query filters:
+  PromptCategory[MultiTenant]: e => (Not(value(Granit.AI.Prompts.EntityFrameworkCore.Internal.AIPromptsDbContext).IsMultiTenantFilterEnabled) OrElse (Property(e, "TenantId") == value(Granit.AI.Prompts.EntityFrameworkCore.Internal.AIPromptsDbContext).CurrentTenantId))
+  PromptCategory[SoftDelete]: e => (Not(value(Granit.AI.Prompts.EntityFrameworkCore.Internal.AIPromptsDbContext).IsSoftDeleteFilterEnabled) OrElse Not(Property(e, "IsDeleted")))
+  PromptTemplate[MultiTenant]: e => (Not(value(Granit.AI.Prompts.EntityFrameworkCore.Internal.AIPromptsDbContext).IsMultiTenantFilterEnabled) OrElse (Property(e, "TenantId") == value(Granit.AI.Prompts.EntityFrameworkCore.Internal.AIPromptsDbContext).CurrentTenantId))
+  PromptTemplate[SoftDelete]: e => (Not(value(Granit.AI.Prompts.EntityFrameworkCore.Internal.AIPromptsDbContext).IsSoftDeleteFilterEnabled) OrElse Not(Property(e, "IsDeleted")))

--- a/tests/Granit.ArchitectureTests/ModelSnapshots/Granit.Auditing.EntityFrameworkCore.Internal.AuditingDbContext.snap
+++ b/tests/Granit.ArchitectureTests/ModelSnapshots/Granit.Auditing.EntityFrameworkCore.Internal.AuditingDbContext.snap
@@ -1,0 +1,152 @@
+Model: 
+  EntityType: AuditEntityChange
+    Properties: 
+      Id (Guid) Required PK AfterSave:Throw ValueGenerated.OnAdd
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      AuditEntryId (Guid) Required FK Index
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+          Relational:ColumnName: AuditLogEntryId
+      ChangeType (AuditChangeType) Required MaxLength(20)
+        Annotations: 
+          MaxLength: 20
+          Npgsql:ValueGenerationStrategy: None
+      EntityId (string) Required Index MaxLength(256)
+        Annotations: 
+          MaxLength: 256
+          Npgsql:ValueGenerationStrategy: None
+      EntityType (string) Required Index MaxLength(256)
+        Annotations: 
+          MaxLength: 256
+          Npgsql:ValueGenerationStrategy: None
+      TenantId (Guid?)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+    Navigations: 
+      PropertyChanges (ICollection<AuditPropertyChange>) Collection ToDependent AuditPropertyChange
+    Keys: 
+      Id PK
+    Foreign keys: 
+      AuditEntityChange {'AuditEntryId'} -> AuditEntry {'Id'} Required Cascade ToDependent: EntityChanges
+    Indexes: 
+      AuditEntryId
+      EntityType, EntityId, AuditEntryId
+        Annotations: 
+          Relational:Name: ix_audit_log_entity_changes_type_id
+    Annotations: 
+      QueryFilter: Microsoft.EntityFrameworkCore.Metadata.Internal.QueryFilterCollection
+      Relational:FunctionName: 
+      Relational:Schema: 
+      Relational:SqlQuery: 
+      Relational:TableName: audit_log_entity_changes
+      Relational:ViewName: 
+      Relational:ViewSchema: 
+  EntityType: AuditEntry
+    Properties: 
+      Id (Guid) Required PK AfterSave:Throw ValueGenerated.OnAdd
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      Category (AuditCategory) Required Index MaxLength(50)
+        Annotations: 
+          MaxLength: 50
+          Npgsql:ValueGenerationStrategy: None
+      CorrelationId (string) Index MaxLength(256)
+        Annotations: 
+          MaxLength: 256
+          Npgsql:ValueGenerationStrategy: None
+      CreatedAt (DateTimeOffset) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      CreatedBy (string) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      IpAddress (string) MaxLength(45)
+        Annotations: 
+          MaxLength: 45
+          Npgsql:ValueGenerationStrategy: None
+      TenantId (Guid?) Index
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      Timestamp (DateTimeOffset) Required Index
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      UserAgent (string) MaxLength(500)
+        Annotations: 
+          MaxLength: 500
+          Npgsql:ValueGenerationStrategy: None
+      UserId (string) Required Index MaxLength(256)
+        Annotations: 
+          MaxLength: 256
+          Npgsql:ValueGenerationStrategy: None
+      UserName (string) MaxLength(256)
+        Annotations: 
+          MaxLength: 256
+          Npgsql:ValueGenerationStrategy: None
+    Navigations: 
+      EntityChanges (ICollection<AuditEntityChange>) Collection ToDependent AuditEntityChange
+    Keys: 
+      Id PK
+    Indexes: 
+      CorrelationId
+        Annotations: 
+          Relational:Name: ix_audit_log_log_entries_correlation
+      Timestamp
+        Annotations: 
+          Relational:Name: ix_audit_log_log_entries_timestamp
+      Category, Timestamp
+        Annotations: 
+          Relational:Name: ix_audit_log_log_entries_category_timestamp
+      TenantId, Timestamp
+        Annotations: 
+          Relational:Name: ix_audit_log_log_entries_tenant_timestamp
+      UserId, Timestamp
+        Annotations: 
+          Relational:Name: ix_audit_log_log_entries_user_timestamp
+    Annotations: 
+      QueryFilter: Microsoft.EntityFrameworkCore.Metadata.Internal.QueryFilterCollection
+      Relational:FunctionName: 
+      Relational:Schema: 
+      Relational:SqlQuery: 
+      Relational:TableName: audit_log_log_entries
+      Relational:ViewName: 
+      Relational:ViewSchema: 
+  EntityType: AuditPropertyChange
+    Properties: 
+      Id (Guid) Required PK AfterSave:Throw ValueGenerated.OnAdd
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      AuditEntityChangeId (Guid) Required FK Index
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      NewValue (string)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      OriginalValue (string)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      PropertyName (string) Required MaxLength(256)
+        Annotations: 
+          MaxLength: 256
+          Npgsql:ValueGenerationStrategy: None
+    Keys: 
+      Id PK
+    Foreign keys: 
+      AuditPropertyChange {'AuditEntityChangeId'} -> AuditEntityChange {'Id'} Required Cascade ToDependent: PropertyChanges
+    Indexes: 
+      AuditEntityChangeId
+    Annotations: 
+      Relational:FunctionName: 
+      Relational:Schema: 
+      Relational:SqlQuery: 
+      Relational:TableName: audit_log_property_changes
+      Relational:ViewName: 
+      Relational:ViewSchema: 
+Annotations: 
+  Npgsql:ValueGenerationStrategy: IdentityByDefaultColumn
+  ProductVersion: 10.0.10
+  Relational:MaxIdentifierLength: 63
+
+Query filters:
+  AuditEntityChange[MultiTenant]: e => (Not(value(Granit.Auditing.EntityFrameworkCore.Internal.AuditingDbContext).IsMultiTenantFilterEnabled) OrElse (Property(e, "TenantId") == value(Granit.Auditing.EntityFrameworkCore.Internal.AuditingDbContext).CurrentTenantId))
+  AuditEntry[MultiTenant]: e => (Not(value(Granit.Auditing.EntityFrameworkCore.Internal.AuditingDbContext).IsMultiTenantFilterEnabled) OrElse (Property(e, "TenantId") == value(Granit.Auditing.EntityFrameworkCore.Internal.AuditingDbContext).CurrentTenantId))

--- a/tests/Granit.ArchitectureTests/ModelSnapshots/Granit.Authentication.ApiKeys.EntityFrameworkCore.Internal.AuthenticationApiKeysDbContext.snap
+++ b/tests/Granit.ArchitectureTests/ModelSnapshots/Granit.Authentication.ApiKeys.EntityFrameworkCore.Internal.AuthenticationApiKeysDbContext.snap
@@ -1,0 +1,109 @@
+Model: 
+  EntityType: ApiKeyEntry
+    Properties: 
+      Id (Guid) Required PK AfterSave:Throw ValueGenerated.OnAdd
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      AllowedCidrs (List<string>) Required Element type: string Required
+        Annotations: 
+          ElementType: Element type: string Required
+          Npgsql:ValueGenerationStrategy: None
+      CacheBehavior (CacheBehavior) Required MaxLength(20)
+        Annotations: 
+          MaxLength: 20
+          Npgsql:ValueGenerationStrategy: None
+      CreatedAt (DateTimeOffset) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      CreatedBy (string) Required MaxLength(200)
+        Annotations: 
+          MaxLength: 200
+          Npgsql:ValueGenerationStrategy: None
+      DeletedAt (DateTimeOffset?)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      DeletedBy (string) MaxLength(200)
+        Annotations: 
+          MaxLength: 200
+          Npgsql:ValueGenerationStrategy: None
+      Environment (string) Required MaxLength(10)
+        Annotations: 
+          MaxLength: 10
+          Npgsql:ValueGenerationStrategy: None
+      ExpiresAt (DateTimeOffset?) Index
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      HashedKey (string) Required Index MaxLength(100)
+        Annotations: 
+          MaxLength: 100
+          Npgsql:ValueGenerationStrategy: None
+      IsDeleted (bool) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      LastExpirationNotifiedAt (DateTimeOffset?) Index
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      LastFourChars (string) Required MaxLength(4)
+        Annotations: 
+          MaxLength: 4
+          Npgsql:ValueGenerationStrategy: None
+      LastUsedAt (DateTimeOffset?)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      ModifiedAt (DateTimeOffset?)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      ModifiedBy (string) MaxLength(200)
+        Annotations: 
+          MaxLength: 200
+          Npgsql:ValueGenerationStrategy: None
+      Name (string) Required MaxLength(200)
+        Annotations: 
+          MaxLength: 200
+          Npgsql:ValueGenerationStrategy: None
+      Permissions (List<string>) Required Element type: string Required
+        Annotations: 
+          ElementType: Element type: string Required
+          Npgsql:ValueGenerationStrategy: None
+      Prefix (string) Required MaxLength(20)
+        Annotations: 
+          MaxLength: 20
+          Npgsql:ValueGenerationStrategy: None
+      RevokedAt (DateTimeOffset?) Index
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      TenantId (Guid?) Index
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      Type (ApiKeyType) Required MaxLength(20)
+        Annotations: 
+          MaxLength: 20
+          Npgsql:ValueGenerationStrategy: None
+    Keys: 
+      Id PK
+    Indexes: 
+      HashedKey Unique
+        Annotations: 
+          Relational:Name: uq_authentication_api_keys_entries_hashed_key
+      TenantId
+        Annotations: 
+          Relational:Name: ix_authentication_api_keys_entries_tenant_id
+      ExpiresAt, LastExpirationNotifiedAt, RevokedAt
+        Annotations: 
+          Relational:Name: ix_authentication_api_keys_entries_expiring_scan
+    Annotations: 
+      QueryFilter: Microsoft.EntityFrameworkCore.Metadata.Internal.QueryFilterCollection
+      Relational:FunctionName: 
+      Relational:Schema: 
+      Relational:SqlQuery: 
+      Relational:TableName: authentication_api_keys_entries
+      Relational:ViewName: 
+      Relational:ViewSchema: 
+Annotations: 
+  Npgsql:ValueGenerationStrategy: IdentityByDefaultColumn
+  ProductVersion: 10.0.10
+  Relational:MaxIdentifierLength: 63
+
+Query filters:
+  ApiKeyEntry[MultiTenant]: e => (Not(value(Granit.Authentication.ApiKeys.EntityFrameworkCore.Internal.AuthenticationApiKeysDbContext).IsMultiTenantFilterEnabled) OrElse (Property(e, "TenantId") == value(Granit.Authentication.ApiKeys.EntityFrameworkCore.Internal.AuthenticationApiKeysDbContext).CurrentTenantId))
+  ApiKeyEntry[SoftDelete]: e => (Not(value(Granit.Authentication.ApiKeys.EntityFrameworkCore.Internal.AuthenticationApiKeysDbContext).IsSoftDeleteFilterEnabled) OrElse Not(Property(e, "IsDeleted")))

--- a/tests/Granit.ArchitectureTests/ModelSnapshots/Granit.BackgroundJobs.EntityFrameworkCore.Internal.BackgroundJobsDbContext.snap
+++ b/tests/Granit.ArchitectureTests/ModelSnapshots/Granit.BackgroundJobs.EntityFrameworkCore.Internal.BackgroundJobsDbContext.snap
@@ -1,0 +1,59 @@
+Model: 
+  EntityType: BackgroundJobDefinition
+    Properties: 
+      Id (Guid) Required PK AfterSave:Throw ValueGenerated.OnAdd
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      ConsecutiveFailureCount (int) Required ValueGenerated.OnAdd
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+          Relational:DefaultValue: 0
+      CronExpression (string) Required MaxLength(100)
+        Annotations: 
+          MaxLength: 100
+          Npgsql:ValueGenerationStrategy: None
+      IsEnabled (bool) Required Sentinel:True ValueGenerated.OnAdd
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+          Relational:DefaultValue: True
+      JobName (string) Required Index MaxLength(200)
+        Annotations: 
+          MaxLength: 200
+          Npgsql:ValueGenerationStrategy: None
+      LastErrorMessage (string) MaxLength(2000)
+        Annotations: 
+          MaxLength: 2000
+          Npgsql:ValueGenerationStrategy: None
+      LastExecutedAt (DateTimeOffset?)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      MessageType (string) Required MaxLength(500)
+        Annotations: 
+          MaxLength: 500
+          Npgsql:ValueGenerationStrategy: None
+      NextExecutionAt (DateTimeOffset?)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      TriggeredBy (string) MaxLength(450)
+        Annotations: 
+          MaxLength: 450
+          Npgsql:ValueGenerationStrategy: None
+    Keys: 
+      Id PK
+    Indexes: 
+      JobName Unique
+        Annotations: 
+          Relational:Name: uq_background_jobs_background_jobs_name
+    Annotations: 
+      Relational:FunctionName: 
+      Relational:Schema: 
+      Relational:SqlQuery: 
+      Relational:TableName: background_jobs_background_jobs
+      Relational:ViewName: 
+      Relational:ViewSchema: 
+Annotations: 
+  Npgsql:ValueGenerationStrategy: IdentityByDefaultColumn
+  ProductVersion: 10.0.10
+  Relational:MaxIdentifierLength: 63
+
+Query filters:

--- a/tests/Granit.ArchitectureTests/ModelSnapshots/Granit.Bff.EntityFrameworkCore.Internal.BffDbContext.snap
+++ b/tests/Granit.ArchitectureTests/ModelSnapshots/Granit.Bff.EntityFrameworkCore.Internal.BffDbContext.snap
@@ -1,0 +1,53 @@
+Model: 
+  EntityType: BffSessionEntity
+    Properties: 
+      Id (Guid) Required PK AfterSave:Throw
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      CreatedAt (DateTimeOffset) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      ExpiresAt (DateTimeOffset) Required Index
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      FrontendName (string) Required Index MaxLength(64)
+        Annotations: 
+          MaxLength: 64
+          Npgsql:ValueGenerationStrategy: None
+      IpAddress (string) MaxLength(256)
+        Annotations: 
+          MaxLength: 256
+          Npgsql:ValueGenerationStrategy: None
+      LastAccessedAt (DateTimeOffset?)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      SerializedTokens (string) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      SessionId (string) Required Index MaxLength(64)
+        Annotations: 
+          MaxLength: 64
+          Npgsql:ValueGenerationStrategy: None
+      UserId (string) Index MaxLength(128)
+        Annotations: 
+          MaxLength: 128
+          Npgsql:ValueGenerationStrategy: None
+    Keys: 
+      Id PK
+    Indexes: 
+      ExpiresAt
+      FrontendName, SessionId Unique
+      FrontendName, UserId
+    Annotations: 
+      Relational:FunctionName: 
+      Relational:Schema: 
+      Relational:SqlQuery: 
+      Relational:TableName: bff_sessions
+      Relational:ViewName: 
+      Relational:ViewSchema: 
+Annotations: 
+  Npgsql:ValueGenerationStrategy: IdentityByDefaultColumn
+  ProductVersion: 10.0.10
+  Relational:MaxIdentifierLength: 63
+
+Query filters:

--- a/tests/Granit.ArchitectureTests/ModelSnapshots/Granit.BlobStorage.Database.Internal.BlobStorageDatabaseDbContext.snap
+++ b/tests/Granit.ArchitectureTests/ModelSnapshots/Granit.BlobStorage.Database.Internal.BlobStorageDatabaseDbContext.snap
@@ -1,0 +1,46 @@
+Model: 
+  EntityType: DatabaseBlobContent
+    Properties: 
+      Id (Guid) Required PK AfterSave:Throw ValueGenerated.OnAdd
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      Content (byte[]) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      CreatedAt (DateTimeOffset) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      CreatedBy (string) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      ObjectKey (string) Required Index MaxLength(1024)
+        Annotations: 
+          MaxLength: 1024
+          Npgsql:ValueGenerationStrategy: None
+      TenantId (Guid?) Index
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+    Keys: 
+      Id PK
+    Indexes: 
+      ObjectKey Unique
+        Annotations: 
+          Relational:Name: uq_blob_storage_contents_object_key
+      TenantId, ObjectKey
+        Annotations: 
+          Relational:Name: ix_blob_storage_contents_tenant_object_key
+    Annotations: 
+      QueryFilter: Microsoft.EntityFrameworkCore.Metadata.Internal.QueryFilterCollection
+      Relational:FunctionName: 
+      Relational:Schema: 
+      Relational:SqlQuery: 
+      Relational:TableName: blob_storage_contents
+      Relational:ViewName: 
+      Relational:ViewSchema: 
+Annotations: 
+  Npgsql:ValueGenerationStrategy: IdentityByDefaultColumn
+  ProductVersion: 10.0.10
+  Relational:MaxIdentifierLength: 63
+
+Query filters:
+  DatabaseBlobContent[MultiTenant]: e => (Not(value(Granit.BlobStorage.Database.Internal.BlobStorageDatabaseDbContext).IsMultiTenantFilterEnabled) OrElse (Property(e, "TenantId") == value(Granit.BlobStorage.Database.Internal.BlobStorageDatabaseDbContext).CurrentTenantId))

--- a/tests/Granit.ArchitectureTests/ModelSnapshots/Granit.BlobStorage.EntityFrameworkCore.Internal.BlobStorageDbContext.snap
+++ b/tests/Granit.ArchitectureTests/ModelSnapshots/Granit.BlobStorage.EntityFrameworkCore.Internal.BlobStorageDbContext.snap
@@ -1,0 +1,83 @@
+Model: 
+  EntityType: BlobDescriptor
+    Properties: 
+      Id (Guid) Required PK AfterSave:Throw ValueGenerated.OnAdd
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      ContainerName (string) Required Index MaxLength(100)
+        Annotations: 
+          MaxLength: 100
+          Npgsql:ValueGenerationStrategy: None
+      CreatedAt (DateTimeOffset) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      CreatedBy (string) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      DeclaredContentType (string) Required MaxLength(127)
+        Annotations: 
+          MaxLength: 127
+          Npgsql:ValueGenerationStrategy: None
+      DeletedAt (DateTimeOffset?)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      DeletionReason (string) MaxLength(500)
+        Annotations: 
+          MaxLength: 500
+          Npgsql:ValueGenerationStrategy: None
+      MaxAllowedBytes (long) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      ObjectKey (string) Required Index MaxLength(1024)
+        Annotations: 
+          MaxLength: 1024
+          Npgsql:ValueGenerationStrategy: None
+      OriginalFileName (string) Required MaxLength(500)
+        Annotations: 
+          MaxLength: 500
+          Npgsql:ValueGenerationStrategy: None
+      RejectionReason (string) MaxLength(500)
+        Annotations: 
+          MaxLength: 500
+          Npgsql:ValueGenerationStrategy: None
+      SizeBytes (long?)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      Status (BlobStatus) Required MaxLength(20)
+        Annotations: 
+          MaxLength: 20
+          Npgsql:ValueGenerationStrategy: None
+      TenantId (Guid?) Index
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      ValidatedAt (DateTimeOffset?)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      VerifiedContentType (string) MaxLength(127)
+        Annotations: 
+          MaxLength: 127
+          Npgsql:ValueGenerationStrategy: None
+    Keys: 
+      Id PK
+    Indexes: 
+      ObjectKey Unique
+        Annotations: 
+          Relational:Name: uq_blob_storage_descriptors_object_key
+      TenantId, ContainerName
+        Annotations: 
+          Relational:Name: ix_blob_storage_descriptors_tenant_container
+    Annotations: 
+      QueryFilter: Microsoft.EntityFrameworkCore.Metadata.Internal.QueryFilterCollection
+      Relational:FunctionName: 
+      Relational:Schema: 
+      Relational:SqlQuery: 
+      Relational:TableName: blob_storage_descriptors
+      Relational:ViewName: 
+      Relational:ViewSchema: 
+Annotations: 
+  Npgsql:ValueGenerationStrategy: IdentityByDefaultColumn
+  ProductVersion: 10.0.10
+  Relational:MaxIdentifierLength: 63
+
+Query filters:
+  BlobDescriptor[MultiTenant]: e => (Not(value(Granit.BlobStorage.EntityFrameworkCore.Internal.BlobStorageDbContext).IsMultiTenantFilterEnabled) OrElse (Property(e, "TenantId") == value(Granit.BlobStorage.EntityFrameworkCore.Internal.BlobStorageDbContext).CurrentTenantId))

--- a/tests/Granit.ArchitectureTests/ModelSnapshots/Granit.DataExchange.EntityFrameworkCore.Internal.DataExchangeDbContext.snap
+++ b/tests/Granit.ArchitectureTests/ModelSnapshots/Granit.DataExchange.EntityFrameworkCore.Internal.DataExchangeDbContext.snap
@@ -1,0 +1,324 @@
+Model: 
+  EntityType: ExportPresetEntity
+    Properties: 
+      Id (Guid) Required PK AfterSave:Throw ValueGenerated.OnAdd
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      DefinitionName (string) Required Index MaxLength(200)
+        Annotations: 
+          MaxLength: 200
+          Npgsql:ValueGenerationStrategy: None
+      Fields (List<string>) Required Element type: string Required
+        Annotations: 
+          ElementType: Element type: string Required
+          Npgsql:ValueGenerationStrategy: None
+      Format (string) Required MaxLength(10)
+        Annotations: 
+          MaxLength: 10
+          Npgsql:ValueGenerationStrategy: None
+      IncludeIdForImport (bool) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      PresetName (string) Required Index MaxLength(200)
+        Annotations: 
+          MaxLength: 200
+          Npgsql:ValueGenerationStrategy: None
+      SavedAt (DateTimeOffset) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      SavedBy (string) Required MaxLength(200)
+        Annotations: 
+          MaxLength: 200
+          Npgsql:ValueGenerationStrategy: None
+      TenantId (Guid?) Index
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+    Keys: 
+      Id PK
+    Indexes: 
+      DefinitionName, PresetName, TenantId Unique
+        Annotations: 
+          Relational:Name: uq_data_exchange_export_presets_def_name_tenant
+    Annotations: 
+      QueryFilter: Microsoft.EntityFrameworkCore.Metadata.Internal.QueryFilterCollection
+      Relational:FunctionName: 
+      Relational:Schema: 
+      Relational:SqlQuery: 
+      Relational:TableName: data_exchange_export_presets
+      Relational:ViewName: 
+      Relational:ViewSchema: 
+  EntityType: ExternalIdMappingEntity
+    Properties: 
+      Id (Guid) Required PK AfterSave:Throw ValueGenerated.OnAdd
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      CreatedAt (DateTimeOffset) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      DefinitionName (string) Required Index MaxLength(200)
+        Annotations: 
+          MaxLength: 200
+          Npgsql:ValueGenerationStrategy: None
+      ExternalId (string) Required Index MaxLength(500)
+        Annotations: 
+          MaxLength: 500
+          Npgsql:ValueGenerationStrategy: None
+      InternalId (Guid) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      TenantId (Guid?) Index
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+    Keys: 
+      Id PK
+    Indexes: 
+      DefinitionName, ExternalId, TenantId Unique
+        Annotations: 
+          Relational:Name: uq_data_exchange_external_id_mappings_def_ext_tenant
+    Annotations: 
+      QueryFilter: Microsoft.EntityFrameworkCore.Metadata.Internal.QueryFilterCollection
+      Relational:FunctionName: 
+      Relational:Schema: 
+      Relational:SqlQuery: 
+      Relational:TableName: data_exchange_external_id_mappings
+      Relational:ViewName: 
+      Relational:ViewSchema: 
+  EntityType: SavedMappingEntity
+    Properties: 
+      Id (Guid) Required PK AfterSave:Throw ValueGenerated.OnAdd
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      DefinitionName (string) Required Index MaxLength(200)
+        Annotations: 
+          MaxLength: 200
+          Npgsql:ValueGenerationStrategy: None
+      SavedAt (DateTimeOffset) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      SavedBy (string) Required MaxLength(200)
+        Annotations: 
+          MaxLength: 200
+          Npgsql:ValueGenerationStrategy: None
+      TenantId (Guid?) Index
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+    Navigations: 
+      Mappings (List<ImportColumnMapping>) Collection ToDependent ImportColumnMapping
+        Annotations: 
+          EagerLoaded: True
+    Keys: 
+      Id PK
+    Indexes: 
+      DefinitionName, TenantId Unique
+        Annotations: 
+          Relational:Name: uq_data_exchange_saved_mappings_def_tenant
+    Annotations: 
+      QueryFilter: Microsoft.EntityFrameworkCore.Metadata.Internal.QueryFilterCollection
+      Relational:FunctionName: 
+      Relational:Schema: 
+      Relational:SqlQuery: 
+      Relational:TableName: data_exchange_saved_mappings
+      Relational:ViewName: 
+      Relational:ViewSchema: 
+  EntityType: ExportJob
+    Properties: 
+      Id (Guid) Required PK AfterSave:Throw ValueGenerated.OnAdd
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      BlobReference (BlobReference) MaxLength(500)
+        Annotations: 
+          MaxLength: 500
+          Npgsql:ValueGenerationStrategy: None
+      CompletedAt (DateTimeOffset?)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      ConcurrencyStamp (string) Required Concurrency MaxLength(36)
+        Annotations: 
+          MaxLength: 36
+          Npgsql:ValueGenerationStrategy: None
+      CreatedAt (DateTimeOffset) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      CreatedBy (string) Required MaxLength(200)
+        Annotations: 
+          MaxLength: 200
+          Npgsql:ValueGenerationStrategy: None
+      DefinitionName (string) Required Index MaxLength(200)
+        Annotations: 
+          MaxLength: 200
+          Npgsql:ValueGenerationStrategy: None
+      ErrorMessage (string) MaxLength(2000)
+        Annotations: 
+          MaxLength: 2000
+          Npgsql:ValueGenerationStrategy: None
+      FileDeletedAt (DateTimeOffset?)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      FileName (string) MaxLength(500)
+        Annotations: 
+          MaxLength: 500
+          Npgsql:ValueGenerationStrategy: None
+      Format (string) Required MaxLength(10)
+        Annotations: 
+          MaxLength: 10
+          Npgsql:ValueGenerationStrategy: None
+      ModifiedAt (DateTimeOffset?)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      ModifiedBy (string) MaxLength(200)
+        Annotations: 
+          MaxLength: 200
+          Npgsql:ValueGenerationStrategy: None
+      Request (ExportRequest) Required
+        Annotations: 
+          Granit:JsonSerialized: True
+          Npgsql:ValueGenerationStrategy: None
+      RowCount (int?)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      Status (ExportJobStatus) Required Index MaxLength(20)
+        Annotations: 
+          MaxLength: 20
+          Npgsql:ValueGenerationStrategy: None
+      TenantId (Guid?) Index
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+    Keys: 
+      Id PK
+    Indexes: 
+      DefinitionName, Status
+        Annotations: 
+          Relational:Name: ix_data_exchange_export_jobs_definition_status
+      TenantId, Status
+        Annotations: 
+          Relational:Name: ix_data_exchange_export_jobs_tenant_status
+    Annotations: 
+      QueryFilter: Microsoft.EntityFrameworkCore.Metadata.Internal.QueryFilterCollection
+      Relational:FunctionName: 
+      Relational:Schema: 
+      Relational:SqlQuery: 
+      Relational:TableName: data_exchange_export_jobs
+      Relational:ViewName: 
+      Relational:ViewSchema: 
+  EntityType: ImportJob
+    Properties: 
+      Id (Guid) Required PK AfterSave:Throw ValueGenerated.OnAdd
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      BlobReference (BlobReference) Required MaxLength(500)
+        Annotations: 
+          MaxLength: 500
+          Npgsql:ValueGenerationStrategy: None
+      CompletedAt (DateTimeOffset?)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      ConcurrencyStamp (string) Required Concurrency MaxLength(36)
+        Annotations: 
+          MaxLength: 36
+          Npgsql:ValueGenerationStrategy: None
+      CreatedAt (DateTimeOffset) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      CreatedBy (string) Required MaxLength(200)
+        Annotations: 
+          MaxLength: 200
+          Npgsql:ValueGenerationStrategy: None
+      DefinitionName (string) Required Index MaxLength(200)
+        Annotations: 
+          MaxLength: 200
+          Npgsql:ValueGenerationStrategy: None
+      EntityTypeName (string) Required MaxLength(200)
+        Annotations: 
+          MaxLength: 200
+          Npgsql:ValueGenerationStrategy: None
+      FileDeletedAt (DateTimeOffset?)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      FileSizeBytes (long) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      Mappings (IReadOnlyList<ImportColumnMapping>)
+        Annotations: 
+          Granit:JsonSerialized: True
+          Npgsql:ValueGenerationStrategy: None
+      MimeType (string) Required MaxLength(127)
+        Annotations: 
+          MaxLength: 127
+          Npgsql:ValueGenerationStrategy: None
+      ModifiedAt (DateTimeOffset?)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      ModifiedBy (string) MaxLength(200)
+        Annotations: 
+          MaxLength: 200
+          Npgsql:ValueGenerationStrategy: None
+      OriginalFileName (string) Required MaxLength(500)
+        Annotations: 
+          MaxLength: 500
+          Npgsql:ValueGenerationStrategy: None
+      Report (ImportReport)
+        Annotations: 
+          Granit:JsonSerialized: True
+          Npgsql:ValueGenerationStrategy: None
+      Status (ImportJobStatus) Required Index MaxLength(20)
+        Annotations: 
+          MaxLength: 20
+          Npgsql:ValueGenerationStrategy: None
+      TenantId (Guid?)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+    Keys: 
+      Id PK
+    Indexes: 
+      DefinitionName, Status
+        Annotations: 
+          Relational:Name: ix_data_exchange_import_jobs_definition_status
+    Annotations: 
+      QueryFilter: Microsoft.EntityFrameworkCore.Metadata.Internal.QueryFilterCollection
+      Relational:FunctionName: 
+      Relational:Schema: 
+      Relational:SqlQuery: 
+      Relational:TableName: data_exchange_import_jobs
+      Relational:ViewName: 
+      Relational:ViewSchema: 
+  EntityType: ImportColumnMapping Owned
+    Properties: 
+      SavedMappingEntityId (no field, Guid) Shadow Required PK FK AfterSave:Throw
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      __synthesizedOrdinal (no field, int) Shadow Required PK AfterSave:Throw ValueGenerated.OnAdd
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: IdentityByDefaultColumn
+      Confidence (MappingConfidence) Required MaxLength(20)
+        Annotations: 
+          MaxLength: 20
+          Npgsql:ValueGenerationStrategy: None
+      SourceColumn (string) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      TargetProperty (string)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+    Keys: 
+      SavedMappingEntityId, __synthesizedOrdinal PK
+    Foreign keys: 
+      ImportColumnMapping {'SavedMappingEntityId'} -> SavedMappingEntity {'Id'} Required Ownership Cascade ToDependent: Mappings
+    Annotations: 
+      Relational:ContainerColumnName: Mappings
+      Relational:FunctionName: 
+      Relational:Schema: 
+      Relational:SqlQuery: 
+      Relational:TableName: data_exchange_saved_mappings
+      Relational:ViewName: 
+      Relational:ViewSchema: 
+Annotations: 
+  Npgsql:ValueGenerationStrategy: IdentityByDefaultColumn
+  ProductVersion: 10.0.10
+  Relational:MaxIdentifierLength: 63
+
+Query filters:
+  ExportPresetEntity[MultiTenant]: e => (Not(value(Granit.DataExchange.EntityFrameworkCore.Internal.DataExchangeDbContext).IsMultiTenantFilterEnabled) OrElse (Property(e, "TenantId") == value(Granit.DataExchange.EntityFrameworkCore.Internal.DataExchangeDbContext).CurrentTenantId))
+  ExternalIdMappingEntity[MultiTenant]: e => (Not(value(Granit.DataExchange.EntityFrameworkCore.Internal.DataExchangeDbContext).IsMultiTenantFilterEnabled) OrElse (Property(e, "TenantId") == value(Granit.DataExchange.EntityFrameworkCore.Internal.DataExchangeDbContext).CurrentTenantId))
+  SavedMappingEntity[MultiTenant]: e => (Not(value(Granit.DataExchange.EntityFrameworkCore.Internal.DataExchangeDbContext).IsMultiTenantFilterEnabled) OrElse (Property(e, "TenantId") == value(Granit.DataExchange.EntityFrameworkCore.Internal.DataExchangeDbContext).CurrentTenantId))
+  ExportJob[MultiTenant]: e => (Not(value(Granit.DataExchange.EntityFrameworkCore.Internal.DataExchangeDbContext).IsMultiTenantFilterEnabled) OrElse (Property(e, "TenantId") == value(Granit.DataExchange.EntityFrameworkCore.Internal.DataExchangeDbContext).CurrentTenantId))
+  ImportJob[MultiTenant]: e => (Not(value(Granit.DataExchange.EntityFrameworkCore.Internal.DataExchangeDbContext).IsMultiTenantFilterEnabled) OrElse (Property(e, "TenantId") == value(Granit.DataExchange.EntityFrameworkCore.Internal.DataExchangeDbContext).CurrentTenantId))

--- a/tests/Granit.ArchitectureTests/ModelSnapshots/Granit.EntityMerge.EntityFrameworkCore.Internal.EntityMergeDbContext.snap
+++ b/tests/Granit.ArchitectureTests/ModelSnapshots/Granit.EntityMerge.EntityFrameworkCore.Internal.EntityMergeDbContext.snap
@@ -1,0 +1,52 @@
+Model: 
+  EntityType: MergeIdempotencyEntry
+    Properties: 
+      Id (Guid) Required PK AfterSave:Throw ValueGenerated.OnAdd
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      CreatedAt (DateTimeOffset) Required Index
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      Key (string) Required Index MaxLength(128)
+        Annotations: 
+          MaxLength: 128
+          Npgsql:ValueGenerationStrategy: None
+      LoserId (Guid) Required Index
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      RequestHash (string) Required Index MaxLength(64)
+        Annotations: 
+          MaxLength: 64
+          Npgsql:ValueGenerationStrategy: None
+      ResultJson (string) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      ResultMac (string) Required MaxLength(64)
+        Annotations: 
+          MaxLength: 64
+          Npgsql:ValueGenerationStrategy: None
+      SurvivorId (Guid) Required Index
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      TenantId (Guid?) Index
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+    Keys: 
+      Id PK
+    Indexes: 
+      CreatedAt
+      TenantId, Key, RequestHash Unique
+      TenantId, SurvivorId, LoserId
+    Annotations: 
+      Relational:FunctionName: 
+      Relational:Schema: 
+      Relational:SqlQuery: 
+      Relational:TableName: entity_merge_idempotency
+      Relational:ViewName: 
+      Relational:ViewSchema: 
+Annotations: 
+  Npgsql:ValueGenerationStrategy: IdentityByDefaultColumn
+  ProductVersion: 10.0.10
+  Relational:MaxIdentifierLength: 63
+
+Query filters:

--- a/tests/Granit.ArchitectureTests/ModelSnapshots/Granit.Features.EntityFrameworkCore.Internal.FeaturesDbContext.snap
+++ b/tests/Granit.ArchitectureTests/ModelSnapshots/Granit.Features.EntityFrameworkCore.Internal.FeaturesDbContext.snap
@@ -1,0 +1,52 @@
+Model: 
+  EntityType: TenantFeatureOverride
+    Properties: 
+      Id (Guid) Required PK AfterSave:Throw ValueGenerated.OnAdd
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      CreatedAt (DateTimeOffset) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      CreatedBy (string) Required MaxLength(450)
+        Annotations: 
+          MaxLength: 450
+          Npgsql:ValueGenerationStrategy: None
+      FeatureName (string) Required Index MaxLength(200)
+        Annotations: 
+          MaxLength: 200
+          Npgsql:ValueGenerationStrategy: None
+      ModifiedAt (DateTimeOffset?)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      ModifiedBy (string) MaxLength(450)
+        Annotations: 
+          MaxLength: 450
+          Npgsql:ValueGenerationStrategy: None
+      TenantId (Guid?) Index
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      Value (string) Required MaxLength(2000)
+        Annotations: 
+          MaxLength: 2000
+          Npgsql:ValueGenerationStrategy: None
+    Keys: 
+      Id PK
+    Indexes: 
+      TenantId, FeatureName Unique
+        Annotations: 
+          Relational:Name: uq_features_overrides_tenant_feature
+    Annotations: 
+      QueryFilter: Microsoft.EntityFrameworkCore.Metadata.Internal.QueryFilterCollection
+      Relational:FunctionName: 
+      Relational:Schema: 
+      Relational:SqlQuery: 
+      Relational:TableName: features_overrides
+      Relational:ViewName: 
+      Relational:ViewSchema: 
+Annotations: 
+  Npgsql:ValueGenerationStrategy: IdentityByDefaultColumn
+  ProductVersion: 10.0.10
+  Relational:MaxIdentifierLength: 63
+
+Query filters:
+  TenantFeatureOverride[MultiTenant]: e => (Not(value(Granit.Features.EntityFrameworkCore.Internal.FeaturesDbContext).IsMultiTenantFilterEnabled) OrElse (Property(e, "TenantId") == value(Granit.Features.EntityFrameworkCore.Internal.FeaturesDbContext).CurrentTenantId))

--- a/tests/Granit.ArchitectureTests/ModelSnapshots/Granit.Hostnames.EntityFrameworkCore.Internal.HostnamesDbContext.snap
+++ b/tests/Granit.ArchitectureTests/ModelSnapshots/Granit.Hostnames.EntityFrameworkCore.Internal.HostnamesDbContext.snap
@@ -1,0 +1,213 @@
+Model: 
+  EntityType: DnsConflict Owned
+    Properties: 
+      ManagedHostnameId (no field, Guid) Shadow Required PK FK AfterSave:Throw
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      __synthesizedOrdinal (no field, int) Shadow Required PK AfterSave:Throw ValueGenerated.OnAdd
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: IdentityByDefaultColumn
+      ConflictType (DnsConflictType) Required MaxLength(21)
+        Annotations: 
+          MaxLength: 21
+          Npgsql:ValueGenerationStrategy: None
+      Details (string) Required MaxLength(1024)
+        Annotations: 
+          MaxLength: 1024
+          Npgsql:ValueGenerationStrategy: None
+    Keys: 
+      ManagedHostnameId, __synthesizedOrdinal PK
+    Foreign keys: 
+      DnsConflict {'ManagedHostnameId'} -> ManagedHostname {'Id'} Required Ownership Cascade ToDependent: Conflicts
+    Annotations: 
+      Relational:ContainerColumnName: Conflicts
+      Relational:FunctionName: 
+      Relational:Schema: 
+      Relational:SqlQuery: 
+      Relational:TableName: hostnames_managed_hostnames
+      Relational:ViewName: 
+      Relational:ViewSchema: 
+  EntityType: ExpectedDnsRecord Owned
+    Properties: 
+      ManagedHostnameId (no field, Guid) Shadow Required PK FK AfterSave:Throw
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      __synthesizedOrdinal (no field, int) Shadow Required PK AfterSave:Throw ValueGenerated.OnAdd
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: IdentityByDefaultColumn
+      Name (string) Required MaxLength(253)
+        Annotations: 
+          MaxLength: 253
+          Npgsql:ValueGenerationStrategy: None
+      RecordType (DnsRecordType) Required MaxLength(20)
+        Annotations: 
+          MaxLength: 20
+          Npgsql:ValueGenerationStrategy: None
+      Value (string) Required MaxLength(512)
+        Annotations: 
+          MaxLength: 512
+          Npgsql:ValueGenerationStrategy: None
+    Keys: 
+      ManagedHostnameId, __synthesizedOrdinal PK
+    Foreign keys: 
+      ExpectedDnsRecord {'ManagedHostnameId'} -> ManagedHostname {'Id'} Required Ownership Cascade ToDependent: ExpectedDnsRecords
+    Annotations: 
+      Relational:ContainerColumnName: ExpectedDnsRecords
+      Relational:FunctionName: 
+      Relational:Schema: 
+      Relational:SqlQuery: 
+      Relational:TableName: hostnames_managed_hostnames
+      Relational:ViewName: 
+      Relational:ViewSchema: 
+  EntityType: ManagedHostname
+    Properties: 
+      Id (Guid) Required PK AfterSave:Throw ValueGenerated.OnAdd
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      CertExpiresAt (DateTimeOffset?)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      CertificateStatus (CertificateStatus) Required MaxLength(20)
+        Annotations: 
+          MaxLength: 20
+          Npgsql:ValueGenerationStrategy: None
+      ConcurrencyStamp (string) Required Concurrency MaxLength(36)
+        Annotations: 
+          MaxLength: 36
+          Npgsql:ValueGenerationStrategy: None
+      CreatedAt (DateTimeOffset) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      CreatedBy (string) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      FailedCheckCount (int) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      Host (Hostname) Required Index MaxLength(253)
+        Annotations: 
+          MaxLength: 253
+          Npgsql:ValueGenerationStrategy: None
+      IsPrimary (bool) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      LastCheckedAt (DateTimeOffset?)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      ModifiedAt (DateTimeOffset?)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      ModifiedBy (string)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      NextCheckAt (DateTimeOffset?) Index
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      OwnerId (Guid) Required Index
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      OwnerType (string) Required Index MaxLength(100)
+        Annotations: 
+          MaxLength: 100
+          Npgsql:ValueGenerationStrategy: None
+      Status (HostnameStatus) Required Index MaxLength(20)
+        Annotations: 
+          MaxLength: 20
+          Npgsql:ValueGenerationStrategy: None
+      TenantId (Guid?)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      VerificationToken (string) MaxLength(128)
+        Annotations: 
+          MaxLength: 128
+          Npgsql:ValueGenerationStrategy: None
+    Navigations: 
+      Conflicts (IReadOnlyList<DnsConflict>) Collection ToDependent DnsConflict
+        Annotations: 
+          EagerLoaded: True
+      ExpectedDnsRecords (IReadOnlyList<ExpectedDnsRecord>) Collection ToDependent ExpectedDnsRecord
+        Annotations: 
+          EagerLoaded: True
+    Keys: 
+      Id PK
+    Indexes: 
+      Host Unique
+        Annotations: 
+          Relational:Name: uq_hostnames_managed_hostnames_host
+      OwnerType, OwnerId
+        Annotations: 
+          Relational:Name: ix_hostnames_managed_hostnames_owner
+      Status, NextCheckAt
+        Annotations: 
+          Relational:Name: ix_hostnames_managed_hostnames_poll
+    Annotations: 
+      QueryFilter: Microsoft.EntityFrameworkCore.Metadata.Internal.QueryFilterCollection
+      Relational:FunctionName: 
+      Relational:Schema: 
+      Relational:SqlQuery: 
+      Relational:TableName: hostnames_managed_hostnames
+      Relational:ViewName: 
+      Relational:ViewSchema: 
+  EntityType: WorkflowTransitionRecord
+    Properties: 
+      Id (Guid) Required PK AfterSave:Throw ValueGenerated.OnAdd
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      Comment (string) MaxLength(2000)
+        Annotations: 
+          MaxLength: 2000
+          Npgsql:ValueGenerationStrategy: None
+      EntityId (string) Required Index MaxLength(200)
+        Annotations: 
+          MaxLength: 200
+          Npgsql:ValueGenerationStrategy: None
+      EntityType (string) Required Index MaxLength(200)
+        Annotations: 
+          MaxLength: 200
+          Npgsql:ValueGenerationStrategy: None
+      NewState (string) Required MaxLength(100)
+        Annotations: 
+          MaxLength: 100
+          Npgsql:ValueGenerationStrategy: None
+      PreviousState (string) Required MaxLength(100)
+        Annotations: 
+          MaxLength: 100
+          Npgsql:ValueGenerationStrategy: None
+      TenantId (Guid?) Index
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      TransitionedAt (DateTimeOffset) Required Index
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      TransitionedBy (string) Required Index MaxLength(450)
+        Annotations: 
+          MaxLength: 450
+          Npgsql:ValueGenerationStrategy: None
+    Keys: 
+      Id PK
+    Indexes: 
+      TenantId, TransitionedAt
+        Annotations: 
+          Relational:Name: ix_workflow_transition_records_tenantid_at
+      TransitionedBy, TransitionedAt
+        Annotations: 
+          Relational:Name: ix_workflow_transition_records_by_user_at
+      EntityType, EntityId, TransitionedAt
+        Annotations: 
+          Relational:Name: ix_workflow_transition_records_entity_type_id_at
+    Annotations: 
+      QueryFilter: Microsoft.EntityFrameworkCore.Metadata.Internal.QueryFilterCollection
+      Relational:FunctionName: 
+      Relational:Schema: 
+      Relational:SqlQuery: 
+      Relational:TableName: workflow_transition_records
+      Relational:ViewName: 
+      Relational:ViewSchema: 
+Annotations: 
+  Npgsql:ValueGenerationStrategy: IdentityByDefaultColumn
+  ProductVersion: 10.0.10
+  Relational:MaxIdentifierLength: 63
+
+Query filters:
+  ManagedHostname[MultiTenant]: e => (Not(value(Granit.Hostnames.EntityFrameworkCore.Internal.HostnamesDbContext).IsMultiTenantFilterEnabled) OrElse (Property(e, "TenantId") == value(Granit.Hostnames.EntityFrameworkCore.Internal.HostnamesDbContext).CurrentTenantId))
+  WorkflowTransitionRecord[MultiTenant]: e => (Not(value(Granit.Hostnames.EntityFrameworkCore.Internal.HostnamesDbContext).IsMultiTenantFilterEnabled) OrElse (Property(e, "TenantId") == value(Granit.Hostnames.EntityFrameworkCore.Internal.HostnamesDbContext).CurrentTenantId))

--- a/tests/Granit.ArchitectureTests/ModelSnapshots/Granit.Http.Cookies.EntityFrameworkCore.Internal.CookiesDbContext.snap
+++ b/tests/Granit.ArchitectureTests/ModelSnapshots/Granit.Http.Cookies.EntityFrameworkCore.Internal.CookiesDbContext.snap
@@ -1,0 +1,70 @@
+Model: 
+  EntityType: CookieConsentRecord
+    Properties: 
+      Id (Guid) Required PK AfterSave:Throw ValueGenerated.OnAdd
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      AnonymizedIp (string) MaxLength(45)
+        Annotations: 
+          MaxLength: 45
+          Npgsql:ValueGenerationStrategy: None
+      CmpSource (string) Required MaxLength(64)
+        Annotations: 
+          MaxLength: 64
+          Npgsql:ValueGenerationStrategy: None
+      CorrelationId (string) MaxLength(256)
+        Annotations: 
+          MaxLength: 256
+          Npgsql:ValueGenerationStrategy: None
+      CreatedAt (DateTimeOffset) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      CreatedBy (string) Required Index
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      DecidedAt (DateTimeOffset) Required Index
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      DeniedCategories (IReadOnlyList<string>) Required MaxLength(512)
+        Annotations: 
+          MaxLength: 512
+          Npgsql:ValueGenerationStrategy: None
+      GrantedCategories (IReadOnlyList<string>) Required MaxLength(512)
+        Annotations: 
+          MaxLength: 512
+          Npgsql:ValueGenerationStrategy: None
+      Mode (CookieConsentMode) Required MaxLength(20)
+        Annotations: 
+          MaxLength: 20
+          Npgsql:ValueGenerationStrategy: None
+      TenantId (Guid?) Index
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      UserAgent (string) MaxLength(256)
+        Annotations: 
+          MaxLength: 256
+          Npgsql:ValueGenerationStrategy: None
+    Keys: 
+      Id PK
+    Indexes: 
+      CreatedBy
+        Annotations: 
+          Relational:Name: ix_cookie_consent_records_created_by
+      TenantId, DecidedAt
+        Annotations: 
+          Relational:Name: ix_cookie_consent_records_tenant_decided_at
+    Annotations: 
+      QueryFilter: Microsoft.EntityFrameworkCore.Metadata.Internal.QueryFilterCollection
+      Relational:FunctionName: 
+      Relational:Schema: 
+      Relational:SqlQuery: 
+      Relational:TableName: cookie_consent_records
+      Relational:ViewName: 
+      Relational:ViewSchema: 
+Annotations: 
+  Npgsql:ValueGenerationStrategy: IdentityByDefaultColumn
+  ProductVersion: 10.0.10
+  Relational:MaxIdentifierLength: 63
+
+Query filters:
+  CookieConsentRecord[MultiTenant]: e => (Not(value(Granit.Http.Cookies.EntityFrameworkCore.Internal.CookiesDbContext).IsMultiTenantFilterEnabled) OrElse (Property(e, "TenantId") == value(Granit.Http.Cookies.EntityFrameworkCore.Internal.CookiesDbContext).CurrentTenantId))

--- a/tests/Granit.ArchitectureTests/ModelSnapshots/Granit.Identity.EntityFrameworkCore.Internal.IdentityDbContext.snap
+++ b/tests/Granit.ArchitectureTests/ModelSnapshots/Granit.Identity.EntityFrameworkCore.Internal.IdentityDbContext.snap
@@ -1,0 +1,224 @@
+Model: 
+  EntityType: User
+    Properties: 
+      Id (Guid) Required PK AfterSave:Throw ValueGenerated.OnAdd
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      CreatedAt (DateTimeOffset) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      CreatedBy (string) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      DisplayName (string) Required MaxLength(256)
+        Annotations: 
+          MaxLength: 256
+          Npgsql:ValueGenerationStrategy: None
+      Email (string) Required MaxLength(4096)
+        Annotations: 
+          MaxLength: 4096
+          Npgsql:ValueGenerationStrategy: None
+      EmailHash (string) Index MaxLength(64)
+        Annotations: 
+          MaxLength: 64
+          Npgsql:ValueGenerationStrategy: None
+      FirstName (string) MaxLength(128)
+        Annotations: 
+          MaxLength: 128
+          Npgsql:ValueGenerationStrategy: None
+      IsEnabled (bool) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      LastName (string) MaxLength(128)
+        Annotations: 
+          MaxLength: 128
+          Npgsql:ValueGenerationStrategy: None
+      ModifiedAt (DateTimeOffset?)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      ModifiedBy (string)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      PhoneNumber (string) MaxLength(4096)
+        Annotations: 
+          MaxLength: 4096
+          Npgsql:ValueGenerationStrategy: None
+      PhoneNumberHash (string) MaxLength(64)
+        Annotations: 
+          MaxLength: 64
+          Npgsql:ValueGenerationStrategy: None
+      PreferredLocale (string) MaxLength(20)
+        Annotations: 
+          MaxLength: 20
+          Npgsql:ValueGenerationStrategy: None
+      TenantId (Guid?) Index
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      Timezone (string) MaxLength(64)
+        Annotations: 
+          MaxLength: 64
+          Npgsql:ValueGenerationStrategy: None
+    Keys: 
+      Id PK
+    Indexes: 
+      EmailHash
+        Annotations: 
+          Relational:Name: ix_identity_users_email_hash
+      TenantId
+        Annotations: 
+          Relational:Name: ix_identity_users_tenant_id
+    Annotations: 
+      QueryFilter: Microsoft.EntityFrameworkCore.Metadata.Internal.QueryFilterCollection
+      Relational:FunctionName: 
+      Relational:Schema: 
+      Relational:SqlQuery: 
+      Relational:TableName: identity_users
+      Relational:ViewName: 
+      Relational:ViewSchema: 
+  EntityType: DeviceTrustEntity
+    Properties: 
+      Id (Guid) Required PK AfterSave:Throw
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      DeviceId (string) Required Index MaxLength(128)
+        Annotations: 
+          MaxLength: 128
+          Npgsql:ValueGenerationStrategy: None
+      Level (DeviceTrustLevel) Required MaxLength(16)
+        Annotations: 
+          MaxLength: 16
+          Npgsql:ValueGenerationStrategy: None
+      Reason (string) MaxLength(64)
+        Annotations: 
+          MaxLength: 64
+          Npgsql:ValueGenerationStrategy: None
+      TrustedAt (DateTimeOffset) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      TrustedUntil (DateTimeOffset?)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      UserId (string) Required Index MaxLength(128)
+        Annotations: 
+          MaxLength: 128
+          Npgsql:ValueGenerationStrategy: None
+    Keys: 
+      Id PK
+    Indexes: 
+      UserId, DeviceId Unique
+    Annotations: 
+      Relational:FunctionName: 
+      Relational:Schema: 
+      Relational:SqlQuery: 
+      Relational:TableName: identity_device_trusts
+      Relational:ViewName: 
+      Relational:ViewSchema: 
+  EntityType: UserBehavioralProfileEntity
+    Properties: 
+      Id (Guid) Required PK AfterSave:Throw
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      Count (int) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      FirstSeenAt (DateTimeOffset) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      Kind (BehavioralObservationKind) Required Index MaxLength(32)
+        Annotations: 
+          MaxLength: 32
+          Npgsql:ValueGenerationStrategy: None
+      LastSeenAt (DateTimeOffset) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      UserId (string) Required Index MaxLength(128)
+        Annotations: 
+          MaxLength: 128
+          Npgsql:ValueGenerationStrategy: None
+      Value (string) Required Index MaxLength(128)
+        Annotations: 
+          MaxLength: 128
+          Npgsql:ValueGenerationStrategy: None
+    Keys: 
+      Id PK
+    Indexes: 
+      UserId, Kind, Value Unique
+    Annotations: 
+      Relational:FunctionName: 
+      Relational:Schema: 
+      Relational:SqlQuery: 
+      Relational:TableName: identity_user_behavioral_profiles
+      Relational:ViewName: 
+      Relational:ViewSchema: 
+  EntityType: UserSessionReviewEntity
+    Properties: 
+      Id (Guid) Required PK AfterSave:Throw
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      Decision (UserSessionReviewDecision) Required MaxLength(16)
+        Annotations: 
+          MaxLength: 16
+          Npgsql:ValueGenerationStrategy: None
+      ReviewedAt (DateTimeOffset) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      SessionId (string) Required Index MaxLength(128)
+        Annotations: 
+          MaxLength: 128
+          Npgsql:ValueGenerationStrategy: None
+      UserId (string) Required Index MaxLength(128)
+        Annotations: 
+          MaxLength: 128
+          Npgsql:ValueGenerationStrategy: None
+    Keys: 
+      Id PK
+    Indexes: 
+      UserId, SessionId Unique
+    Annotations: 
+      Relational:FunctionName: 
+      Relational:Schema: 
+      Relational:SqlQuery: 
+      Relational:TableName: identity_user_session_reviews
+      Relational:ViewName: 
+      Relational:ViewSchema: 
+  EntityType: UserSessionRiskEntity
+    Properties: 
+      Id (Guid) Required PK AfterSave:Throw
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      AssessedAt (DateTimeOffset) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      Level (UserSessionRiskLevel) Required MaxLength(16)
+        Annotations: 
+          MaxLength: 16
+          Npgsql:ValueGenerationStrategy: None
+      ReasonsJson (string) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      SessionId (string) Required Index MaxLength(128)
+        Annotations: 
+          MaxLength: 128
+          Npgsql:ValueGenerationStrategy: None
+      UserId (string) Required Index MaxLength(128)
+        Annotations: 
+          MaxLength: 128
+          Npgsql:ValueGenerationStrategy: None
+    Keys: 
+      Id PK
+    Indexes: 
+      UserId, SessionId Unique
+    Annotations: 
+      Relational:FunctionName: 
+      Relational:Schema: 
+      Relational:SqlQuery: 
+      Relational:TableName: identity_user_session_risks
+      Relational:ViewName: 
+      Relational:ViewSchema: 
+Annotations: 
+  Npgsql:ValueGenerationStrategy: IdentityByDefaultColumn
+  ProductVersion: 10.0.10
+  Relational:MaxIdentifierLength: 63
+
+Query filters:
+  User[MultiTenant]: e => (Not(value(Granit.Identity.EntityFrameworkCore.Internal.IdentityDbContext).IsMultiTenantFilterEnabled) OrElse (Property(e, "TenantId") == value(Granit.Identity.EntityFrameworkCore.Internal.IdentityDbContext).CurrentTenantId))

--- a/tests/Granit.ArchitectureTests/ModelSnapshots/Granit.Identity.Federated.EntityFrameworkCore.Internal.IdentityFederatedDbContext.snap
+++ b/tests/Granit.ArchitectureTests/ModelSnapshots/Granit.Identity.Federated.EntityFrameworkCore.Internal.IdentityFederatedDbContext.snap
@@ -1,0 +1,81 @@
+Model: 
+  EntityType: FederatedIdentity
+    Properties: 
+      Id (Guid) Required PK AfterSave:Throw ValueGenerated.OnAdd
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      CreatedAt (DateTimeOffset) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      CreatedBy (string) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      Email (string) MaxLength(2048)
+        Annotations: 
+          MaxLength: 2048
+          Npgsql:ValueGenerationStrategy: None
+      EmailHash (string) Index MaxLength(64)
+        Annotations: 
+          MaxLength: 64
+          Npgsql:ValueGenerationStrategy: None
+      Enabled (bool) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      ExternalUserId (string) Required Index MaxLength(256)
+        Annotations: 
+          MaxLength: 256
+          Npgsql:ValueGenerationStrategy: None
+      FirstName (string) MaxLength(2048)
+        Annotations: 
+          MaxLength: 2048
+          Npgsql:ValueGenerationStrategy: None
+      LastName (string) MaxLength(2048)
+        Annotations: 
+          MaxLength: 2048
+          Npgsql:ValueGenerationStrategy: None
+      LastSyncedAt (DateTimeOffset) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      MetadataJson (string)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      ModifiedAt (DateTimeOffset?)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      ModifiedBy (string)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      TenantId (Guid?) Index
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      UserId (Guid) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      Username (string) MaxLength(2048)
+        Annotations: 
+          MaxLength: 2048
+          Npgsql:ValueGenerationStrategy: None
+    Keys: 
+      Id PK
+    Indexes: 
+      TenantId, EmailHash
+        Annotations: 
+          Relational:Name: ix_identity_federated_user_cache_tenant_email_hash
+      TenantId, ExternalUserId Unique
+        Annotations: 
+          Relational:Name: uq_identity_federated_user_cache_tenant_external_id
+    Annotations: 
+      QueryFilter: Microsoft.EntityFrameworkCore.Metadata.Internal.QueryFilterCollection
+      Relational:FunctionName: 
+      Relational:Schema: 
+      Relational:SqlQuery: 
+      Relational:TableName: identity_federated_user_cache_entries
+      Relational:ViewName: 
+      Relational:ViewSchema: 
+Annotations: 
+  Npgsql:ValueGenerationStrategy: IdentityByDefaultColumn
+  ProductVersion: 10.0.10
+  Relational:MaxIdentifierLength: 63
+
+Query filters:
+  FederatedIdentity[MultiTenant]: e => (Not(value(Granit.Identity.Federated.EntityFrameworkCore.Internal.IdentityFederatedDbContext).IsMultiTenantFilterEnabled) OrElse (Property(e, "TenantId") == value(Granit.Identity.Federated.EntityFrameworkCore.Internal.IdentityFederatedDbContext).CurrentTenantId))

--- a/tests/Granit.ArchitectureTests/ModelSnapshots/Granit.Identity.Local.EntityFrameworkCore.Internal.IdentityLocalDbContext.snap
+++ b/tests/Granit.ArchitectureTests/ModelSnapshots/Granit.Identity.Local.EntityFrameworkCore.Internal.IdentityLocalDbContext.snap
@@ -1,0 +1,452 @@
+Model: 
+  EntityType: GranitRole
+    Properties: 
+      Id (Guid) Required PK AfterSave:Throw ValueGenerated.OnAdd
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      ConcurrencyStamp (string) Concurrency
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      Description (string) MaxLength(512)
+        Annotations: 
+          MaxLength: 512
+          Npgsql:ValueGenerationStrategy: None
+      Name (string) MaxLength(256)
+        Annotations: 
+          MaxLength: 256
+          Npgsql:ValueGenerationStrategy: None
+      NormalizedName (string) Index MaxLength(256)
+        Annotations: 
+          MaxLength: 256
+          Npgsql:ValueGenerationStrategy: None
+    Keys: 
+      Id PK
+    Indexes: 
+      NormalizedName Unique
+        Annotations: 
+          Relational:Name: RoleNameIndex
+    Annotations: 
+      Relational:FunctionName: 
+      Relational:Schema: 
+      Relational:SqlQuery: 
+      Relational:TableName: openiddict_roles
+      Relational:ViewName: 
+      Relational:ViewSchema: 
+  EntityType: GranitUserGroup
+    Properties: 
+      Id (Guid) Required PK AfterSave:Throw ValueGenerated.OnAdd
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      CreatedAt (DateTimeOffset) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      CreatedBy (string) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      Description (string) MaxLength(512)
+        Annotations: 
+          MaxLength: 512
+          Npgsql:ValueGenerationStrategy: None
+      ModifiedAt (DateTimeOffset?)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      ModifiedBy (string)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      Name (string) Required Index MaxLength(256)
+        Annotations: 
+          MaxLength: 256
+          Npgsql:ValueGenerationStrategy: None
+      TenantId (Guid?) Index
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+    Keys: 
+      Id PK
+    Indexes: 
+      TenantId, Name Unique
+        Annotations: 
+          Relational:Name: uq_openiddict_user_groups_tenant_name
+    Annotations: 
+      QueryFilter: Microsoft.EntityFrameworkCore.Metadata.Internal.QueryFilterCollection
+      Relational:FunctionName: 
+      Relational:Schema: 
+      Relational:SqlQuery: 
+      Relational:TableName: openiddict_user_groups
+      Relational:ViewName: 
+      Relational:ViewSchema: 
+  EntityType: GranitUserGroupMember
+    Properties: 
+      Id (Guid) Required PK AfterSave:Throw ValueGenerated.OnAdd
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      CreatedAt (DateTimeOffset) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      CreatedBy (string) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      GroupId (Guid) Required Index
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      ModifiedAt (DateTimeOffset?)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      ModifiedBy (string)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      TenantId (Guid?)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      UserId (Guid) Required Index
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+    Keys: 
+      Id PK
+    Indexes: 
+      UserId
+        Annotations: 
+          Relational:Name: ix_openiddict_user_group_members_user_id
+      GroupId, UserId Unique
+        Annotations: 
+          Relational:Name: uq_openiddict_user_group_members_group_user
+    Annotations: 
+      QueryFilter: Microsoft.EntityFrameworkCore.Metadata.Internal.QueryFilterCollection
+      Relational:FunctionName: 
+      Relational:Schema: 
+      Relational:SqlQuery: 
+      Relational:TableName: openiddict_user_group_members
+      Relational:ViewName: 
+      Relational:ViewSchema: 
+  EntityType: LocalIdentity
+    Properties: 
+      Id (Guid) Required PK AfterSave:Throw ValueGenerated.OnAdd
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      AccessFailedCount (int) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      ConcurrencyStamp (string) Concurrency
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      ConsecutiveLockouts (int) Required ValueGenerated.OnAdd
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+          Relational:DefaultValue: 0
+      CreatedAt (DateTimeOffset) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      CreatedBy (string) Required MaxLength(256)
+        Annotations: 
+          MaxLength: 256
+          Npgsql:ValueGenerationStrategy: None
+      CustomAttributesJson (string)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      DeletedAt (DateTimeOffset?)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      DeletedBy (string) MaxLength(256)
+        Annotations: 
+          MaxLength: 256
+          Npgsql:ValueGenerationStrategy: None
+      DeletionEventDispatchedAt (DateTimeOffset?)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      Email (string) MaxLength(256)
+        Annotations: 
+          MaxLength: 256
+          Npgsql:ValueGenerationStrategy: None
+      EmailConfirmed (bool) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      FirstName (string) MaxLength(256)
+        Annotations: 
+          MaxLength: 256
+          Npgsql:ValueGenerationStrategy: None
+      IsDeleted (bool) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      LastName (string) MaxLength(256)
+        Annotations: 
+          MaxLength: 256
+          Npgsql:ValueGenerationStrategy: None
+      LockoutEnabled (bool) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      LockoutEnd (DateTimeOffset?)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      ModifiedAt (DateTimeOffset?)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      ModifiedBy (string) MaxLength(256)
+        Annotations: 
+          MaxLength: 256
+          Npgsql:ValueGenerationStrategy: None
+      NormalizedEmail (string) Index MaxLength(256)
+        Annotations: 
+          MaxLength: 256
+          Npgsql:ValueGenerationStrategy: None
+      NormalizedUserName (string) Index MaxLength(256)
+        Annotations: 
+          MaxLength: 256
+          Npgsql:ValueGenerationStrategy: None
+      PasswordHash (string)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      PhoneNumber (string)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      PhoneNumberConfirmed (bool) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      RegistrationEventPendingSince (DateTimeOffset?)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      SecurityStamp (string)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      TenantId (Guid?) Index
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      TwoFactorEnabled (bool) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      UserId (Guid) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      UserName (string) MaxLength(256)
+        Annotations: 
+          MaxLength: 256
+          Npgsql:ValueGenerationStrategy: None
+    Keys: 
+      Id PK
+    Indexes: 
+      NormalizedEmail
+        Annotations: 
+          Relational:Name: EmailIndex
+      NormalizedUserName Unique
+        Annotations: 
+          Relational:Name: UserNameIndex
+      TenantId
+        Annotations: 
+          Relational:Name: ix_openiddict_users_tenant_id
+    Annotations: 
+      QueryFilter: Microsoft.EntityFrameworkCore.Metadata.Internal.QueryFilterCollection
+      Relational:FunctionName: 
+      Relational:Schema: 
+      Relational:SqlQuery: 
+      Relational:TableName: openiddict_users
+      Relational:ViewName: 
+      Relational:ViewSchema: 
+  EntityType: IdentityPasskeyData Owned
+    Properties: 
+      IdentityUserPasskeyCredentialId (no field, byte[]) Shadow Required PK FK AfterSave:Throw
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      AttestationObject (byte[]) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      ClientDataJson (byte[]) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      CreatedAt (DateTimeOffset) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      IsBackedUp (bool) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      IsBackupEligible (bool) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      IsUserVerified (bool) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      Name (string)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      PublicKey (byte[]) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      SignCount (uint) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      Transports (string[]) Element type: string Required
+        Annotations: 
+          ElementType: Element type: string Required
+          Npgsql:ValueGenerationStrategy: None
+    Keys: 
+      IdentityUserPasskeyCredentialId PK
+    Foreign keys: 
+      IdentityPasskeyData {'IdentityUserPasskeyCredentialId'} -> IdentityUserPasskey<Guid> {'CredentialId'} Unique Required RequiredDependent Ownership Cascade ToDependent: Data
+    Annotations: 
+      Relational:ContainerColumnName: Data
+      Relational:FunctionName: 
+      Relational:Schema: 
+      Relational:SqlQuery: 
+      Relational:TableName: openiddict_user_passkeys
+      Relational:ViewName: 
+      Relational:ViewSchema: 
+  EntityType: IdentityRoleClaim<Guid>
+    Properties: 
+      Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: IdentityByDefaultColumn
+      ClaimType (string)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      ClaimValue (string)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      RoleId (Guid) Required FK Index
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+    Keys: 
+      Id PK
+    Foreign keys: 
+      IdentityRoleClaim<Guid> {'RoleId'} -> GranitRole {'Id'} Required Cascade
+    Indexes: 
+      RoleId
+    Annotations: 
+      Relational:FunctionName: 
+      Relational:Schema: 
+      Relational:SqlQuery: 
+      Relational:TableName: openiddict_role_claims
+      Relational:ViewName: 
+      Relational:ViewSchema: 
+  EntityType: IdentityUserClaim<Guid>
+    Properties: 
+      Id (int) Required PK AfterSave:Throw ValueGenerated.OnAdd
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: IdentityByDefaultColumn
+      ClaimType (string)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      ClaimValue (string)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      UserId (Guid) Required FK Index
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+    Keys: 
+      Id PK
+    Foreign keys: 
+      IdentityUserClaim<Guid> {'UserId'} -> LocalIdentity {'Id'} Required Cascade
+    Indexes: 
+      UserId
+    Annotations: 
+      Relational:FunctionName: 
+      Relational:Schema: 
+      Relational:SqlQuery: 
+      Relational:TableName: openiddict_user_claims
+      Relational:ViewName: 
+      Relational:ViewSchema: 
+  EntityType: IdentityUserLogin<Guid>
+    Properties: 
+      LoginProvider (string) Required PK AfterSave:Throw
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      ProviderKey (string) Required PK AfterSave:Throw
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      ProviderDisplayName (string)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      UserId (Guid) Required FK Index
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+    Keys: 
+      LoginProvider, ProviderKey PK
+    Foreign keys: 
+      IdentityUserLogin<Guid> {'UserId'} -> LocalIdentity {'Id'} Required Cascade
+    Indexes: 
+      UserId
+    Annotations: 
+      Relational:FunctionName: 
+      Relational:Schema: 
+      Relational:SqlQuery: 
+      Relational:TableName: openiddict_user_logins
+      Relational:ViewName: 
+      Relational:ViewSchema: 
+  EntityType: IdentityUserPasskey<Guid>
+    Properties: 
+      CredentialId (byte[]) Required PK AfterSave:Throw
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      UserId (Guid) Required FK Index
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+    Navigations: 
+      Data (IdentityPasskeyData) Required ToDependent IdentityPasskeyData
+        Annotations: 
+          EagerLoaded: True
+    Keys: 
+      CredentialId PK
+    Foreign keys: 
+      IdentityUserPasskey<Guid> {'UserId'} -> LocalIdentity {'Id'} Required Cascade
+    Indexes: 
+      UserId
+    Annotations: 
+      Relational:FunctionName: 
+      Relational:Schema: 
+      Relational:SqlQuery: 
+      Relational:TableName: openiddict_user_passkeys
+      Relational:ViewName: 
+      Relational:ViewSchema: 
+  EntityType: IdentityUserRole<Guid>
+    Properties: 
+      UserId (Guid) Required PK FK AfterSave:Throw
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      RoleId (Guid) Required PK FK Index AfterSave:Throw
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+    Keys: 
+      UserId, RoleId PK
+    Foreign keys: 
+      IdentityUserRole<Guid> {'RoleId'} -> GranitRole {'Id'} Required Cascade
+      IdentityUserRole<Guid> {'UserId'} -> LocalIdentity {'Id'} Required Cascade
+    Indexes: 
+      RoleId
+    Annotations: 
+      Relational:FunctionName: 
+      Relational:Schema: 
+      Relational:SqlQuery: 
+      Relational:TableName: openiddict_user_roles
+      Relational:ViewName: 
+      Relational:ViewSchema: 
+  EntityType: IdentityUserToken<Guid>
+    Properties: 
+      UserId (Guid) Required PK FK AfterSave:Throw
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      LoginProvider (string) Required PK AfterSave:Throw
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      Name (string) Required PK AfterSave:Throw
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      Value (string)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+    Keys: 
+      UserId, LoginProvider, Name PK
+    Foreign keys: 
+      IdentityUserToken<Guid> {'UserId'} -> LocalIdentity {'Id'} Required Cascade
+    Annotations: 
+      Relational:FunctionName: 
+      Relational:Schema: 
+      Relational:SqlQuery: 
+      Relational:TableName: openiddict_user_tokens
+      Relational:ViewName: 
+      Relational:ViewSchema: 
+Annotations: 
+  Npgsql:ValueGenerationStrategy: IdentityByDefaultColumn
+  ProductVersion: 10.0.10
+  Relational:MaxIdentifierLength: 63
+
+Query filters:
+  GranitUserGroup[MultiTenant]: e => ((Not(value(Granit.Identity.Local.EntityFrameworkCore.Internal.IdentityLocalDbContext).IsMultiTenantFilterEnabled) OrElse (Property(e, "TenantId") == null)) OrElse (Property(e, "TenantId") == value(Granit.Identity.Local.EntityFrameworkCore.Internal.IdentityLocalDbContext).CurrentTenantId))
+  GranitUserGroupMember[MultiTenant]: e => ((Not(value(Granit.Identity.Local.EntityFrameworkCore.Internal.IdentityLocalDbContext).IsMultiTenantFilterEnabled) OrElse (Property(e, "TenantId") == null)) OrElse (Property(e, "TenantId") == value(Granit.Identity.Local.EntityFrameworkCore.Internal.IdentityLocalDbContext).CurrentTenantId))
+  LocalIdentity[MultiTenant]: e => ((Not(value(Granit.Identity.Local.EntityFrameworkCore.Internal.IdentityLocalDbContext).IsMultiTenantFilterEnabled) OrElse (Property(e, "TenantId") == null)) OrElse (Property(e, "TenantId") == value(Granit.Identity.Local.EntityFrameworkCore.Internal.IdentityLocalDbContext).CurrentTenantId))
+  LocalIdentity[SoftDelete]: u => (Not(value(Granit.Identity.Local.EntityFrameworkCore.Extensions.IdentityLocalModelBuilderExtensions+SoftDeleteProxy).SoftDeleteEnabled) OrElse Not(u.IsDeleted))

--- a/tests/Granit.ArchitectureTests/ModelSnapshots/Granit.Indexing.EntityFrameworkCore.IndexingDbContext.snap
+++ b/tests/Granit.ArchitectureTests/ModelSnapshots/Granit.Indexing.EntityFrameworkCore.IndexingDbContext.snap
@@ -1,0 +1,92 @@
+Model: 
+  EntityType: IndexedEntryRow<Guid>
+    Properties: 
+      TenantId (Guid?) Required PK Index AfterSave:Throw
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      Key (Guid) Required PK AfterSave:Throw
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      CharCount (int) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      Content (string) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      DataSubjectId (Guid?) Index
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      IsTruncated (bool) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      Language (string) MaxLength(16)
+        Annotations: 
+          MaxLength: 16
+          Npgsql:ValueGenerationStrategy: None
+      SearchVector (NpgsqlTsVector) Required Index BeforeSave:Ignore AfterSave:Ignore ValueGenerated.OnAddOrUpdate
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+          Relational:ColumnType: tsvector
+          Relational:ComputedColumnSql: to_tsvector('english'::regconfig, coalesce("Content", ''))
+          Relational:IsStored: True
+      Summary (string)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      Tags (string[]) Element type: string Required
+        Annotations: 
+          ElementType: Element type: string Required
+          Npgsql:ValueGenerationStrategy: None
+    Keys: 
+      TenantId, Key PK
+    Indexes: 
+      SearchVector
+        Annotations: 
+          Npgsql:IndexMethod: GIN
+          Relational:Name: ix_indexing_indexed_entry_guid_search_vector_gin
+      TenantId, DataSubjectId
+        Annotations: 
+          Relational:Name: ix_indexing_indexed_entry_guid_data_subject
+    Annotations: 
+      QueryFilter: Microsoft.EntityFrameworkCore.Metadata.Internal.QueryFilterCollection
+      Relational:FunctionName: 
+      Relational:Schema: 
+      Relational:SqlQuery: 
+      Relational:TableName: indexing_indexed_entry_guid
+      Relational:ViewName: 
+      Relational:ViewSchema: 
+  EntityType: IndexingRebuildCheckpointRow
+    Properties: 
+      TenantId (Guid?) Required PK AfterSave:Throw
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      SourceName (string) Required PK AfterSave:Throw MaxLength(128)
+        Annotations: 
+          MaxLength: 128
+          Npgsql:ValueGenerationStrategy: None
+      ConcurrencyStamp (string) Required Concurrency MaxLength(36)
+        Annotations: 
+          MaxLength: 36
+          Npgsql:ValueGenerationStrategy: None
+      LastProcessedKey (string) Required MaxLength(256)
+        Annotations: 
+          MaxLength: 256
+          Npgsql:ValueGenerationStrategy: None
+      UpdatedAt (DateTimeOffset) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+    Keys: 
+      TenantId, SourceName PK
+    Annotations: 
+      Relational:FunctionName: 
+      Relational:Schema: 
+      Relational:SqlQuery: 
+      Relational:TableName: indexing_rebuild_checkpoint
+      Relational:ViewName: 
+      Relational:ViewSchema: 
+Annotations: 
+  Npgsql:ValueGenerationStrategy: IdentityByDefaultColumn
+  ProductVersion: 10.0.10
+  Relational:MaxIdentifierLength: 63
+
+Query filters:
+  IndexedEntryRow[MultiTenant]: e => (Not(value(Granit.Indexing.EntityFrameworkCore.IndexingDbContext).IsMultiTenantFilterEnabled) OrElse (Property(e, "TenantId") == value(Granit.Indexing.EntityFrameworkCore.IndexingDbContext).CurrentTenantId))

--- a/tests/Granit.ArchitectureTests/ModelSnapshots/Granit.Localization.EntityFrameworkCore.Internal.LocalizationDbContext.snap
+++ b/tests/Granit.ArchitectureTests/ModelSnapshots/Granit.Localization.EntityFrameworkCore.Internal.LocalizationDbContext.snap
@@ -1,0 +1,63 @@
+Model: 
+  EntityType: LocalizationOverride
+    Properties: 
+      Id (Guid) Required PK AfterSave:Throw ValueGenerated.OnAdd
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      CreatedAt (DateTimeOffset) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      CreatedBy (string) Required MaxLength(450)
+        Annotations: 
+          MaxLength: 450
+          Npgsql:ValueGenerationStrategy: None
+      CultureName (string) Required Index MaxLength(20)
+        Annotations: 
+          MaxLength: 20
+          Npgsql:ValueGenerationStrategy: None
+      Key (string) Required Index MaxLength(500)
+        Annotations: 
+          MaxLength: 500
+          Npgsql:ValueGenerationStrategy: None
+      ModifiedAt (DateTimeOffset?)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      ModifiedBy (string) MaxLength(450)
+        Annotations: 
+          MaxLength: 450
+          Npgsql:ValueGenerationStrategy: None
+      ResourceName (string) Required Index MaxLength(200)
+        Annotations: 
+          MaxLength: 200
+          Npgsql:ValueGenerationStrategy: None
+      TenantId (Guid?) Index
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      Value (string) Required MaxLength(4000)
+        Annotations: 
+          MaxLength: 4000
+          Npgsql:ValueGenerationStrategy: None
+    Keys: 
+      Id PK
+    Indexes: 
+      TenantId, ResourceName, CultureName
+        Annotations: 
+          Relational:Name: ix_localization_overrides_tenant_resource_culture
+      TenantId, ResourceName, CultureName, Key Unique
+        Annotations: 
+          Relational:Name: uq_localization_overrides_tenant_resource_culture_key
+    Annotations: 
+      QueryFilter: Microsoft.EntityFrameworkCore.Metadata.Internal.QueryFilterCollection
+      Relational:FunctionName: 
+      Relational:Schema: 
+      Relational:SqlQuery: 
+      Relational:TableName: localization_overrides
+      Relational:ViewName: 
+      Relational:ViewSchema: 
+Annotations: 
+  Npgsql:ValueGenerationStrategy: IdentityByDefaultColumn
+  ProductVersion: 10.0.10
+  Relational:MaxIdentifierLength: 63
+
+Query filters:
+  LocalizationOverride[MultiTenant]: e => (Not(value(Granit.Localization.EntityFrameworkCore.Internal.LocalizationDbContext).IsMultiTenantFilterEnabled) OrElse (Property(e, "TenantId") == value(Granit.Localization.EntityFrameworkCore.Internal.LocalizationDbContext).CurrentTenantId))

--- a/tests/Granit.ArchitectureTests/ModelSnapshots/Granit.MultiTenancy.EntityFrameworkCore.Internal.MultiTenancyDbContext.snap
+++ b/tests/Granit.ArchitectureTests/ModelSnapshots/Granit.MultiTenancy.EntityFrameworkCore.Internal.MultiTenancyDbContext.snap
@@ -1,0 +1,82 @@
+Model: 
+  EntityType: Tenant
+    Properties: 
+      Id (Guid) Required PK AfterSave:Throw ValueGenerated.OnAdd
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      Activated (bool) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      ConcurrencyStamp (string) Required Concurrency MaxLength(36)
+        Annotations: 
+          MaxLength: 36
+          Npgsql:ValueGenerationStrategy: None
+      ContactEmail (string) MaxLength(256)
+        Annotations: 
+          MaxLength: 256
+          Npgsql:ValueGenerationStrategy: None
+      CreatedAt (DateTimeOffset) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      CreatedBy (string) Required MaxLength(450)
+        Annotations: 
+          MaxLength: 450
+          Npgsql:ValueGenerationStrategy: None
+      CustomDomain (string) Index MaxLength(253)
+        Annotations: 
+          MaxLength: 253
+          Npgsql:ValueGenerationStrategy: None
+      DeletedAt (DateTimeOffset?)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      DeletedBy (string) MaxLength(450)
+        Annotations: 
+          MaxLength: 450
+          Npgsql:ValueGenerationStrategy: None
+      Identifier (string) Required Index MaxLength(64)
+        Annotations: 
+          MaxLength: 64
+          Npgsql:ValueGenerationStrategy: None
+      IsDeleted (bool) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      Jurisdiction (string) MaxLength(16)
+        Annotations: 
+          MaxLength: 16
+          Npgsql:ValueGenerationStrategy: None
+      ModifiedAt (DateTimeOffset?)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      ModifiedBy (string) MaxLength(450)
+        Annotations: 
+          MaxLength: 450
+          Npgsql:ValueGenerationStrategy: None
+      Name (string) Required MaxLength(256)
+        Annotations: 
+          MaxLength: 256
+          Npgsql:ValueGenerationStrategy: None
+    Keys: 
+      Id PK
+    Indexes: 
+      CustomDomain Unique
+        Annotations: 
+          Relational:Filter: "CustomDomain" IS NOT NULL
+          Relational:Name: uq_tenants_custom_domain
+      Identifier Unique
+        Annotations: 
+          Relational:Name: uq_tenants_identifier
+    Annotations: 
+      QueryFilter: Microsoft.EntityFrameworkCore.Metadata.Internal.QueryFilterCollection
+      Relational:FunctionName: 
+      Relational:Schema: 
+      Relational:SqlQuery: 
+      Relational:TableName: tenants_tenants
+      Relational:ViewName: 
+      Relational:ViewSchema: 
+Annotations: 
+  Npgsql:ValueGenerationStrategy: IdentityByDefaultColumn
+  ProductVersion: 10.0.10
+  Relational:MaxIdentifierLength: 63
+
+Query filters:
+  Tenant[SoftDelete]: e => (Not(value(Granit.MultiTenancy.EntityFrameworkCore.Internal.MultiTenancyDbContext).IsSoftDeleteFilterEnabled) OrElse Not(Property(e, "IsDeleted")))

--- a/tests/Granit.ArchitectureTests/ModelSnapshots/Granit.Notifications.EntityFrameworkCore.Internal.NotificationsDbContext.snap
+++ b/tests/Granit.ArchitectureTests/ModelSnapshots/Granit.Notifications.EntityFrameworkCore.Internal.NotificationsDbContext.snap
@@ -1,0 +1,229 @@
+Model: 
+  EntityType: NotificationDeliveryAttempt
+    Properties: 
+      Id (Guid) Required PK AfterSave:Throw ValueGenerated.OnAdd
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      ChannelName (string) Required Index MaxLength(64)
+        Annotations: 
+          MaxLength: 64
+          Npgsql:ValueGenerationStrategy: None
+      DeliveryId (Guid) Required Index
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      DurationMs (long) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      ErrorMessage (string) MaxLength(2048)
+        Annotations: 
+          MaxLength: 2048
+          Npgsql:ValueGenerationStrategy: None
+      IsSuccess (bool?)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      NotificationId (Guid) Required Index
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      NotificationTypeName (string) Required MaxLength(256)
+        Annotations: 
+          MaxLength: 256
+          Npgsql:ValueGenerationStrategy: None
+      OccurredAt (DateTimeOffset) Required Index
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      RecipientUserId (string) Required MaxLength(256)
+        Annotations: 
+          MaxLength: 256
+          Npgsql:ValueGenerationStrategy: None
+      TenantId (Guid?) Index
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+    Keys: 
+      Id PK
+    Indexes: 
+      DeliveryId Unique
+        Annotations: 
+          Relational:Name: uq_notifications_delivery_attempts_delivery_id
+      NotificationId, ChannelName
+        Annotations: 
+          Relational:Name: ix_notifications_delivery_attempts_notification
+      TenantId, OccurredAt
+        Annotations: 
+          Relational:Name: ix_notifications_delivery_attempts_audit
+    Annotations: 
+      Relational:FunctionName: 
+      Relational:Schema: 
+      Relational:SqlQuery: 
+      Relational:TableName: notifications_delivery_attempts
+      Relational:ViewName: 
+      Relational:ViewSchema: 
+  EntityType: NotificationPreference
+    Properties: 
+      Id (Guid) Required PK AfterSave:Throw ValueGenerated.OnAdd
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      ChannelName (string) Required Index MaxLength(64)
+        Annotations: 
+          MaxLength: 64
+          Npgsql:ValueGenerationStrategy: None
+      CreatedAt (DateTimeOffset) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      CreatedBy (string) Required MaxLength(256)
+        Annotations: 
+          MaxLength: 256
+          Npgsql:ValueGenerationStrategy: None
+      IsEnabled (bool) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      ModifiedAt (DateTimeOffset?)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      ModifiedBy (string) MaxLength(256)
+        Annotations: 
+          MaxLength: 256
+          Npgsql:ValueGenerationStrategy: None
+      NotificationTypeName (string) Required Index MaxLength(256)
+        Annotations: 
+          MaxLength: 256
+          Npgsql:ValueGenerationStrategy: None
+      TenantId (Guid?) Index
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      UserId (string) Required Index MaxLength(256)
+        Annotations: 
+          MaxLength: 256
+          Npgsql:ValueGenerationStrategy: None
+    Keys: 
+      Id PK
+    Indexes: 
+      UserId, NotificationTypeName, ChannelName, TenantId Unique
+        Annotations: 
+          Relational:Name: uq_notifications_preferences_user_type_channel_tenant
+    Annotations: 
+      QueryFilter: Microsoft.EntityFrameworkCore.Metadata.Internal.QueryFilterCollection
+      Relational:FunctionName: 
+      Relational:Schema: 
+      Relational:SqlQuery: 
+      Relational:TableName: notifications_preferences
+      Relational:ViewName: 
+      Relational:ViewSchema: 
+  EntityType: NotificationSubscription
+    Properties: 
+      Id (Guid) Required PK AfterSave:Throw ValueGenerated.OnAdd
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      CreatedAt (DateTimeOffset) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      CreatedBy (string) Required MaxLength(256)
+        Annotations: 
+          MaxLength: 256
+          Npgsql:ValueGenerationStrategy: None
+      EntityId (string) Index MaxLength(256)
+        Annotations: 
+          MaxLength: 256
+          Npgsql:ValueGenerationStrategy: None
+      EntityType (string) Index MaxLength(256)
+        Annotations: 
+          MaxLength: 256
+          Npgsql:ValueGenerationStrategy: None
+      NotificationTypeName (string) Required Index MaxLength(256)
+        Annotations: 
+          MaxLength: 256
+          Npgsql:ValueGenerationStrategy: None
+      TenantId (Guid?) Index
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      UserId (string) Required Index MaxLength(256)
+        Annotations: 
+          MaxLength: 256
+          Npgsql:ValueGenerationStrategy: None
+    Keys: 
+      Id PK
+    Indexes: 
+      EntityType, EntityId, TenantId
+        Annotations: 
+          Relational:Name: ix_notifications_subscriptions_entity
+      UserId, NotificationTypeName, TenantId
+        Annotations: 
+          Relational:Name: ix_notifications_subscriptions_global
+    Annotations: 
+      QueryFilter: Microsoft.EntityFrameworkCore.Metadata.Internal.QueryFilterCollection
+      Relational:FunctionName: 
+      Relational:Schema: 
+      Relational:SqlQuery: 
+      Relational:TableName: notifications_subscriptions
+      Relational:ViewName: 
+      Relational:ViewSchema: 
+  EntityType: UserNotification
+    Properties: 
+      Id (Guid) Required PK AfterSave:Throw ValueGenerated.OnAdd
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      CreatedAt (DateTimeOffset) Required Index
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      Data (JsonElement) Required
+        Annotations: 
+          Granit:JsonSerialized: True
+          Npgsql:ValueGenerationStrategy: None
+      NotificationId (Guid) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      NotificationTypeName (string) Required MaxLength(256)
+        Annotations: 
+          MaxLength: 256
+          Npgsql:ValueGenerationStrategy: None
+      ReadAt (DateTimeOffset?)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      RecipientUserId (string) Required Index MaxLength(256)
+        Annotations: 
+          MaxLength: 256
+          Npgsql:ValueGenerationStrategy: None
+      RelatedEntityId (string) Index MaxLength(256)
+        Annotations: 
+          MaxLength: 256
+          Npgsql:ValueGenerationStrategy: None
+      RelatedEntityType (string) Index MaxLength(256)
+        Annotations: 
+          MaxLength: 256
+          Npgsql:ValueGenerationStrategy: None
+      Severity (NotificationSeverity) Required MaxLength(20)
+        Annotations: 
+          MaxLength: 20
+          Npgsql:ValueGenerationStrategy: None
+      State (UserNotificationState) Required Index MaxLength(20)
+        Annotations: 
+          MaxLength: 20
+          Npgsql:ValueGenerationStrategy: None
+      TenantId (Guid?) Index
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+    Keys: 
+      Id PK
+    Indexes: 
+      RecipientUserId, TenantId, State, CreatedAt
+        Annotations: 
+          Relational:Name: ix_notifications_user_notifications_inbox
+      RelatedEntityType, RelatedEntityId, TenantId, CreatedAt
+        Annotations: 
+          Relational:Name: ix_notifications_user_notifications_entity_feed
+    Annotations: 
+      QueryFilter: Microsoft.EntityFrameworkCore.Metadata.Internal.QueryFilterCollection
+      Relational:FunctionName: 
+      Relational:Schema: 
+      Relational:SqlQuery: 
+      Relational:TableName: notifications_user_notifications
+      Relational:ViewName: 
+      Relational:ViewSchema: 
+Annotations: 
+  Npgsql:ValueGenerationStrategy: IdentityByDefaultColumn
+  ProductVersion: 10.0.10
+  Relational:MaxIdentifierLength: 63
+
+Query filters:
+  NotificationPreference[MultiTenant]: e => (Not(value(Granit.Notifications.EntityFrameworkCore.Internal.NotificationsDbContext).IsMultiTenantFilterEnabled) OrElse (Property(e, "TenantId") == value(Granit.Notifications.EntityFrameworkCore.Internal.NotificationsDbContext).CurrentTenantId))
+  NotificationSubscription[MultiTenant]: e => (Not(value(Granit.Notifications.EntityFrameworkCore.Internal.NotificationsDbContext).IsMultiTenantFilterEnabled) OrElse (Property(e, "TenantId") == value(Granit.Notifications.EntityFrameworkCore.Internal.NotificationsDbContext).CurrentTenantId))
+  UserNotification[MultiTenant]: e => (Not(value(Granit.Notifications.EntityFrameworkCore.Internal.NotificationsDbContext).IsMultiTenantFilterEnabled) OrElse (Property(e, "TenantId") == value(Granit.Notifications.EntityFrameworkCore.Internal.NotificationsDbContext).CurrentTenantId))

--- a/tests/Granit.ArchitectureTests/ModelSnapshots/Granit.Notifications.MobilePush.EntityFrameworkCore.Internal.MobilePushDbContext.snap
+++ b/tests/Granit.ArchitectureTests/ModelSnapshots/Granit.Notifications.MobilePush.EntityFrameworkCore.Internal.MobilePushDbContext.snap
@@ -1,0 +1,56 @@
+Model: 
+  EntityType: MobilePushToken
+    Properties: 
+      Id (Guid) Required PK AfterSave:Throw ValueGenerated.OnAdd
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      CreatedAt (DateTimeOffset) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      CreatedBy (string) Required MaxLength(256)
+        Annotations: 
+          MaxLength: 256
+          Npgsql:ValueGenerationStrategy: None
+      DeviceToken (string) Required MaxLength(4096)
+        Annotations: 
+          MaxLength: 4096
+          Npgsql:ValueGenerationStrategy: None
+      DeviceTokenHash (string) Required Index MaxLength(64)
+        Annotations: 
+          MaxLength: 64
+          Npgsql:ValueGenerationStrategy: None
+      Platform (MobilePlatform) Required MaxLength(16)
+        Annotations: 
+          MaxLength: 16
+          Npgsql:ValueGenerationStrategy: None
+      TenantId (Guid?) Index
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      UserId (string) Required Index MaxLength(256)
+        Annotations: 
+          MaxLength: 256
+          Npgsql:ValueGenerationStrategy: None
+    Keys: 
+      Id PK
+    Indexes: 
+      DeviceTokenHash, TenantId Unique
+        Annotations: 
+          Relational:Name: uq_notifications_mobile_push_tokens_device_hash_tenant
+      UserId, TenantId
+        Annotations: 
+          Relational:Name: ix_notifications_mobile_push_tokens_user_tenant
+    Annotations: 
+      QueryFilter: Microsoft.EntityFrameworkCore.Metadata.Internal.QueryFilterCollection
+      Relational:FunctionName: 
+      Relational:Schema: 
+      Relational:SqlQuery: 
+      Relational:TableName: notifications_mobile_push_tokens
+      Relational:ViewName: 
+      Relational:ViewSchema: 
+Annotations: 
+  Npgsql:ValueGenerationStrategy: IdentityByDefaultColumn
+  ProductVersion: 10.0.10
+  Relational:MaxIdentifierLength: 63
+
+Query filters:
+  MobilePushToken[MultiTenant]: e => (Not(value(Granit.Notifications.MobilePush.EntityFrameworkCore.Internal.MobilePushDbContext).IsMultiTenantFilterEnabled) OrElse (Property(e, "TenantId") == value(Granit.Notifications.MobilePush.EntityFrameworkCore.Internal.MobilePushDbContext).CurrentTenantId))

--- a/tests/Granit.ArchitectureTests/ModelSnapshots/Granit.Notifications.WebPush.EntityFrameworkCore.Internal.WebPushDbContext.snap
+++ b/tests/Granit.ArchitectureTests/ModelSnapshots/Granit.Notifications.WebPush.EntityFrameworkCore.Internal.WebPushDbContext.snap
@@ -1,0 +1,59 @@
+Model: 
+  EntityType: WebPushSubscription
+    Properties: 
+      Id (Guid) Required PK AfterSave:Throw ValueGenerated.OnAdd
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      Auth (string) Required MaxLength(256)
+        Annotations: 
+          MaxLength: 256
+          Npgsql:ValueGenerationStrategy: None
+      CreatedAt (DateTimeOffset) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      CreatedBy (string) Required MaxLength(256)
+        Annotations: 
+          MaxLength: 256
+          Npgsql:ValueGenerationStrategy: None
+      Endpoint (string) Required Index MaxLength(2048)
+        Annotations: 
+          MaxLength: 2048
+          Npgsql:ValueGenerationStrategy: None
+      ExpirationTime (long?)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      P256dh (string) Required MaxLength(512)
+        Annotations: 
+          MaxLength: 512
+          Npgsql:ValueGenerationStrategy: None
+      TenantId (Guid?) Index
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      UserId (string) Required Index MaxLength(256)
+        Annotations: 
+          MaxLength: 256
+          Npgsql:ValueGenerationStrategy: None
+    Keys: 
+      Id PK
+    Indexes: 
+      Endpoint, TenantId Unique
+        Annotations: 
+          Relational:Name: uq_notifications_web_push_subscriptions_endpoint_tenant
+      UserId, TenantId
+        Annotations: 
+          Relational:Name: ix_notifications_web_push_subscriptions_user_tenant
+    Annotations: 
+      QueryFilter: Microsoft.EntityFrameworkCore.Metadata.Internal.QueryFilterCollection
+      Relational:FunctionName: 
+      Relational:Schema: 
+      Relational:SqlQuery: 
+      Relational:TableName: notifications_web_push_subscriptions
+      Relational:ViewName: 
+      Relational:ViewSchema: 
+Annotations: 
+  Npgsql:ValueGenerationStrategy: IdentityByDefaultColumn
+  ProductVersion: 10.0.10
+  Relational:MaxIdentifierLength: 63
+
+Query filters:
+  WebPushSubscription[MultiTenant]: e => (Not(value(Granit.Notifications.WebPush.EntityFrameworkCore.Internal.WebPushDbContext).IsMultiTenantFilterEnabled) OrElse (Property(e, "TenantId") == value(Granit.Notifications.WebPush.EntityFrameworkCore.Internal.WebPushDbContext).CurrentTenantId))

--- a/tests/Granit.ArchitectureTests/ModelSnapshots/Granit.OpenIddict.EntityFrameworkCore.Internal.OpenIddictDbContext.snap
+++ b/tests/Granit.ArchitectureTests/ModelSnapshots/Granit.OpenIddict.EntityFrameworkCore.Internal.OpenIddictDbContext.snap
@@ -1,0 +1,322 @@
+Model: 
+  EntityType: SigningKey
+    Properties: 
+      Id (Guid) Required PK AfterSave:Throw ValueGenerated.OnAdd
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      ActivatedAt (DateTimeOffset) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      Algorithm (string) Required MaxLength(32)
+        Annotations: 
+          MaxLength: 32
+          Npgsql:ValueGenerationStrategy: None
+      ConcurrencyStamp (string) Required Concurrency MaxLength(36)
+        Annotations: 
+          MaxLength: 36
+          Npgsql:ValueGenerationStrategy: None
+      CreatedAt (DateTimeOffset) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      CreatedBy (string) Required MaxLength(256)
+        Annotations: 
+          MaxLength: 256
+          Npgsql:ValueGenerationStrategy: None
+      EncryptedKeyMaterial (string) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      ExpiresAt (DateTimeOffset) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      KeyId (string) Required Index MaxLength(128)
+        Annotations: 
+          MaxLength: 128
+          Npgsql:ValueGenerationStrategy: None
+      KeySize (int) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      KeyType (string) Required Index MaxLength(32)
+        Annotations: 
+          MaxLength: 32
+          Npgsql:ValueGenerationStrategy: None
+      RetiredAt (DateTimeOffset?)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      Status (SigningKeyStatus) Required Index MaxLength(20)
+        Annotations: 
+          MaxLength: 20
+          Npgsql:ValueGenerationStrategy: None
+    Keys: 
+      Id PK
+    Indexes: 
+      KeyId Unique
+        Annotations: 
+          Relational:Name: uq_openiddict_signing_keys_key_id
+      KeyType Unique
+        Annotations: 
+          Relational:Filter: "Status" = 'Active'
+          Relational:Name: uq_openiddict_signing_keys_active_type
+      KeyType, Status
+        Annotations: 
+          Relational:Name: ix_openiddict_signing_keys_type_status
+    Annotations: 
+      Relational:FunctionName: 
+      Relational:Schema: 
+      Relational:SqlQuery: 
+      Relational:TableName: openiddict_signing_keys
+      Relational:ViewName: 
+      Relational:ViewSchema: 
+  EntityType: GranitOpenIddictApplication
+    Properties: 
+      Id (Guid) Required PK AfterSave:Throw ValueGenerated.OnAdd
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      ApplicationType (string) MaxLength(50)
+        Annotations: 
+          MaxLength: 50
+          Npgsql:ValueGenerationStrategy: None
+      ClientId (string) Index MaxLength(100)
+        Annotations: 
+          MaxLength: 100
+          Npgsql:ValueGenerationStrategy: None
+      ClientSecret (string)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      ClientType (string) MaxLength(50)
+        Annotations: 
+          MaxLength: 50
+          Npgsql:ValueGenerationStrategy: None
+      ConcurrencyToken (string) Concurrency MaxLength(50)
+        Annotations: 
+          MaxLength: 50
+          Npgsql:ValueGenerationStrategy: None
+      ConsentType (string) MaxLength(50)
+        Annotations: 
+          MaxLength: 50
+          Npgsql:ValueGenerationStrategy: None
+      DisplayName (string)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      DisplayNames (string)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      JsonWebKeySet (string)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      Permissions (string)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      PostLogoutRedirectUris (string)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      Properties (string)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      RedirectUris (string)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      Requirements (string)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      Settings (string)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      TenantId (Guid?)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+    Navigations: 
+      Authorizations (ICollection<GranitOpenIddictAuthorization>) Collection ToDependent GranitOpenIddictAuthorization Inverse: Application
+      Tokens (ICollection<GranitOpenIddictToken>) Collection ToDependent GranitOpenIddictToken Inverse: Application
+    Keys: 
+      Id PK
+    Indexes: 
+      ClientId Unique
+    Annotations: 
+      QueryFilter: Microsoft.EntityFrameworkCore.Metadata.Internal.QueryFilterCollection
+      Relational:FunctionName: 
+      Relational:Schema: 
+      Relational:SqlQuery: 
+      Relational:TableName: openiddict_applications
+      Relational:ViewName: 
+      Relational:ViewSchema: 
+  EntityType: GranitOpenIddictAuthorization
+    Properties: 
+      Id (Guid) Required PK AfterSave:Throw ValueGenerated.OnAdd
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      ApplicationId (no field, Guid?) Shadow FK Index
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      ConcurrencyToken (string) Concurrency MaxLength(50)
+        Annotations: 
+          MaxLength: 50
+          Npgsql:ValueGenerationStrategy: None
+      CreationDate (DateTime?)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      Properties (string)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      Scopes (string)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      Status (string) Index MaxLength(50)
+        Annotations: 
+          MaxLength: 50
+          Npgsql:ValueGenerationStrategy: None
+      Subject (string) Index MaxLength(400)
+        Annotations: 
+          MaxLength: 400
+          Npgsql:ValueGenerationStrategy: None
+      TenantId (Guid?)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      Type (string) Index MaxLength(50)
+        Annotations: 
+          MaxLength: 50
+          Npgsql:ValueGenerationStrategy: None
+    Navigations: 
+      Application (GranitOpenIddictApplication) Optional ToPrincipal GranitOpenIddictApplication Inverse: Authorizations
+      Tokens (ICollection<GranitOpenIddictToken>) Collection ToDependent GranitOpenIddictToken Inverse: Authorization
+    Keys: 
+      Id PK
+    Foreign keys: 
+      GranitOpenIddictAuthorization {'ApplicationId'} -> GranitOpenIddictApplication {'Id'} ClientSetNull ToDependent: Authorizations ToPrincipal: Application
+    Indexes: 
+      ApplicationId, Status, Subject, Type
+    Annotations: 
+      QueryFilter: Microsoft.EntityFrameworkCore.Metadata.Internal.QueryFilterCollection
+      Relational:FunctionName: 
+      Relational:Schema: 
+      Relational:SqlQuery: 
+      Relational:TableName: openiddict_authorizations
+      Relational:ViewName: 
+      Relational:ViewSchema: 
+  EntityType: GranitOpenIddictScope
+    Properties: 
+      Id (Guid) Required PK AfterSave:Throw ValueGenerated.OnAdd
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      ConcurrencyToken (string) Concurrency MaxLength(50)
+        Annotations: 
+          MaxLength: 50
+          Npgsql:ValueGenerationStrategy: None
+      Description (string)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      Descriptions (string)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      DisplayName (string)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      DisplayNames (string)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      Name (string) Index MaxLength(200)
+        Annotations: 
+          MaxLength: 200
+          Npgsql:ValueGenerationStrategy: None
+      Properties (string)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      Resources (string)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      TenantId (Guid?)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+    Keys: 
+      Id PK
+    Indexes: 
+      Name Unique
+    Annotations: 
+      QueryFilter: Microsoft.EntityFrameworkCore.Metadata.Internal.QueryFilterCollection
+      Relational:FunctionName: 
+      Relational:Schema: 
+      Relational:SqlQuery: 
+      Relational:TableName: openiddict_scopes
+      Relational:ViewName: 
+      Relational:ViewSchema: 
+  EntityType: GranitOpenIddictToken
+    Properties: 
+      Id (Guid) Required PK AfterSave:Throw ValueGenerated.OnAdd
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      ApplicationId (no field, Guid?) Shadow FK Index
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      AuthorizationId (no field, Guid?) Shadow FK Index
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      ConcurrencyToken (string) Concurrency MaxLength(50)
+        Annotations: 
+          MaxLength: 50
+          Npgsql:ValueGenerationStrategy: None
+      CreationDate (DateTime?)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      ExpirationDate (DateTime?)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      LastActivityAt (DateTimeOffset?)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      Payload (string)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      Properties (string)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      RedemptionDate (DateTime?)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      ReferenceId (string) Index MaxLength(100)
+        Annotations: 
+          MaxLength: 100
+          Npgsql:ValueGenerationStrategy: None
+      Status (string) Index MaxLength(50)
+        Annotations: 
+          MaxLength: 50
+          Npgsql:ValueGenerationStrategy: None
+      Subject (string) Index MaxLength(400)
+        Annotations: 
+          MaxLength: 400
+          Npgsql:ValueGenerationStrategy: None
+      TenantId (Guid?)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      Type (string) Index MaxLength(150)
+        Annotations: 
+          MaxLength: 150
+          Npgsql:ValueGenerationStrategy: None
+    Navigations: 
+      Application (GranitOpenIddictApplication) Optional ToPrincipal GranitOpenIddictApplication Inverse: Tokens
+      Authorization (GranitOpenIddictAuthorization) Optional ToPrincipal GranitOpenIddictAuthorization Inverse: Tokens
+    Keys: 
+      Id PK
+    Foreign keys: 
+      GranitOpenIddictToken {'ApplicationId'} -> GranitOpenIddictApplication {'Id'} ClientSetNull ToDependent: Tokens ToPrincipal: Application
+      GranitOpenIddictToken {'AuthorizationId'} -> GranitOpenIddictAuthorization {'Id'} ClientSetNull ToDependent: Tokens ToPrincipal: Authorization
+    Indexes: 
+      AuthorizationId
+      ReferenceId Unique
+      ApplicationId, Status, Subject, Type
+    Annotations: 
+      QueryFilter: Microsoft.EntityFrameworkCore.Metadata.Internal.QueryFilterCollection
+      Relational:FunctionName: 
+      Relational:Schema: 
+      Relational:SqlQuery: 
+      Relational:TableName: openiddict_tokens
+      Relational:ViewName: 
+      Relational:ViewSchema: 
+Annotations: 
+  Npgsql:ValueGenerationStrategy: IdentityByDefaultColumn
+  ProductVersion: 10.0.10
+  Relational:MaxIdentifierLength: 63
+
+Query filters:
+  GranitOpenIddictApplication[MultiTenant]: e => ((Not(value(Granit.OpenIddict.EntityFrameworkCore.Internal.OpenIddictDbContext).IsMultiTenantFilterEnabled) OrElse (Property(e, "TenantId") == null)) OrElse (Property(e, "TenantId") == value(Granit.OpenIddict.EntityFrameworkCore.Internal.OpenIddictDbContext).CurrentTenantId))
+  GranitOpenIddictAuthorization[MultiTenant]: e => ((Not(value(Granit.OpenIddict.EntityFrameworkCore.Internal.OpenIddictDbContext).IsMultiTenantFilterEnabled) OrElse (Property(e, "TenantId") == null)) OrElse (Property(e, "TenantId") == value(Granit.OpenIddict.EntityFrameworkCore.Internal.OpenIddictDbContext).CurrentTenantId))
+  GranitOpenIddictScope[MultiTenant]: e => ((Not(value(Granit.OpenIddict.EntityFrameworkCore.Internal.OpenIddictDbContext).IsMultiTenantFilterEnabled) OrElse (Property(e, "TenantId") == null)) OrElse (Property(e, "TenantId") == value(Granit.OpenIddict.EntityFrameworkCore.Internal.OpenIddictDbContext).CurrentTenantId))
+  GranitOpenIddictToken[MultiTenant]: e => ((Not(value(Granit.OpenIddict.EntityFrameworkCore.Internal.OpenIddictDbContext).IsMultiTenantFilterEnabled) OrElse (Property(e, "TenantId") == null)) OrElse (Property(e, "TenantId") == value(Granit.OpenIddict.EntityFrameworkCore.Internal.OpenIddictDbContext).CurrentTenantId))

--- a/tests/Granit.ArchitectureTests/ModelSnapshots/Granit.Persistence.EntityFrameworkCore.Migrations.Internal.MigrationProgressDbContext.snap
+++ b/tests/Granit.ArchitectureTests/ModelSnapshots/Granit.Persistence.EntityFrameworkCore.Migrations.Internal.MigrationProgressDbContext.snap
@@ -1,0 +1,63 @@
+Model: 
+  EntityType: MigrationProgress
+    Properties: 
+      Id (Guid) Required PK AfterSave:Throw ValueGenerated.OnAdd
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      CompletedAt (DateTimeOffset?)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      CycleId (string) Required Index MaxLength(200)
+        Annotations: 
+          MaxLength: 200
+          Npgsql:ValueGenerationStrategy: None
+      Error (string) MaxLength(4000)
+        Annotations: 
+          MaxLength: 4000
+          Npgsql:ValueGenerationStrategy: None
+      LastCursor (string) MaxLength(2000)
+        Annotations: 
+          MaxLength: 2000
+          Npgsql:ValueGenerationStrategy: None
+      Phase (MigrationPhase) Required MaxLength(20)
+        Annotations: 
+          MaxLength: 20
+          Npgsql:ValueGenerationStrategy: None
+          ProviderClrType: System.String
+      ProcessedRows (long) Required ValueGenerated.OnAdd
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+          Relational:DefaultValue: 0
+      StartedAt (DateTimeOffset?)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      Status (MigrationStatus) Required MaxLength(20)
+        Annotations: 
+          MaxLength: 20
+          Npgsql:ValueGenerationStrategy: None
+          ProviderClrType: System.String
+      TenantId (Guid?) Index
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      TotalRows (long?)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+    Keys: 
+      Id PK
+    Indexes: 
+      CycleId, TenantId Unique
+        Annotations: 
+          Relational:Name: uq_data_migration_progress
+    Annotations: 
+      Relational:FunctionName: 
+      Relational:Schema: 
+      Relational:SqlQuery: 
+      Relational:TableName: data_migration_progress
+      Relational:ViewName: 
+      Relational:ViewSchema: 
+Annotations: 
+  Npgsql:ValueGenerationStrategy: IdentityByDefaultColumn
+  ProductVersion: 10.0.10
+  Relational:MaxIdentifierLength: 63
+
+Query filters:

--- a/tests/Granit.ArchitectureTests/ModelSnapshots/Granit.Presence.EntityFrameworkCore.Internal.PresenceDbContext.snap
+++ b/tests/Granit.ArchitectureTests/ModelSnapshots/Granit.Presence.EntityFrameworkCore.Internal.PresenceDbContext.snap
@@ -1,0 +1,48 @@
+Model: 
+  EntityType: UserPresence
+    Properties: 
+      Id (Guid) Required PK AfterSave:Throw ValueGenerated.OnAdd
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      CreatedAt (DateTimeOffset) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      CreatedBy (string) Required MaxLength(450)
+        Annotations: 
+          MaxLength: 450
+          Npgsql:ValueGenerationStrategy: None
+      ManualStatus (ManualPresenceStatus) Required ValueGenerated.OnAdd
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+          ProviderClrType: System.Int16
+          Relational:DefaultValue: Available
+      ModifiedAt (DateTimeOffset?)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      ModifiedBy (string) MaxLength(450)
+        Annotations: 
+          MaxLength: 450
+          Npgsql:ValueGenerationStrategy: None
+      OverrideUntilUtc (DateTimeOffset?)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      UserId (Guid) Required Index
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+    Keys: 
+      Id PK
+    Indexes: 
+      UserId Unique
+    Annotations: 
+      Relational:FunctionName: 
+      Relational:Schema: 
+      Relational:SqlQuery: 
+      Relational:TableName: presence_user_presence
+      Relational:ViewName: 
+      Relational:ViewSchema: 
+Annotations: 
+  Npgsql:ValueGenerationStrategy: IdentityByDefaultColumn
+  ProductVersion: 10.0.10
+  Relational:MaxIdentifierLength: 63
+
+Query filters:

--- a/tests/Granit.ArchitectureTests/ModelSnapshots/Granit.Privacy.EntityFrameworkCore.Internal.PrivacyDbContext.snap
+++ b/tests/Granit.ArchitectureTests/ModelSnapshots/Granit.Privacy.EntityFrameworkCore.Internal.PrivacyDbContext.snap
@@ -1,0 +1,229 @@
+Model: 
+  EntityType: DeletionRequestEntity
+    Properties: 
+      Id (Guid) Required PK AfterSave:Throw ValueGenerated.OnAdd
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      CancelledAt (DateTimeOffset?)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      ExecutedAt (DateTimeOffset?)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      MissingProviders (string) MaxLength(1000)
+        Annotations: 
+          MaxLength: 1000
+          Npgsql:ValueGenerationStrategy: None
+      Reason (string) Required MaxLength(2000)
+        Annotations: 
+          MaxLength: 2000
+          Npgsql:ValueGenerationStrategy: None
+      Regulation (string) MaxLength(40)
+        Annotations: 
+          MaxLength: 40
+          Npgsql:ValueGenerationStrategy: None
+      RequestedAt (DateTimeOffset) Required Index
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      ScheduledDeletionAt (DateTimeOffset) Required Index
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      State (DeletionRequestState) Required Index MaxLength(30)
+        Annotations: 
+          MaxLength: 30
+          Npgsql:ValueGenerationStrategy: None
+      TenantId (Guid?) Index
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      UserId (Guid) Required Index
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+    Keys: 
+      Id PK
+    Indexes: 
+      State, ScheduledDeletionAt
+        Annotations: 
+          Relational:Name: ix_privacy_deletion_requests_due
+      TenantId, UserId, RequestedAt
+        Annotations: 
+          Relational:Name: ix_privacy_deletion_requests_user_timeline
+    Annotations: 
+      QueryFilter: Microsoft.EntityFrameworkCore.Metadata.Internal.QueryFilterCollection
+      Relational:FunctionName: 
+      Relational:Schema: 
+      Relational:SqlQuery: 
+      Relational:TableName: privacy_deletion_requests
+      Relational:ViewName: 
+      Relational:ViewSchema: 
+  EntityType: ExportAssemblyCheckpointRow
+    Properties: 
+      RequestId (Guid) Required PK AfterSave:Throw
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      TenantId (Guid?) Required PK AfterSave:Throw
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      CompletedShardObjectKeys (List<string>) Required
+        Annotations: 
+          Granit:JsonSerialized: True
+          Npgsql:ValueGenerationStrategy: None
+      ConcurrencyStamp (string) Required Concurrency MaxLength(36)
+        Annotations: 
+          MaxLength: 36
+          Npgsql:ValueGenerationStrategy: None
+      LastCompletedShardIndex (int) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      NextFragmentIndex (int) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      UpdatedAt (DateTimeOffset) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+    Keys: 
+      RequestId, TenantId PK
+    Annotations: 
+      QueryFilter: Microsoft.EntityFrameworkCore.Metadata.Internal.QueryFilterCollection
+      Relational:FunctionName: 
+      Relational:Schema: 
+      Relational:SqlQuery: 
+      Relational:TableName: privacy_export_assembly_checkpoints
+      Relational:ViewName: 
+      Relational:ViewSchema: 
+  EntityType: ExportRequestEntity
+    Properties: 
+      Id (Guid) Required PK AfterSave:Throw ValueGenerated.OnAdd
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      ArchiveBlobReferenceId (BlobReference) MaxLength(200)
+        Annotations: 
+          MaxLength: 200
+          Npgsql:ValueGenerationStrategy: None
+      CallerUserId (Guid?) Index
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      CompletedAt (DateTimeOffset?)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      MissingProviders (List<string>) Required
+        Annotations: 
+          Granit:JsonSerialized: True
+          Npgsql:ValueGenerationStrategy: None
+      RequestedAt (DateTimeOffset) Required Index
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      State (ExportRequestState) Required MaxLength(30)
+        Annotations: 
+          MaxLength: 30
+          Npgsql:ValueGenerationStrategy: None
+      TenantId (Guid?) Index
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      UserId (Guid) Required Index
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+    Keys: 
+      Id PK
+    Indexes: 
+      TenantId, CallerUserId, RequestedAt
+        Annotations: 
+          Relational:Name: ix_privacy_export_requests_caller_timeline
+      TenantId, UserId, RequestedAt
+        Annotations: 
+          Relational:Name: ix_privacy_export_requests_user_timeline
+    Annotations: 
+      QueryFilter: Microsoft.EntityFrameworkCore.Metadata.Internal.QueryFilterCollection
+      Relational:FunctionName: 
+      Relational:Schema: 
+      Relational:SqlQuery: 
+      Relational:TableName: privacy_export_requests
+      Relational:ViewName: 
+      Relational:ViewSchema: 
+  EntityType: LegalDocument
+    Properties: 
+      Id (Guid) Required PK AfterSave:Throw ValueGenerated.OnAdd
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      ConcurrencyStamp (string) Required Concurrency MaxLength(36)
+        Annotations: 
+          MaxLength: 36
+          Npgsql:ValueGenerationStrategy: None
+      CreatedAt (DateTimeOffset) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      CreatedBy (string) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      Description (string) MaxLength(2000)
+        Annotations: 
+          MaxLength: 2000
+          Npgsql:ValueGenerationStrategy: None
+      DisplayName (string) Required MaxLength(500)
+        Annotations: 
+          MaxLength: 500
+          Npgsql:ValueGenerationStrategy: None
+      DocumentBlobId (Guid?)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      DocumentId (string) Required Index MaxLength(200)
+        Annotations: 
+          MaxLength: 200
+          Npgsql:ValueGenerationStrategy: None
+      IsPublished (bool) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      LifecycleStatus (WorkflowLifecycleStatus) Required Index MaxLength(20)
+        Annotations: 
+          MaxLength: 20
+          Npgsql:ValueGenerationStrategy: None
+      ModifiedAt (DateTimeOffset?)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      ModifiedBy (string)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      TemplateName (string) MaxLength(500)
+        Annotations: 
+          MaxLength: 500
+          Npgsql:ValueGenerationStrategy: None
+      TenantId (Guid?) Index
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      Version (int) Required Index
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      VersionId (Guid) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+    Keys: 
+      Id PK
+    Indexes: 
+      DocumentId, Version
+        Annotations: 
+          Relational:Name: ix_privacy_legal_documents_version
+      TenantId, DocumentId Unique
+        Annotations: 
+          Relational:Filter: "IsPublished" = true
+          Relational:Name: uq_privacy_legal_documents_published
+      TenantId, DocumentId, LifecycleStatus
+        Annotations: 
+          Relational:Name: ix_privacy_legal_documents_tenant_status
+    Annotations: 
+      QueryFilter: Microsoft.EntityFrameworkCore.Metadata.Internal.QueryFilterCollection
+      Relational:FunctionName: 
+      Relational:Schema: 
+      Relational:SqlQuery: 
+      Relational:TableName: privacy_legal_documents
+      Relational:ViewName: 
+      Relational:ViewSchema: 
+Annotations: 
+  Npgsql:ValueGenerationStrategy: IdentityByDefaultColumn
+  ProductVersion: 10.0.10
+  Relational:MaxIdentifierLength: 63
+
+Query filters:
+  DeletionRequestEntity[MultiTenant]: e => (Not(value(Granit.Privacy.EntityFrameworkCore.Internal.PrivacyDbContext).IsMultiTenantFilterEnabled) OrElse (Property(e, "TenantId") == value(Granit.Privacy.EntityFrameworkCore.Internal.PrivacyDbContext).CurrentTenantId))
+  ExportAssemblyCheckpointRow[MultiTenant]: e => (Not(value(Granit.Privacy.EntityFrameworkCore.Internal.PrivacyDbContext).IsMultiTenantFilterEnabled) OrElse (Property(e, "TenantId") == value(Granit.Privacy.EntityFrameworkCore.Internal.PrivacyDbContext).CurrentTenantId))
+  ExportRequestEntity[MultiTenant]: e => (Not(value(Granit.Privacy.EntityFrameworkCore.Internal.PrivacyDbContext).IsMultiTenantFilterEnabled) OrElse (Property(e, "TenantId") == value(Granit.Privacy.EntityFrameworkCore.Internal.PrivacyDbContext).CurrentTenantId))
+  LegalDocument[MultiTenant]: e => (Not(value(Granit.Privacy.EntityFrameworkCore.Internal.PrivacyDbContext).IsMultiTenantFilterEnabled) OrElse (Property(e, "TenantId") == value(Granit.Privacy.EntityFrameworkCore.Internal.PrivacyDbContext).CurrentTenantId))
+  LegalDocument[Publishable]: e => (Not(value(Granit.Privacy.EntityFrameworkCore.Internal.PrivacyDbContext).IsPublishableFilterEnabled) OrElse Property(e, "IsPublished"))

--- a/tests/Granit.ArchitectureTests/ModelSnapshots/Granit.Scheduling.EntityFrameworkCore.Internal.SchedulingDbContext.snap
+++ b/tests/Granit.ArchitectureTests/ModelSnapshots/Granit.Scheduling.EntityFrameworkCore.Internal.SchedulingDbContext.snap
@@ -1,0 +1,77 @@
+Model: 
+  EntityType: ScheduledAction
+    Properties: 
+      Id (Guid) Required PK AfterSave:Throw ValueGenerated.OnAdd
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      AttemptCount (int) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      CancelledBy (string) MaxLength(450)
+        Annotations: 
+          MaxLength: 450
+          Npgsql:ValueGenerationStrategy: None
+      CorrelationId (string) Index MaxLength(500)
+        Annotations: 
+          MaxLength: 500
+          Npgsql:ValueGenerationStrategy: None
+      CreatedAt (DateTimeOffset) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      CreatedBy (string) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      ExecuteAt (DateTimeOffset) Required Index
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      ExecutedAt (DateTimeOffset?)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      FailureReason (string) MaxLength(500)
+        Annotations: 
+          MaxLength: 500
+          Npgsql:ValueGenerationStrategy: None
+      ModifiedAt (DateTimeOffset?)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      ModifiedBy (string)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      PayloadJson (string) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      PayloadType (string) Required MaxLength(500)
+        Annotations: 
+          MaxLength: 500
+          Npgsql:ValueGenerationStrategy: None
+      Status (ScheduledActionStatus) Required Index MaxLength(20)
+        Annotations: 
+          MaxLength: 20
+          Npgsql:ValueGenerationStrategy: None
+      TenantId (Guid?)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+    Keys: 
+      Id PK
+    Indexes: 
+      CorrelationId
+        Annotations: 
+          Relational:Name: ix_scheduling_scheduled_actions_correlation_id
+      Status, ExecuteAt
+        Annotations: 
+          Relational:Name: ix_scheduling_scheduled_actions_status_execute_at
+    Annotations: 
+      QueryFilter: Microsoft.EntityFrameworkCore.Metadata.Internal.QueryFilterCollection
+      Relational:FunctionName: 
+      Relational:Schema: 
+      Relational:SqlQuery: 
+      Relational:TableName: scheduling_scheduled_actions
+      Relational:ViewName: 
+      Relational:ViewSchema: 
+Annotations: 
+  Npgsql:ValueGenerationStrategy: IdentityByDefaultColumn
+  ProductVersion: 10.0.10
+  Relational:MaxIdentifierLength: 63
+
+Query filters:
+  ScheduledAction[MultiTenant]: e => (Not(value(Granit.Scheduling.EntityFrameworkCore.Internal.SchedulingDbContext).IsMultiTenantFilterEnabled) OrElse (Property(e, "TenantId") == value(Granit.Scheduling.EntityFrameworkCore.Internal.SchedulingDbContext).CurrentTenantId))

--- a/tests/Granit.ArchitectureTests/ModelSnapshots/Granit.Settings.EntityFrameworkCore.Internal.SettingsDbContext.snap
+++ b/tests/Granit.ArchitectureTests/ModelSnapshots/Granit.Settings.EntityFrameworkCore.Internal.SettingsDbContext.snap
@@ -1,0 +1,55 @@
+Model: 
+  EntityType: SettingRecord
+    Properties: 
+      Id (Guid) Required PK AfterSave:Throw ValueGenerated.OnAdd
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      CreatedAt (DateTimeOffset) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      CreatedBy (string) Required MaxLength(256)
+        Annotations: 
+          MaxLength: 256
+          Npgsql:ValueGenerationStrategy: None
+      ModifiedAt (DateTimeOffset?)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      ModifiedBy (string) MaxLength(256)
+        Annotations: 
+          MaxLength: 256
+          Npgsql:ValueGenerationStrategy: None
+      Name (string) Required Index MaxLength(256)
+        Annotations: 
+          MaxLength: 256
+          Npgsql:ValueGenerationStrategy: None
+      ProviderKey (string) Index MaxLength(256)
+        Annotations: 
+          MaxLength: 256
+          Npgsql:ValueGenerationStrategy: None
+      ProviderName (string) Required Index MaxLength(4)
+        Annotations: 
+          MaxLength: 4
+          Npgsql:ValueGenerationStrategy: None
+      Value (string) MaxLength(4000)
+        Annotations: 
+          MaxLength: 4000
+          Npgsql:ValueGenerationStrategy: None
+    Keys: 
+      Id PK
+    Indexes: 
+      Name, ProviderName, ProviderKey Unique
+        Annotations: 
+          Relational:Name: uq_settings_setting_records_name_provider
+    Annotations: 
+      Relational:FunctionName: 
+      Relational:Schema: 
+      Relational:SqlQuery: 
+      Relational:TableName: settings_setting_records
+      Relational:ViewName: 
+      Relational:ViewSchema: 
+Annotations: 
+  Npgsql:ValueGenerationStrategy: IdentityByDefaultColumn
+  ProductVersion: 10.0.10
+  Relational:MaxIdentifierLength: 63
+
+Query filters:

--- a/tests/Granit.ArchitectureTests/ModelSnapshots/Granit.Templating.EntityFrameworkCore.Internal.TemplatingDbContext.snap
+++ b/tests/Granit.ArchitectureTests/ModelSnapshots/Granit.Templating.EntityFrameworkCore.Internal.TemplatingDbContext.snap
@@ -1,0 +1,207 @@
+Model: 
+  EntityType: TemplateCategoryEntity
+    Properties: 
+      Id (Guid) Required PK AfterSave:Throw ValueGenerated.OnAdd
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      CreatedAt (DateTimeOffset) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      CreatedBy (string) Required MaxLength(200)
+        Annotations: 
+          MaxLength: 200
+          Npgsql:ValueGenerationStrategy: None
+      Description (string) MaxLength(500)
+        Annotations: 
+          MaxLength: 500
+          Npgsql:ValueGenerationStrategy: None
+      Icon (string) MaxLength(100)
+        Annotations: 
+          MaxLength: 100
+          Npgsql:ValueGenerationStrategy: None
+      Name (string) Required Index MaxLength(200)
+        Annotations: 
+          MaxLength: 200
+          Npgsql:ValueGenerationStrategy: None
+      SortOrder (int) Required Index
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      TenantId (Guid?) Index
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+    Keys: 
+      Id PK
+    Indexes: 
+      SortOrder, Name
+        Annotations: 
+          Relational:Name: ix_templating_categories_sort
+      TenantId, Name Unique
+        Annotations: 
+          Relational:Name: uq_templating_categories_tenant_name
+    Annotations: 
+      QueryFilter: Microsoft.EntityFrameworkCore.Metadata.Internal.QueryFilterCollection
+      Relational:FunctionName: 
+      Relational:Schema: 
+      Relational:SqlQuery: 
+      Relational:TableName: templating_categories
+      Relational:ViewName: 
+      Relational:ViewSchema: 
+  EntityType: TemplateRevisionEntity
+    Properties: 
+      Id (Guid) Required PK AfterSave:Throw ValueGenerated.OnAdd
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      CategoryId (Guid?) FK Index
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      ConcurrencyStamp (string) Required Concurrency MaxLength(36)
+        Annotations: 
+          MaxLength: 36
+          Npgsql:ValueGenerationStrategy: None
+      Content (string) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      CreatedAt (DateTimeOffset) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      CreatedBy (string) Required MaxLength(200)
+        Annotations: 
+          MaxLength: 200
+          Npgsql:ValueGenerationStrategy: None
+      Culture (string) Index MaxLength(10)
+        Annotations: 
+          MaxLength: 10
+          Npgsql:ValueGenerationStrategy: None
+      IsPublished (bool) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      LayoutName (string)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      LifecycleStatus (WorkflowLifecycleStatus) Required Index MaxLength(20)
+        Annotations: 
+          MaxLength: 20
+          Npgsql:ValueGenerationStrategy: None
+      MimeType (string) Required MaxLength(127)
+        Annotations: 
+          MaxLength: 127
+          Npgsql:ValueGenerationStrategy: None
+      ModifiedAt (DateTimeOffset?)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      ModifiedBy (string) MaxLength(200)
+        Annotations: 
+          MaxLength: 200
+          Npgsql:ValueGenerationStrategy: None
+      PublishedAt (DateTimeOffset?)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      PublishedBy (string) MaxLength(200)
+        Annotations: 
+          MaxLength: 200
+          Npgsql:ValueGenerationStrategy: None
+      TemplateName (string) Required Index MaxLength(200)
+        Annotations: 
+          MaxLength: 200
+          Npgsql:ValueGenerationStrategy: None
+      TenantId (Guid?) Index
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      Version (int) Required Index
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      VersionId (Guid) Required Index
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+    Keys: 
+      Id PK
+    Foreign keys: 
+      TemplateRevisionEntity {'CategoryId'} -> TemplateCategoryEntity {'Id'} SetNull
+    Indexes: 
+      CategoryId
+      TemplateName, Culture
+        Annotations: 
+          Relational:Name: ix_templating_revisions_name_culture
+      VersionId, Version
+        Annotations: 
+          Relational:Name: ix_templating_revisions_version
+      TemplateName, Culture, LifecycleStatus
+        Annotations: 
+          Relational:Name: ix_templating_revisions_name_culture_status
+      TenantId, TemplateName, Culture Unique
+        Annotations: 
+          Relational:Filter: "IsPublished" = true
+          Relational:Name: uq_templating_revisions_published
+    Annotations: 
+      QueryFilter: Microsoft.EntityFrameworkCore.Metadata.Internal.QueryFilterCollection
+      Relational:FunctionName: 
+      Relational:Schema: 
+      Relational:SqlQuery: 
+      Relational:TableName: templating_revisions
+      Relational:ViewName: 
+      Relational:ViewSchema: 
+  EntityType: WorkflowTransitionRecord
+    Properties: 
+      Id (Guid) Required PK AfterSave:Throw ValueGenerated.OnAdd
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      Comment (string) MaxLength(2000)
+        Annotations: 
+          MaxLength: 2000
+          Npgsql:ValueGenerationStrategy: None
+      EntityId (string) Required Index MaxLength(200)
+        Annotations: 
+          MaxLength: 200
+          Npgsql:ValueGenerationStrategy: None
+      EntityType (string) Required Index MaxLength(200)
+        Annotations: 
+          MaxLength: 200
+          Npgsql:ValueGenerationStrategy: None
+      NewState (string) Required MaxLength(100)
+        Annotations: 
+          MaxLength: 100
+          Npgsql:ValueGenerationStrategy: None
+      PreviousState (string) Required MaxLength(100)
+        Annotations: 
+          MaxLength: 100
+          Npgsql:ValueGenerationStrategy: None
+      TenantId (Guid?) Index
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      TransitionedAt (DateTimeOffset) Required Index
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      TransitionedBy (string) Required Index MaxLength(450)
+        Annotations: 
+          MaxLength: 450
+          Npgsql:ValueGenerationStrategy: None
+    Keys: 
+      Id PK
+    Indexes: 
+      TenantId, TransitionedAt
+        Annotations: 
+          Relational:Name: ix_workflow_transition_records_tenantid_at
+      TransitionedBy, TransitionedAt
+        Annotations: 
+          Relational:Name: ix_workflow_transition_records_by_user_at
+      EntityType, EntityId, TransitionedAt
+        Annotations: 
+          Relational:Name: ix_workflow_transition_records_entity_type_id_at
+    Annotations: 
+      QueryFilter: Microsoft.EntityFrameworkCore.Metadata.Internal.QueryFilterCollection
+      Relational:FunctionName: 
+      Relational:Schema: 
+      Relational:SqlQuery: 
+      Relational:TableName: workflow_transition_records
+      Relational:ViewName: 
+      Relational:ViewSchema: 
+Annotations: 
+  Npgsql:ValueGenerationStrategy: IdentityByDefaultColumn
+  ProductVersion: 10.0.10
+  Relational:MaxIdentifierLength: 63
+
+Query filters:
+  TemplateCategoryEntity[MultiTenant]: e => (Not(value(Granit.Templating.EntityFrameworkCore.Internal.TemplatingDbContext).IsMultiTenantFilterEnabled) OrElse (Property(e, "TenantId") == value(Granit.Templating.EntityFrameworkCore.Internal.TemplatingDbContext).CurrentTenantId))
+  TemplateRevisionEntity[MultiTenant]: e => (Not(value(Granit.Templating.EntityFrameworkCore.Internal.TemplatingDbContext).IsMultiTenantFilterEnabled) OrElse (Property(e, "TenantId") == value(Granit.Templating.EntityFrameworkCore.Internal.TemplatingDbContext).CurrentTenantId))
+  TemplateRevisionEntity[Publishable]: e => (Not(value(Granit.Templating.EntityFrameworkCore.Internal.TemplatingDbContext).IsPublishableFilterEnabled) OrElse Property(e, "IsPublished"))
+  WorkflowTransitionRecord[MultiTenant]: e => (Not(value(Granit.Templating.EntityFrameworkCore.Internal.TemplatingDbContext).IsMultiTenantFilterEnabled) OrElse (Property(e, "TenantId") == value(Granit.Templating.EntityFrameworkCore.Internal.TemplatingDbContext).CurrentTenantId))

--- a/tests/Granit.ArchitectureTests/ModelSnapshots/Granit.Testing.Persistence.ConformanceDbContext.snap
+++ b/tests/Granit.ArchitectureTests/ModelSnapshots/Granit.Testing.Persistence.ConformanceDbContext.snap
@@ -1,0 +1,83 @@
+Model: 
+  EntityType: ConformanceOrder
+    Properties: 
+      Id (Guid) Required PK AfterSave:Throw ValueGenerated.OnAdd
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      ConcurrencyStamp (string) Required Concurrency MaxLength(36)
+        Annotations: 
+          MaxLength: 36
+          Npgsql:ValueGenerationStrategy: None
+      CreatedAt (DateTimeOffset) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      CreatedBy (string) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      DeletedAt (DateTimeOffset?)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      DeletedBy (string)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      IsDeleted (bool) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      Label (string) Required MaxLength(128)
+        Annotations: 
+          MaxLength: 128
+          Npgsql:ValueGenerationStrategy: None
+      ModifiedAt (DateTimeOffset?)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      ModifiedBy (string)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      Status (ConformanceOrderStatus) Required MaxLength(20)
+        Annotations: 
+          MaxLength: 20
+          Npgsql:ValueGenerationStrategy: None
+      TenantId (Guid?)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+    Keys: 
+      Id PK
+    Annotations: 
+      QueryFilter: Microsoft.EntityFrameworkCore.Metadata.Internal.QueryFilterCollection
+      Relational:FunctionName: 
+      Relational:Schema: 
+      Relational:SqlQuery: 
+      Relational:TableName: Orders
+      Relational:ViewName: 
+      Relational:ViewSchema: 
+  EntityType: ConformanceToggle
+    Properties: 
+      Id (Guid) Required PK AfterSave:Throw ValueGenerated.OnAdd
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      Activated (bool) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      Label (string) Required MaxLength(128)
+        Annotations: 
+          MaxLength: 128
+          Npgsql:ValueGenerationStrategy: None
+    Keys: 
+      Id PK
+    Annotations: 
+      QueryFilter: Microsoft.EntityFrameworkCore.Metadata.Internal.QueryFilterCollection
+      Relational:FunctionName: 
+      Relational:Schema: 
+      Relational:SqlQuery: 
+      Relational:TableName: Toggles
+      Relational:ViewName: 
+      Relational:ViewSchema: 
+Annotations: 
+  Npgsql:ValueGenerationStrategy: IdentityByDefaultColumn
+  ProductVersion: 10.0.10
+  Relational:MaxIdentifierLength: 63
+
+Query filters:
+  ConformanceOrder[MultiTenant]: e => (Not(value(Granit.Testing.Persistence.ConformanceDbContext).IsMultiTenantFilterEnabled) OrElse (Property(e, "TenantId") == value(Granit.Testing.Persistence.ConformanceDbContext).CurrentTenantId))
+  ConformanceOrder[SoftDelete]: e => (Not(value(Granit.Testing.Persistence.ConformanceDbContext).IsSoftDeleteFilterEnabled) OrElse Not(Property(e, "IsDeleted")))
+  ConformanceToggle[Active]: e => (Not(value(Granit.Testing.Persistence.ConformanceDbContext).IsActiveFilterEnabled) OrElse Property(e, "Activated"))

--- a/tests/Granit.ArchitectureTests/ModelSnapshots/Granit.Timeline.EntityFrameworkCore.Internal.TimelineDbContext.snap
+++ b/tests/Granit.ArchitectureTests/ModelSnapshots/Granit.Timeline.EntityFrameworkCore.Internal.TimelineDbContext.snap
@@ -1,0 +1,185 @@
+Model: 
+  EntityType: Reaction
+    Properties: 
+      Id (Guid) Required PK AfterSave:Throw ValueGenerated.OnAdd
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      CreatedAt (DateTimeOffset) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      CreatedBy (string) Required MaxLength(256)
+        Annotations: 
+          MaxLength: 256
+          Npgsql:ValueGenerationStrategy: None
+      Emoji (string) Required Index MaxLength(64)
+        Annotations: 
+          MaxLength: 64
+          Npgsql:ValueGenerationStrategy: None
+      EntryId (Guid) Required FK Index
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      TenantId (Guid?) Index
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      UserId (Guid) Required Index
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+    Keys: 
+      Id PK
+    Foreign keys: 
+      Reaction {'EntryId'} -> TimelineEntry {'Id'} Required Cascade
+    Indexes: 
+      EntryId, TenantId
+        Annotations: 
+          Relational:Name: ix_timeline_reactions_by_entry
+      EntryId, UserId, Emoji Unique
+        Annotations: 
+          Relational:Name: ix_timeline_reactions_unique
+    Annotations: 
+      QueryFilter: Microsoft.EntityFrameworkCore.Metadata.Internal.QueryFilterCollection
+      Relational:FunctionName: 
+      Relational:Schema: 
+      Relational:SqlQuery: 
+      Relational:TableName: timeline_reactions
+      Relational:ViewName: 
+      Relational:ViewSchema: 
+  EntityType: TimelineAttachment
+    Properties: 
+      Id (Guid) Required PK AfterSave:Throw ValueGenerated.OnAdd
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      BlobId (Guid) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      ContentType (string) Required MaxLength(256)
+        Annotations: 
+          MaxLength: 256
+          Npgsql:ValueGenerationStrategy: None
+      CreatedAt (DateTimeOffset) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      CreatedBy (string) Required MaxLength(256)
+        Annotations: 
+          MaxLength: 256
+          Npgsql:ValueGenerationStrategy: None
+      EntryId (Guid) Required Index
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      FileName (string) Required MaxLength(512)
+        Annotations: 
+          MaxLength: 512
+          Npgsql:ValueGenerationStrategy: None
+      SizeBytes (long) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      TenantId (Guid?) Index
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+    Keys: 
+      Id PK
+    Indexes: 
+      EntryId, TenantId
+        Annotations: 
+          Relational:Name: ix_timeline_attachments_entry
+    Annotations: 
+      QueryFilter: Microsoft.EntityFrameworkCore.Metadata.Internal.QueryFilterCollection
+      Relational:FunctionName: 
+      Relational:Schema: 
+      Relational:SqlQuery: 
+      Relational:TableName: timeline_attachments
+      Relational:ViewName: 
+      Relational:ViewSchema: 
+  EntityType: TimelineEntry
+    Properties: 
+      Id (Guid) Required PK AfterSave:Throw ValueGenerated.OnAdd
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      AuthorId (string) Required MaxLength(256)
+        Annotations: 
+          MaxLength: 256
+          Npgsql:ValueGenerationStrategy: None
+      AuthorName (string) Required MaxLength(512)
+        Annotations: 
+          MaxLength: 512
+          Npgsql:ValueGenerationStrategy: None
+      Body (string) Required MaxLength(65536)
+        Annotations: 
+          MaxLength: 65536
+          Npgsql:ValueGenerationStrategy: None
+      CreatedAt (DateTimeOffset) Required Index
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      CreatedBy (string) Required MaxLength(256)
+        Annotations: 
+          MaxLength: 256
+          Npgsql:ValueGenerationStrategy: None
+      DeletedAt (DateTimeOffset?)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      DeletedBy (string) MaxLength(256)
+        Annotations: 
+          MaxLength: 256
+          Npgsql:ValueGenerationStrategy: None
+      EditedAt (DateTimeOffset?)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      EntityId (string) Required Index MaxLength(256)
+        Annotations: 
+          MaxLength: 256
+          Npgsql:ValueGenerationStrategy: None
+      EntityType (string) Required Index MaxLength(256)
+        Annotations: 
+          MaxLength: 256
+          Npgsql:ValueGenerationStrategy: None
+      EntryType (TimelineEntryType) Required MaxLength(20)
+        Annotations: 
+          MaxLength: 20
+          Npgsql:ValueGenerationStrategy: None
+      IsDeleted (bool) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      ParentEntryId (Guid?) Index
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      SourceId (string) Index MaxLength(128)
+        Annotations: 
+          MaxLength: 128
+          Npgsql:ValueGenerationStrategy: None
+      SourceKey (string) Index MaxLength(64)
+        Annotations: 
+          MaxLength: 64
+          Npgsql:ValueGenerationStrategy: None
+      TenantId (Guid?) Index
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+    Keys: 
+      Id PK
+    Indexes: 
+      ParentEntryId
+        Annotations: 
+          Relational:Name: ix_timeline_entries_parent
+      EntityType, EntityId, TenantId, CreatedAt
+        Annotations: 
+          Relational:Name: ix_timeline_entries_entity_stream
+      TenantId, EntityType, EntityId, SourceKey, SourceId Unique
+        Annotations: 
+          Relational:Filter: "SourceKey" IS NOT NULL
+          Relational:Name: ux_timeline_entries_shadow
+    Annotations: 
+      QueryFilter: Microsoft.EntityFrameworkCore.Metadata.Internal.QueryFilterCollection
+      Relational:FunctionName: 
+      Relational:Schema: 
+      Relational:SqlQuery: 
+      Relational:TableName: timeline_entries
+      Relational:ViewName: 
+      Relational:ViewSchema: 
+Annotations: 
+  Npgsql:ValueGenerationStrategy: IdentityByDefaultColumn
+  ProductVersion: 10.0.10
+  Relational:MaxIdentifierLength: 63
+
+Query filters:
+  Reaction[MultiTenant]: e => (Not(value(Granit.Timeline.EntityFrameworkCore.Internal.TimelineDbContext).IsMultiTenantFilterEnabled) OrElse (Property(e, "TenantId") == value(Granit.Timeline.EntityFrameworkCore.Internal.TimelineDbContext).CurrentTenantId))
+  TimelineAttachment[MultiTenant]: e => (Not(value(Granit.Timeline.EntityFrameworkCore.Internal.TimelineDbContext).IsMultiTenantFilterEnabled) OrElse (Property(e, "TenantId") == value(Granit.Timeline.EntityFrameworkCore.Internal.TimelineDbContext).CurrentTenantId))
+  TimelineEntry[MultiTenant]: e => (Not(value(Granit.Timeline.EntityFrameworkCore.Internal.TimelineDbContext).IsMultiTenantFilterEnabled) OrElse (Property(e, "TenantId") == value(Granit.Timeline.EntityFrameworkCore.Internal.TimelineDbContext).CurrentTenantId))
+  TimelineEntry[SoftDelete]: e => (Not(value(Granit.Timeline.EntityFrameworkCore.Internal.TimelineDbContext).IsSoftDeleteFilterEnabled) OrElse Not(Property(e, "IsDeleted")))

--- a/tests/Granit.ArchitectureTests/ModelSnapshots/Granit.Webhooks.EntityFrameworkCore.Internal.WebhooksDbContext.snap
+++ b/tests/Granit.ArchitectureTests/ModelSnapshots/Granit.Webhooks.EntityFrameworkCore.Internal.WebhooksDbContext.snap
@@ -1,0 +1,195 @@
+Model: 
+  EntityType: WebhookDeliveryAttempt
+    Properties: 
+      Id (Guid) Required PK AfterSave:Throw ValueGenerated.OnAdd
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      DeliveryId (Guid) Required Index
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      DurationMs (long) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      ErrorMessage (string) MaxLength(2000)
+        Annotations: 
+          MaxLength: 2000
+          Npgsql:ValueGenerationStrategy: None
+      EventType (string) Required MaxLength(200)
+        Annotations: 
+          MaxLength: 200
+          Npgsql:ValueGenerationStrategy: None
+      HttpStatusCode (int?)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      IsSuccess (bool) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      OccurredAt (DateTimeOffset) Required Index
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      Payload (string)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+          Relational:ColumnType: text
+      PayloadHash (string) Required MaxLength(64)
+        Annotations: 
+          MaxLength: 64
+          Npgsql:ValueGenerationStrategy: None
+      SubscriptionId (Guid) Required Index
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      TargetUrl (string) Required MaxLength(2048)
+        Annotations: 
+          MaxLength: 2048
+          Npgsql:ValueGenerationStrategy: None
+      TenantId (Guid?) Index
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+    Keys: 
+      Id PK
+    Indexes: 
+      DeliveryId Unique
+        Annotations: 
+          Relational:Name: uq_webhooks_delivery_attempts_deliveryid
+      SubscriptionId, OccurredAt
+        Annotations: 
+          Relational:Name: ix_webhooks_delivery_attempts_subscriptionid_occurredat
+      TenantId, OccurredAt
+        Annotations: 
+          Relational:Name: ix_webhooks_delivery_attempts_tenantid_occurredat
+    Annotations: 
+      QueryFilter: Microsoft.EntityFrameworkCore.Metadata.Internal.QueryFilterCollection
+      Relational:FunctionName: 
+      Relational:Schema: 
+      Relational:SqlQuery: 
+      Relational:TableName: webhooks_delivery_attempts
+      Relational:ViewName: 
+      Relational:ViewSchema: 
+  EntityType: WebhookSigningKey
+    Properties: 
+      Id (Guid) Required PK AfterSave:Throw ValueGenerated.OnAdd
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      CreatedAt (DateTimeOffset) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      ExpiresAt (DateTimeOffset?) Index
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      LastRotationNotificationAt (DateTimeOffset?)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      ProtectedSecret (string) Required MaxLength(1000)
+        Annotations: 
+          MaxLength: 1000
+          Npgsql:ValueGenerationStrategy: None
+      RevokedAt (DateTimeOffset?)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      Status (WebhookSigningKeyStatus) Required Index ValueGenerated.OnAdd MaxLength(20)
+        Annotations: 
+          MaxLength: 20
+          Npgsql:ValueGenerationStrategy: None
+          Relational:DefaultValue: Active
+      SubscriptionId (Guid) Required FK Index
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+    Keys: 
+      Id PK
+    Foreign keys: 
+      WebhookSigningKey {'SubscriptionId'} -> WebhookSubscription {'Id'} Required Cascade ToDependent: SigningKeys
+    Indexes: 
+      ExpiresAt
+        Annotations: 
+          Relational:Name: ix_webhooks_signing_keys_expires_at
+      SubscriptionId, Status
+        Annotations: 
+          Relational:Name: ix_webhooks_signing_keys_subscription_status
+    Annotations: 
+      Relational:FunctionName: 
+      Relational:Schema: 
+      Relational:SqlQuery: 
+      Relational:TableName: webhooks_signing_keys
+      Relational:ViewName: 
+      Relational:ViewSchema: 
+  EntityType: WebhookSubscription
+    Properties: 
+      Id (Guid) Required PK AfterSave:Throw ValueGenerated.OnAdd
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      ConsecutiveFailureCount (int) Required ValueGenerated.OnAdd
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+          Relational:DefaultValue: 0
+      CreatedAt (DateTimeOffset) Required
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      CreatedBy (string) Required MaxLength(450)
+        Annotations: 
+          MaxLength: 450
+          Npgsql:ValueGenerationStrategy: None
+      DeactivationReason (string) MaxLength(500)
+        Annotations: 
+          MaxLength: 500
+          Npgsql:ValueGenerationStrategy: None
+      EventType (string) Required Index MaxLength(200)
+        Annotations: 
+          MaxLength: 200
+          Npgsql:ValueGenerationStrategy: None
+      LastSuccessAt (DateTimeOffset?)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      ModifiedAt (DateTimeOffset?)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      ModifiedBy (string) MaxLength(450)
+        Annotations: 
+          MaxLength: 450
+          Npgsql:ValueGenerationStrategy: None
+      SigningSecretHint (string) MaxLength(32)
+        Annotations: 
+          MaxLength: 32
+          Npgsql:ValueGenerationStrategy: None
+      Status (WebhookSubscriptionStatus) Required Index ValueGenerated.OnAdd MaxLength(20)
+        Annotations: 
+          MaxLength: 20
+          Npgsql:ValueGenerationStrategy: None
+          Relational:DefaultValue: Active
+      SuspendedAt (DateTimeOffset?)
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+      SuspendedBy (string) MaxLength(450)
+        Annotations: 
+          MaxLength: 450
+          Npgsql:ValueGenerationStrategy: None
+      TargetUrl (HttpsUrl) Required MaxLength(2048)
+        Annotations: 
+          MaxLength: 2048
+          Npgsql:ValueGenerationStrategy: None
+      TenantId (Guid?) Index
+        Annotations: 
+          Npgsql:ValueGenerationStrategy: None
+    Navigations: 
+      SigningKeys (_signingKeys, IReadOnlyList<WebhookSigningKey>) Collection ToDependent WebhookSigningKey PropertyAccessMode.Field
+    Keys: 
+      Id PK
+    Indexes: 
+      EventType, TenantId, Status
+        Annotations: 
+          Relational:Name: ix_webhooks_subscriptions_eventtype_tenantid_status
+    Annotations: 
+      QueryFilter: Microsoft.EntityFrameworkCore.Metadata.Internal.QueryFilterCollection
+      Relational:FunctionName: 
+      Relational:Schema: 
+      Relational:SqlQuery: 
+      Relational:TableName: webhooks_subscriptions
+      Relational:ViewName: 
+      Relational:ViewSchema: 
+Annotations: 
+  Npgsql:ValueGenerationStrategy: IdentityByDefaultColumn
+  ProductVersion: 10.0.10
+  Relational:MaxIdentifierLength: 63
+
+Query filters:
+  WebhookDeliveryAttempt[MultiTenant]: e => (Not(value(Granit.Webhooks.EntityFrameworkCore.Internal.WebhooksDbContext).IsMultiTenantFilterEnabled) OrElse (Property(e, "TenantId") == value(Granit.Webhooks.EntityFrameworkCore.Internal.WebhooksDbContext).CurrentTenantId))
+  WebhookSubscription[MultiTenant]: e => (Not(value(Granit.Webhooks.EntityFrameworkCore.Internal.WebhooksDbContext).IsMultiTenantFilterEnabled) OrElse (Property(e, "TenantId") == value(Granit.Webhooks.EntityFrameworkCore.Internal.WebhooksDbContext).CurrentTenantId))

--- a/tests/Granit.ArchitectureTests/packages.lock.json
+++ b/tests/Granit.ArchitectureTests/packages.lock.json
@@ -40,6 +40,17 @@
           "Microsoft.TestPlatform.TestHost": "18.8.1"
         }
       },
+      "Npgsql.EntityFrameworkCore.PostgreSQL": {
+        "type": "Direct",
+        "requested": "[10.*, )",
+        "resolved": "10.0.3",
+        "contentHash": "IPGrrZnRkuW7OlHDhUESZz4G5DLkW7Nej/O3Cx+0iTsgyU5XJxBgpsvTHLloo3WWuAKKbDHXBvWPVkX1deRh1Q==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore": "[10.0.4, 11.0.0)",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.0.4, 11.0.0)",
+          "Npgsql": "10.0.3"
+        }
+      },
       "Roslynator.Analyzers": {
         "type": "Direct",
         "requested": "[4.15.*, )",
@@ -5123,17 +5134,6 @@
         "requested": "[2.*, )",
         "resolved": "2.5.0",
         "contentHash": "5/+2O2ADomEdUn09mlSigACdqvAf0m/pVPGtIPEPQWnyrVykYY0NlfXLIdkMgi41kvH9kNrPqYaFBTZtHYH7Xw=="
-      },
-      "Npgsql.EntityFrameworkCore.PostgreSQL": {
-        "type": "CentralTransitive",
-        "requested": "[10.*, )",
-        "resolved": "10.0.3",
-        "contentHash": "IPGrrZnRkuW7OlHDhUESZz4G5DLkW7Nej/O3Cx+0iTsgyU5XJxBgpsvTHLloo3WWuAKKbDHXBvWPVkX1deRh1Q==",
-        "dependencies": {
-          "Microsoft.EntityFrameworkCore": "[10.0.4, 11.0.0)",
-          "Microsoft.EntityFrameworkCore.Relational": "[10.0.4, 11.0.0)",
-          "Npgsql": "10.0.3"
-        }
       },
       "Npgsql.OpenTelemetry": {
         "type": "CentralTransitive",


### PR DESCRIPTION
Closes #3157 — first story of Phase 2 (#3146, epic #3143). Pure test infrastructure, zero behavior change.

## What this does

`ModelSnapshotTests` (in `Granit.ArchitectureTests`, which already references every src assembly): all **33 DbContexts** in `src/` — public and internal — build their EF Core model offline against the Npgsql provider (no connection), and the full `ToDebugString(LongDefault)` is compared **byte-for-byte** against committed baselines under `ModelSnapshots/` (208K total). This is the equivalence proof the Phase 2 convention-engine rewrite (#3158/#3159) runs under: any model drift is a red test with a reviewable diff.

## Key detail: named filters made diffable

`ToDebugString` prints only the query-filter collection *type*, not the expressions — and the named filters are half the convention surface Phase 2 must keep identical. The harness appends every named filter's expression explicitly (entity × filter name, ordinal order); the `this`-bound bypass shapes from #3178 are fully visible:

```text
ConformanceOrder[MultiTenant]: e => (Not(value(...).IsMultiTenantFilterEnabled) OrElse (Property(e, "TenantId") == value(...).CurrentTenantId))
ConformanceOrder[SoftDelete]:  e => (Not(value(...).IsSoftDeleteFilterEnabled) OrElse Not(Property(e, "IsDeleted")))
```

## Harness mechanics

- **Constructor resolver**: `DbContextOptions<T>`, `GranitDesignTime` tenant/data-filter stubs, a passthrough `IStringEncryptionService` (converter model shape is instance-independent — keeps the 5 encrypted-column contexts *inside* the guarantee instead of exempting them), a canonical `IndexingDbContextSchema`, and genuine parameter defaults. An unresolvable dependency is an explicit error pointing at the justified `Unbuildable` exemption set — **currently empty: all 33 contexts build**.
- **Regeneration**: `GRANIT_MODEL_SNAPSHOTS=regen dotnet test tests/Granit.ArchitectureTests --filter ModelSnapshot` (the failure message says exactly this). Guards for stale exemptions and orphan snapshot files keep the suite honest as contexts are added/renamed.
- **Determinism**: proven across separate processes (two assert-mode runs identical) plus an in-run double-build fact.

## Verification

- Architecture shard **642/642** (606 prior + 36 new).
- Regen → assert → assert: stable. `dotnet format` clean.
- `Npgsql.EntityFrameworkCore.PostgreSQL` added to the ArchitectureTests project only (already centrally versioned — no `Directory.Packages.props` change, single lock file regenerated, no repo-wide sweep needed).

Next in Phase 2: #3158 — native EF Core conventions implemented in parallel, flag-gated, validated against these baselines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)