### PR TITLE
feat(persistence): native EF Core convention engine, parallel and parity-gated

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -44680,7 +44680,7 @@
       "kind": "class",
       "project": "Granit.Persistence.EntityFrameworkCore",
       "file": "src/Granit.Persistence.EntityFrameworkCore/GranitDbContext.cs",
-      "line": 48,
+      "line": 49,
       "members": [
         {
           "name": "IsMultiTenantFilterEnabled",

--- a/src/Granit.Persistence.EntityFrameworkCore/Conventions/GranitConcurrencyStampConvention.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/Conventions/GranitConcurrencyStampConvention.cs
@@ -1,0 +1,40 @@
+using Granit.Domain;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Microsoft.EntityFrameworkCore.Metadata.Conventions;
+
+namespace Granit.Persistence.EntityFrameworkCore.Conventions;
+
+/// <summary>
+/// Native form of the concurrency-stamp pass (#3158): <see cref="IConcurrencyAware"/>
+/// entities get <c>ConcurrencyStamp</c> as a VARCHAR(36) concurrency token.
+/// </summary>
+internal sealed class GranitConcurrencyStampConvention : IModelFinalizingConvention
+{
+    public void ProcessModelFinalizing(
+        IConventionModelBuilder modelBuilder,
+        IConventionContext<IConventionModelBuilder> context)
+    {
+        foreach (IConventionEntityType entityType in modelBuilder.Metadata.GetEntityTypes())
+        {
+            if (!typeof(IConcurrencyAware).IsAssignableFrom(entityType.ClrType))
+            {
+                continue;
+            }
+
+            IConventionProperty? stamp = entityType.FindProperty(nameof(IConcurrencyAware.ConcurrencyStamp));
+            if (stamp is null)
+            {
+                continue;
+            }
+
+            // Parity with the legacy pass, which uses the explicit Fluent API and therefore
+            // ALWAYS pins VARCHAR(36) — even over an entity configuration's own value. The
+            // mutable surface writes with explicit configuration source; a convention-source
+            // set would be refused. Revisit the stomp itself in the Phase 3 cleanup.
+            var mutableStamp = (IMutableProperty)stamp;
+            mutableStamp.SetMaxLength(36);
+            mutableStamp.IsConcurrencyToken = true;
+        }
+    }
+}

--- a/src/Granit.Persistence.EntityFrameworkCore/Conventions/GranitEnumStringConvention.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/Conventions/GranitEnumStringConvention.cs
@@ -1,0 +1,60 @@
+using System.Reflection;
+using Granit.Domain;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Microsoft.EntityFrameworkCore.Metadata.Conventions;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+
+namespace Granit.Persistence.EntityFrameworkCore.Conventions;
+
+/// <summary>
+/// Native form of the enum-as-string pass of <c>ApplyGranitConventionsCore</c> (#3158):
+/// every enum property persists as its PascalCase name in a varchar sized to the longest
+/// value (min 20). Explicit <c>HasConversion</c>/<c>[PersistAsInt]</c>/<c>[Flags]</c>
+/// opt-outs match the legacy pass; explicit configuration wins via configuration sources.
+/// </summary>
+internal sealed class GranitEnumStringConvention : IModelFinalizingConvention
+{
+    public void ProcessModelFinalizing(
+        IConventionModelBuilder modelBuilder,
+        IConventionContext<IConventionModelBuilder> context)
+    {
+        foreach (IConventionEntityType entityType in modelBuilder.Metadata.GetEntityTypes())
+        {
+            foreach (IConventionProperty property in entityType.GetDeclaredProperties())
+            {
+                Apply(property);
+            }
+        }
+    }
+
+    private static void Apply(IConventionProperty property)
+    {
+        Type underlying = Nullable.GetUnderlyingType(property.ClrType) ?? property.ClrType;
+        if (!underlying.IsEnum)
+        {
+            return;
+        }
+
+        // Same guards as the legacy pass: an explicit converter or provider CLR type wins.
+        if (property.GetValueConverter() is not null || property.GetProviderClrType() is not null)
+        {
+            return;
+        }
+
+        if (property.PropertyInfo?.GetCustomAttribute<PersistAsIntAttribute>() is not null
+            || underlying.GetCustomAttribute<FlagsAttribute>() is not null)
+        {
+            return;
+        }
+
+        Type converterType = typeof(EnumToStringConverter<>).MakeGenericType(underlying);
+        property.SetValueConverter((ValueConverter)Activator.CreateInstance(converterType)!);
+
+        if (property.GetMaxLength() is null)
+        {
+            int longestName = Enum.GetNames(underlying).Max(name => name.Length);
+            property.SetMaxLength(Math.Max(20, longestName + 4));
+        }
+    }
+}

--- a/src/Granit.Persistence.EntityFrameworkCore/Conventions/GranitMergeTombstoneConvention.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/Conventions/GranitMergeTombstoneConvention.cs
@@ -1,0 +1,36 @@
+using Granit.Domain;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Microsoft.EntityFrameworkCore.Metadata.Conventions;
+
+namespace Granit.Persistence.EntityFrameworkCore.Conventions;
+
+/// <summary>
+/// Native form of the merge-tombstone pass (#3158): <see cref="IHasMergeTombstone"/>
+/// entities get <c>MergedIntoId</c>/<c>MergedAt</c> columns and an index on
+/// <c>MergedIntoId</c> ("who merged into X" lookups + admin tombstone listings).
+/// </summary>
+internal sealed class GranitMergeTombstoneConvention : IModelFinalizingConvention
+{
+    public void ProcessModelFinalizing(
+        IConventionModelBuilder modelBuilder,
+        IConventionContext<IConventionModelBuilder> context)
+    {
+        foreach (IConventionEntityType entityType in modelBuilder.Metadata.GetEntityTypes())
+        {
+            if (!typeof(IHasMergeTombstone).IsAssignableFrom(entityType.ClrType))
+            {
+                continue;
+            }
+
+            IConventionProperty? mergedInto =
+                entityType.Builder.Property(typeof(Guid?), nameof(IHasMergeTombstone.MergedIntoId))?.Metadata;
+            entityType.Builder.Property(typeof(DateTimeOffset?), "MergedAt");
+
+            if (mergedInto is not null && entityType.FindIndex([mergedInto]) is null)
+            {
+                entityType.Builder.HasIndex([mergedInto]);
+            }
+        }
+    }
+}

--- a/src/Granit.Persistence.EntityFrameworkCore/Conventions/GranitNativeConventions.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/Conventions/GranitNativeConventions.cs
@@ -1,0 +1,17 @@
+namespace Granit.Persistence.EntityFrameworkCore.Conventions;
+
+/// <summary>
+/// Test-only gate for the native EF Core convention engine (#3158, overhaul Phase 2).
+/// While the parallel implementation is validated against the golden-model baselines,
+/// the legacy <c>ApplyGranitConventionsCore</c> pipeline stays the production path;
+/// the flip (#3159) removes this switch.
+/// </summary>
+internal static class GranitNativeConventions
+{
+    /// <summary>AppContext switch name enabling the native engine on GranitDbContext.</summary>
+    public const string SwitchName = "Granit.Persistence.NativeConventions";
+
+    /// <summary><c>true</c> when the native convention engine is enabled.</summary>
+    public static bool Enabled =>
+        AppContext.TryGetSwitch(SwitchName, out bool enabled) && enabled;
+}

--- a/src/Granit.Persistence.EntityFrameworkCore/Conventions/GranitOwnershipIndexConvention.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/Conventions/GranitOwnershipIndexConvention.cs
@@ -1,0 +1,71 @@
+using Granit.Domain;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Microsoft.EntityFrameworkCore.Metadata.Conventions;
+
+namespace Granit.Persistence.EntityFrameworkCore.Conventions;
+
+/// <summary>
+/// Native form of the ownership-index pass (#3158): <see cref="IOwnable"/> entities get a
+/// composite index on <c>(TenantId, OwnerId)</c> when also <see cref="IMultiTenant"/>, or on
+/// <c>(OwnerId)</c> alone — named <c>ix_{table}_{tenant_owner|owner}</c>. De-duplicates
+/// against an existing index over the exact same property set.
+/// </summary>
+internal sealed class GranitOwnershipIndexConvention : IModelFinalizingConvention
+{
+    public void ProcessModelFinalizing(
+        IConventionModelBuilder modelBuilder,
+        IConventionContext<IConventionModelBuilder> context)
+    {
+        foreach (IConventionEntityType entityType in modelBuilder.Metadata.GetEntityTypes())
+        {
+            if (!typeof(IOwnable).IsAssignableFrom(entityType.ClrType))
+            {
+                continue;
+            }
+
+            string? tableName = entityType.GetTableName();
+            if (tableName is null)
+            {
+                continue; // Keyless / TPH-derived / view-mapped — no own table to index.
+            }
+
+            bool isMultiTenant = typeof(IMultiTenant).IsAssignableFrom(entityType.ClrType);
+            string[] propertyNames = isMultiTenant
+                ? [nameof(IMultiTenant.TenantId), nameof(IOwnable.OwnerId)]
+                : [nameof(IOwnable.OwnerId)];
+
+            List<IConventionProperty> properties = [];
+            foreach (string name in propertyNames)
+            {
+                IConventionProperty? property = entityType.FindProperty(name);
+                if (property is null)
+                {
+                    properties.Clear();
+                    break;
+                }
+
+                properties.Add(property);
+            }
+
+            if (properties.Count == 0)
+            {
+                continue;
+            }
+
+            bool alreadyIndexed = entityType.GetIndexes().Any(idx =>
+                idx.Properties.Count == propertyNames.Length
+                && idx.Properties.Select(p => p.Name).SequenceEqual(propertyNames));
+
+            if (alreadyIndexed)
+            {
+                continue;
+            }
+
+            string suffix = isMultiTenant ? "tenant_owner" : "owner";
+            entityType.Builder.HasIndex(properties)
+                ?.Metadata.SetDatabaseName($"ix_{tableName}_{suffix}");
+        }
+    }
+}

--- a/src/Granit.Persistence.EntityFrameworkCore/Conventions/GranitTranslationConvention.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/Conventions/GranitTranslationConvention.cs
@@ -1,0 +1,70 @@
+using Granit.Domain;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Microsoft.EntityFrameworkCore.Metadata.Conventions;
+
+namespace Granit.Persistence.EntityFrameworkCore.Conventions;
+
+/// <summary>
+/// Native form of the translation pass (#3158), non-filter half: for every
+/// <see cref="ITranslation{TParent}"/> entity — FK <c>ParentId → Parent.Id</c> with cascade
+/// delete, unique index on <c>(ParentId, Culture)</c>, and <c>Culture</c> capped at 20 chars
+/// (BCP 47). The soft-delete/active filter mirrors stay in <c>GranitDbContext</c>
+/// (this-bound, #3178).
+/// </summary>
+internal sealed class GranitTranslationConvention : IModelFinalizingConvention
+{
+    public void ProcessModelFinalizing(
+        IConventionModelBuilder modelBuilder,
+        IConventionContext<IConventionModelBuilder> context)
+    {
+        foreach (IConventionEntityType entityType in modelBuilder.Metadata.GetEntityTypes().ToList())
+        {
+            Type? translationInterface = entityType.ClrType
+                .GetInterfaces()
+                .FirstOrDefault(i => i.IsGenericType
+                    && i.GetGenericTypeDefinition() == typeof(ITranslation<>));
+
+            if (translationInterface is null)
+            {
+                continue;
+            }
+
+            IConventionProperty? culture = entityType.FindProperty(nameof(ITranslation.Culture));
+            if (culture is not null)
+            {
+                if (culture.GetMaxLength() is null)
+                {
+                    culture.SetMaxLength(20);
+                }
+
+                culture.SetIsNullable(false);
+            }
+
+            Type parentType = translationInterface.GetGenericArguments()[0];
+            IConventionEntityType? parentEntityType = modelBuilder.Metadata.FindEntityType(parentType);
+            IConventionProperty? parentId = entityType.FindProperty(nameof(ITranslation.ParentId));
+
+            if (parentEntityType is not null && parentId is not null)
+            {
+                IConventionForeignKeyBuilder? fkBuilder = entityType.Builder.HasRelationship(
+                    parentEntityType, [parentId], parentEntityType.FindPrimaryKey()!);
+                fkBuilder?.Metadata.SetDeleteBehavior(Microsoft.EntityFrameworkCore.DeleteBehavior.Cascade);
+                fkBuilder?.Metadata.SetDependentToPrincipal(
+                    entityType.ClrType.GetProperty(nameof(ITranslation<Entity>.Parent)));
+            }
+
+            IConventionProperty? cultureProperty = entityType.FindProperty(nameof(ITranslation.Culture));
+            if (parentId is not null && cultureProperty is not null)
+            {
+                IConventionProperty[] indexProperties = [parentId, cultureProperty];
+                bool exists = entityType.GetIndexes().Any(i =>
+                    i.Properties.Select(p => p.Name).SequenceEqual(indexProperties.Select(p => p.Name)));
+                if (!exists)
+                {
+                    entityType.Builder.HasIndex(indexProperties)?.Metadata.SetIsUnique(true);
+                }
+            }
+        }
+    }
+}

--- a/src/Granit.Persistence.EntityFrameworkCore/Extensions/ModelBuilderExtensions.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/Extensions/ModelBuilderExtensions.cs
@@ -239,6 +239,20 @@ public static class ModelBuilderExtensions
         return modelBuilder;
     }
 
+    /// <summary>
+    /// Value-object trio only (QueryableValueObject mappings, phantom removal, SVO/JSON
+    /// converters) — the passes not yet nativized as EF Core conventions. Called by
+    /// <see cref="GranitDbContext"/> in native-conventions mode (#3158) while the other
+    /// passes run as <c>IModelFinalizingConvention</c>s; disappears with the flip (#3159).
+    /// </summary>
+    internal static ModelBuilder ApplyGranitValueObjectPasses(this ModelBuilder modelBuilder)
+    {
+        ApplyQueryableValueObjectMappings(modelBuilder);
+        RemoveValueObjectEntityTypes(modelBuilder);
+        ApplySingleValueObjectConverters(modelBuilder);
+        return modelBuilder;
+    }
+
     // Adds an automatic composite index on (TenantId, OwnerId) for IOwnable + IMultiTenant
     // entities, or on (OwnerId) alone otherwise. Uses the Fluent API
     // modelBuilder.Entity(...).HasIndex(...) rather than the low-level

--- a/src/Granit.Persistence.EntityFrameworkCore/GranitDbContext.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/GranitDbContext.cs
@@ -3,6 +3,7 @@ using System.Reflection;
 using Granit.DataFiltering;
 using Granit.Domain;
 using Granit.MultiTenancy;
+using Granit.Persistence.EntityFrameworkCore.Conventions;
 using Granit.Persistence.EntityFrameworkCore.Extensions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
@@ -193,13 +194,21 @@ public abstract class GranitDbContext : DbContext
             }
         }
 
-        // 3) Non-filter conventions: concurrency + merge tombstone columns + ownership
-        //    indexes + translation FKs + enum-as-string + SVO entity removal & converters.
-        //    `currentTenant: null` skips the IMultiTenant block; `registerConventionFilters:
-        //    false` skips the proxy-based named filters — this class owns ALL filters,
-        //    with parameterised bypass flags (steps 2 / 2-bis). Runs LAST so the SVO
-        //    cleanup is the final pass over the model surface.
-        modelBuilder.ApplyGranitConventionsCore(currentTenant: null, DataFilter, registerConventionFilters: false);
+        // 3) Non-filter conventions. `currentTenant: null` skips the IMultiTenant block;
+        //    `registerConventionFilters: false` skips the proxy-based named filters — this
+        //    class owns ALL filters, with parameterised bypass flags (steps 2 / 2-bis).
+        //    Runs LAST so the SVO cleanup is the final pass over the model surface.
+        //    Native-conventions mode (#3158, test-gated): the scalar passes run as
+        //    IModelFinalizingConventions (see OnGranitConfigureConventionsCore) and only
+        //    the value-object trio still executes here.
+        if (GranitNativeConventions.Enabled)
+        {
+            modelBuilder.ApplyGranitValueObjectPasses();
+        }
+        else
+        {
+            modelBuilder.ApplyGranitConventionsCore(currentTenant: null, DataFilter, registerConventionFilters: false);
+        }
 
         // 4) External, opt-in model extensions registered in DI by separate packages — applied LAST so they
         //    get the final say (after conventions). Lets e.g. a PostGIS package add a generated geography
@@ -241,6 +250,39 @@ public abstract class GranitDbContext : DbContext
     /// conventions on either side.
     /// </summary>
     protected virtual void OnGranitModelCreating(ModelBuilder modelBuilder)
+    {
+        // No-op by default.
+    }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Sealed for the same ordering reasons as <see cref="OnModelCreating"/>. In
+    /// native-conventions mode (#3158, test-gated) the scalar Granit passes (enum-as-string,
+    /// concurrency stamp, merge tombstone, ownership indexes, translation config) run as
+    /// <c>IModelFinalizingConvention</c>s. Derived contexts extend via
+    /// <see cref="OnGranitConfigureConventions"/>.
+    /// </remarks>
+    protected sealed override void ConfigureConventions(ModelConfigurationBuilder configurationBuilder)
+    {
+        base.ConfigureConventions(configurationBuilder);
+
+        if (GranitNativeConventions.Enabled)
+        {
+            configurationBuilder.Conventions.Add(_ => new GranitEnumStringConvention());
+            configurationBuilder.Conventions.Add(_ => new GranitConcurrencyStampConvention());
+            configurationBuilder.Conventions.Add(_ => new GranitMergeTombstoneConvention());
+            configurationBuilder.Conventions.Add(_ => new GranitOwnershipIndexConvention());
+            configurationBuilder.Conventions.Add(_ => new GranitTranslationConvention());
+        }
+
+        OnGranitConfigureConventions(configurationBuilder);
+    }
+
+    /// <summary>
+    /// Override point for derived classes that need additional model-configuration
+    /// conventions; the Granit set is always registered first.
+    /// </summary>
+    protected virtual void OnGranitConfigureConventions(ModelConfigurationBuilder configurationBuilder)
     {
         // No-op by default.
     }

--- a/tests/Granit.ArchitectureTests/ModelSnapshotNativeParityTests.cs
+++ b/tests/Granit.ArchitectureTests/ModelSnapshotNativeParityTests.cs
@@ -1,0 +1,61 @@
+using Granit.Persistence.EntityFrameworkCore;
+using Shouldly;
+using Xunit;
+
+namespace Granit.ArchitectureTests;
+
+/// <summary>Serialises every test class that flips the native-conventions switch or builds snapshot models.</summary>
+[CollectionDefinition(Name)]
+public sealed class ModelSnapshotSerialGroup
+{
+    /// <summary>Collection name.</summary>
+    public const string Name = "model-snapshots";
+}
+
+/// <summary>
+/// Phase 2 parity gate (#3158): every DbContext builds its model twice — legacy
+/// <c>ApplyGranitConventionsCore</c> pipeline vs the native convention engine
+/// (<c>Granit.Persistence.NativeConventions</c> AppContext switch) — and the two snapshots
+/// (full debug string + named filter expressions) must be bit-identical. The flip (#3159)
+/// happens only when this suite is green for all contexts.
+/// </summary>
+[Collection(ModelSnapshotSerialGroup.Name)]
+public sealed class ModelSnapshotNativeParityTests
+{
+    private const string SwitchName = "Granit.Persistence.NativeConventions";
+
+    public static TheoryData<string> GranitContexts()
+    {
+        TheoryData<string> data = [];
+        foreach (Type type in ModelSnapshotTests.EnumerateContextTypes()
+            .Where(t => typeof(GranitDbContext).IsAssignableFrom(t)))
+        {
+            data.Add(type.FullName!);
+        }
+
+        return data;
+    }
+
+    [Theory]
+    [MemberData(nameof(GranitContexts))]
+    public void Native_conventions_produce_an_identical_model(string contextTypeName)
+    {
+        Type contextType = ModelSnapshotTests.EnumerateContextTypes()
+            .Single(t => t.FullName == contextTypeName);
+
+        string legacy = ModelSnapshotTests.BuildSnapshot(contextType, freshInternalServices: true);
+
+        AppContext.SetSwitch(SwitchName, true);
+        try
+        {
+            string native = ModelSnapshotTests.BuildSnapshot(contextType, freshInternalServices: true);
+            native.ShouldBe(legacy,
+                $"{contextTypeName}: the native convention engine produced a different model "
+                + "than the legacy ApplyGranitConventionsCore pipeline.");
+        }
+        finally
+        {
+            AppContext.SetSwitch(SwitchName, false);
+        }
+    }
+}

--- a/tests/Granit.ArchitectureTests/ModelSnapshotTests.cs
+++ b/tests/Granit.ArchitectureTests/ModelSnapshotTests.cs
@@ -20,6 +20,7 @@ namespace Granit.ArchitectureTests;
 /// GRANIT_MODEL_SNAPSHOTS=regen dotnet test tests/Granit.ArchitectureTests --filter ModelSnapshot
 /// </code>
 /// </summary>
+[Collection(ModelSnapshotSerialGroup.Name)]
 public sealed class ModelSnapshotTests
 {
     private const string RegenEnvVar = "GRANIT_MODEL_SNAPSHOTS";
@@ -121,9 +122,9 @@ public sealed class ModelSnapshotTests
 
     // ── Harness ─────────────────────────────────────────────────────────
 
-    private static string BuildSnapshot(Type contextType)
+    internal static string BuildSnapshot(Type contextType, bool freshInternalServices = false)
     {
-        using DbContext context = CreateContext(contextType);
+        using DbContext context = CreateContext(contextType, freshInternalServices);
 
         // ToDebugString prints only the query-filter collection TYPE, not the expressions —
         // and the named filters are half the convention surface Phase 2 must keep identical.
@@ -148,13 +149,21 @@ public sealed class ModelSnapshotTests
         return Normalize(snapshot.ToString());
     }
 
-    private static DbContext CreateContext(Type contextType)
+    private static DbContext CreateContext(Type contextType, bool freshInternalServices = false)
     {
         var optionsBuilder = (DbContextOptionsBuilder)Activator.CreateInstance(
             typeof(DbContextOptionsBuilder<>).MakeGenericType(contextType))!;
         optionsBuilder
             .UseNpgsql("Host=snapshot;Database=snapshot;Username=snapshot;Password=snapshot")
             .ConfigureWarnings(w => w.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning));
+
+        if (freshInternalServices)
+        {
+            // Parity dual-builds flip a process-global switch between two builds of the SAME
+            // context type: a shared internal service provider would serve the first build's
+            // cached model to the second. A fresh provider isolates each build.
+            optionsBuilder.EnableServiceProviderCaching(false);
+        }
 
         ConstructorInfo constructor = contextType
             .GetConstructors(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
@@ -232,7 +241,7 @@ public sealed class ModelSnapshotTests
         public string? Decrypt(string cipherText) => cipherText;
     }
 
-    private static IEnumerable<Type> EnumerateContextTypes() =>
+    internal static IEnumerable<Type> EnumerateContextTypes() =>
         Directory.EnumerateFiles(AppContext.BaseDirectory, "Granit.*.dll")
             .Select(Path.GetFileNameWithoutExtension)
             .Order(StringComparer.Ordinal)


### PR DESCRIPTION
Closes #3158 — Phase 2 of the overhaul (#3146, epic #3143). **Zero production behavior change**: the native engine is gated behind a test-only AppContext switch until the flip (#3159).

## What this does

The five scalar passes of `ApplyGranitConventionsCore` become real `IModelFinalizingConvention`s under `Conventions/`:

- `GranitEnumStringConvention` — enum-as-string, varchar sized to longest value (min 20), `[PersistAsInt]`/`[Flags]`/explicit-conversion opt-outs preserved via configuration sources.
- `GranitConcurrencyStampConvention` — `ConcurrencyStamp` VARCHAR(36) concurrency token.
- `GranitMergeTombstoneConvention` — `MergedIntoId`/`MergedAt` columns + index.
- `GranitOwnershipIndexConvention` — `(TenantId, OwnerId)` / `(OwnerId)` indexes, de-duplicated, legacy naming.
- `GranitTranslationConvention` — FK + cascade + unique `(ParentId, Culture)` + culture length; the filter mirrors stay `this`-bound in `GranitDbContext` (#3178 — target design already).

Wiring: `GranitDbContext.ConfigureConventions` (sealed; no derived overrides existed; new `OnGranitConfigureConventions` extension point) registers them in native mode; `OnModelCreating` step 3 then runs only the **value-object trio** (`ApplyGranitValueObjectPasses`). VO nativization is deliberately scoped to the flip story — its discovery-time semantics carry the `OwnsOne`/`[QueryableValueObject]` carve-outs, and the parity gate now makes that later change safe.

## The parity gate

`ModelSnapshotNativeParityTests` dual-builds **every `GranitDbContext` (32)** — legacy vs native — with fresh internal service providers (the process-global switch cannot cross-pollinate cached models) and serialized against `ModelSnapshotTests` via a shared collection. **All 32 snapshots are bit-identical**, named-filter expressions included.

First run caught exactly one divergence, now documented in code: the legacy concurrency-stamp pass **always pins VARCHAR(36)**, even over an entity configuration's own value (explicit Fluent API). The native convention replicates the stomp for parity; revisiting it is flagged for the Phase 3 cleanup.

## Verification

- Parity 32/32; architecture shard **674/674** (642 + 32); `Granit.Persistence.EntityFrameworkCore.Tests` 405/405; format clean.
- No dependency changes (no lock-file impact).

Next: #3159 — the flip: native becomes the only path, VO trio nativized, legacy passes deleted, golden baselines re-validated unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)