### PR TITLE
refactor(persistence): single conventions path — remove the last redundant ApplyGranitConventions calls

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -35045,7 +35045,7 @@
       "kind": "class",
       "project": "Granit.Indexing.EntityFrameworkCore",
       "file": "src/Granit.Indexing.EntityFrameworkCore/IndexingDbContext.cs",
-      "line": 34,
+      "line": 33,
       "members": []
     },
     {
@@ -35054,7 +35054,7 @@
       "kind": "record",
       "project": "Granit.Indexing.EntityFrameworkCore",
       "file": "src/Granit.Indexing.EntityFrameworkCore/IndexingDbContext.cs",
-      "line": 74,
+      "line": 71,
       "members": []
     },
     {
@@ -46524,7 +46524,7 @@
       "kind": "class",
       "project": "Granit.Presence.EntityFrameworkCore",
       "file": "src/Granit.Presence.EntityFrameworkCore/Extensions/PresenceModelBuilderExtensions.cs",
-      "line": 11,
+      "line": 10,
       "members": [
         {
           "name": "ConfigurePresenceModule",

--- a/src/Granit.Indexing.EntityFrameworkCore/IndexingDbContext.cs
+++ b/src/Granit.Indexing.EntityFrameworkCore/IndexingDbContext.cs
@@ -2,7 +2,6 @@ using Granit.DataFiltering;
 using Granit.Indexing.EntityFrameworkCore.Extensions;
 using Granit.MultiTenancy;
 using Granit.Persistence.EntityFrameworkCore;
-using Granit.Persistence.EntityFrameworkCore.Extensions;
 using Microsoft.EntityFrameworkCore;
 
 namespace Granit.Indexing.EntityFrameworkCore;
@@ -60,8 +59,6 @@ public sealed class IndexingDbContext : GranitDbContext
             DefaultDictionary,
             EmbeddingDimensions,
             isPostgres);
-
-        modelBuilder.ApplyGranitConventions(currentTenant: null, dataFilter: null);
     }
 }
 

--- a/src/Granit.Persistence.EntityFrameworkCore.Migrations/Internal/MigrationProgressDbContext.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore.Migrations/Internal/MigrationProgressDbContext.cs
@@ -12,6 +12,13 @@ namespace Granit.Persistence.EntityFrameworkCore.Migrations.Internal;
 /// and Granit interceptors. Registered via <c>AddDbContextFactory</c> (not <c>AddGranitDbContext</c>)
 /// so progress commits are independent from the tenant data transaction.
 /// </remarks>
+// Deliberately a plain DbContext, NOT GranitDbContext (Phase 3 exemption, #3161): this is
+// tenant-AGNOSTIC system infrastructure — MigrationProgress.TenantId is an orchestration
+// column, not IMultiTenant (the runner must enumerate progress across every tenant), no
+// entity uses the convention interfaces, and the factory is registered Singleton (a
+// GranitDbContext ctor requires the scoped ICurrentTenant). No ApplyGranitConventions call
+// → no legacy-filter surface. Enum columns are configured explicitly in
+// MigrationProgressConfiguration.
 internal sealed class MigrationProgressDbContext(DbContextOptions<MigrationProgressDbContext> options)
     : DbContext(options)
 {

--- a/src/Granit.Presence.EntityFrameworkCore/Extensions/PresenceModelBuilderExtensions.cs
+++ b/src/Granit.Presence.EntityFrameworkCore/Extensions/PresenceModelBuilderExtensions.cs
@@ -1,4 +1,3 @@
-using Granit.Persistence.EntityFrameworkCore.Extensions;
 using Granit.Presence.EntityFrameworkCore.Configurations;
 using Microsoft.EntityFrameworkCore;
 
@@ -18,7 +17,6 @@ public static class PresenceModelBuilderExtensions
     public static ModelBuilder ConfigurePresenceModule(this ModelBuilder modelBuilder)
     {
         ArgumentNullException.ThrowIfNull(modelBuilder);
-        modelBuilder.ApplyGranitConventions();
         modelBuilder.ApplyConfiguration(new UserPresenceConfiguration());
         return modelBuilder;
     }

--- a/src/Granit.Presence.EntityFrameworkCore/Internal/PresenceDbContext.cs
+++ b/src/Granit.Presence.EntityFrameworkCore/Internal/PresenceDbContext.cs
@@ -1,7 +1,6 @@
 using Granit.DataFiltering;
 using Granit.MultiTenancy;
 using Granit.Persistence.EntityFrameworkCore;
-using Granit.Persistence.EntityFrameworkCore.Extensions;
 using Granit.Presence.Domain;
 using Granit.Presence.EntityFrameworkCore.Configurations;
 using Microsoft.EntityFrameworkCore;
@@ -30,7 +29,6 @@ internal sealed class PresenceDbContext(
     protected override void OnGranitModelCreating(ModelBuilder modelBuilder)
     {
         ArgumentNullException.ThrowIfNull(modelBuilder);
-        modelBuilder.ApplyGranitConventions();
         modelBuilder.ApplyConfiguration(new UserPresenceConfiguration());
     }
 }


### PR DESCRIPTION
Closes #3161 — first story of Phase 3 (#3147, epic #3143).

## What this does

Post-flip audit: only **three** real `ApplyGranitConventions` invocation sites remained outside the persistence package (the historical "55" were mostly doc mentions) — `PresenceDbContext` + `ConfigurePresenceModule` (the one `Configure*Module` outlier applying conventions inside the embedding extension) and `IndexingDbContext`. All three are `GranitDbContext`-derived, so the calls were redundant since #3181 (the base owns every pass). Removed — **the golden harness is the referee: 36/36 with zero baseline changes.**

`MigrationProgressDbContext` keeps a documented Phase 3 exemption as a plain `DbContext`: tenant-agnostic system infrastructure (its `TenantId` is an orchestration column, not `IMultiTenant` — the migration runner must enumerate progress across every tenant), Singleton factory (a `GranitDbContext` ctor requires the scoped `ICurrentTenant`), and zero `ApplyGranitConventions` usage → no legacy-filter surface.

## Deliberately split out → #3162 (next PR)

Internalizing `ApplyGranitConventions` + deleting the legacy `SetEntityFilter` tenant branch (the historical leak shape) + the GranitDbContext-mandatory architecture test. That step rewrites the legacy-branch test suites (`ModelBuilderExtensionsTests` §tenant, `GranitDesignTimeTests`) and deserves its own review.

## Verification

Golden snapshots 36/36 (baselines untouched); Presence 8/8; Indexing 26/26; architecture shard 642/642; format clean; no dependency changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)