### PR TITLE
fix(wolverine): make codegen-reachable service concretes public

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -22929,6 +22929,24 @@
       ]
     },
     {
+      "name": "WolverineHostReadiness",
+      "fqn": "Granit.Events.Wolverine.Internal.WolverineHostReadiness",
+      "kind": "class",
+      "project": "Granit.Events.Wolverine",
+      "file": "src/Granit.Events.Wolverine/Internal/WolverineHostReadiness.cs",
+      "line": 17,
+      "members": []
+    },
+    {
+      "name": "WolverineLocalEventBus",
+      "fqn": "Granit.Events.Wolverine.Internal.WolverineLocalEventBus",
+      "kind": "class",
+      "project": "Granit.Events.Wolverine",
+      "file": "src/Granit.Events.Wolverine/Internal/WolverineLocalEventBus.cs",
+      "line": 20,
+      "members": []
+    },
+    {
       "name": "BusinessException",
       "fqn": "Granit.Exceptions.BusinessException",
       "kind": "class",
@@ -60711,6 +60729,88 @@
           "kind": "method",
           "signature": "Change(string? userId, ActorKind actorKind = ActorKind.User, Guid? apiKeyId = null)",
           "returnType": "IDisposable"
+        }
+      ]
+    },
+    {
+      "name": "WolverineCurrentUserService",
+      "fqn": "Granit.Wolverine.Internal.WolverineCurrentUserService",
+      "kind": "class",
+      "project": "Granit.Wolverine",
+      "file": "src/Granit.Wolverine/Internal/WolverineCurrentUserService.cs",
+      "line": 32,
+      "members": [
+        {
+          "name": "Change",
+          "kind": "method",
+          "signature": "Change(string? userId, ActorKind actorKind = ActorKind.User, Guid? apiKeyId = null)",
+          "returnType": "IDisposable"
+        },
+        {
+          "name": "UserId",
+          "kind": "property",
+          "signature": "string? UserId",
+          "returnType": "string?"
+        },
+        {
+          "name": "IsAuthenticated",
+          "kind": "property",
+          "signature": "bool IsAuthenticated",
+          "returnType": "bool"
+        },
+        {
+          "name": "UserName",
+          "kind": "property",
+          "signature": "string? UserName",
+          "returnType": "string?"
+        },
+        {
+          "name": "Email",
+          "kind": "property",
+          "signature": "string? Email",
+          "returnType": "string?"
+        },
+        {
+          "name": "FirstName",
+          "kind": "property",
+          "signature": "string? FirstName",
+          "returnType": "string?"
+        },
+        {
+          "name": "LastName",
+          "kind": "property",
+          "signature": "string? LastName",
+          "returnType": "string?"
+        },
+        {
+          "name": "GetRoles",
+          "kind": "method",
+          "signature": "GetRoles()",
+          "returnType": "IReadOnlyList<string>"
+        },
+        {
+          "name": "IsInRole",
+          "kind": "method",
+          "signature": "IsInRole(string role)",
+          "returnType": "bool"
+        },
+        {
+          "name": "ActorKind",
+          "kind": "property",
+          "signature": "ActorKind ActorKind",
+          "returnType": "ActorKind"
+        },
+        {
+          "name": "IsMachine",
+          "kind": "property",
+          "signature": "bool IsMachine",
+          "returnType": "bool"
+        },
+        {
+          "name": "ApiKeyId",
+          "kind": "property",
+          "signature": "Guid? ApiKeyId",
+          "returnType": "Guid?"
         }
       ]
     },

--- a/src/Granit.Events.Wolverine/Internal/WolverineHostReadiness.cs
+++ b/src/Granit.Events.Wolverine/Internal/WolverineHostReadiness.cs
@@ -14,7 +14,7 @@ namespace Granit.Events.Wolverine.Internal;
 /// hosted services (including Wolverine) have completed <c>StartAsync</c>,
 /// making it the safe point to enable Wolverine-backed event publishing.
 /// </remarks>
-internal sealed partial class WolverineHostReadiness(
+public sealed partial class WolverineHostReadiness(
     ILogger<WolverineHostReadiness> logger) : IHostedLifecycleService
 {
     private volatile bool _isReady;

--- a/src/Granit.Events.Wolverine/Internal/WolverineLocalEventBus.cs
+++ b/src/Granit.Events.Wolverine/Internal/WolverineLocalEventBus.cs
@@ -17,7 +17,7 @@ namespace Granit.Events.Wolverine.Internal;
 /// resolving <see cref="ILocalEventHandler{TEvent}"/> from DI and calling sequentially,
 /// matching <c>InProcessLocalEventBus</c> behavior.
 /// </remarks>
-internal sealed partial class WolverineLocalEventBus(
+public sealed partial class WolverineLocalEventBus(
     IMessageBus bus,
     IServiceProvider serviceProvider,
     WolverineHostReadiness readiness,

--- a/src/Granit.Wolverine/Extensions/WolverineHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Wolverine/Extensions/WolverineHostApplicationBuilderExtensions.cs
@@ -166,10 +166,12 @@ public static class WolverineHostApplicationBuilderExtensions
             opts.CodeGeneration.TypeLoadMode = messagingOptions.CodeGenerationMode;
 
             // Service-location policy: NotAllowed aborts `codegen write` when a dependency
-            // can't be inlined. All three previously-problematic registrations are now clean:
-            // ICurrentUserService + IWolverineUserContextSetter use direct AddScoped<IFoo, TConcrete>
-            // (no lambda); INotificationPublisher impls are internal but InternalsVisibleTo
-            // "WolverineHandlers" is declared in Granit.Notifications and Granit.Notifications.Wolverine.
+            // can't be inlined. Every concrete type reachable from a handler chain must be
+            // PUBLIC, not merely registered without a lambda: for a consumer's Static build the
+            // generated sources compile into the *host* assembly, which no framework
+            // InternalsVisibleTo grant can name — internal concretes therefore always degrade
+            // to service location there and abort the build (public-in-Internal-namespace is
+            // the accepted shape, e.g. WolverineCurrentUserService, WolverineLocalEventBus).
             opts.ServiceLocationPolicy = ServiceLocationPolicy.NotAllowed;
 
             // IDomainEvent — force local routing, never forward to external transports.

--- a/src/Granit.Wolverine/Internal/WolverineCurrentUserService.cs
+++ b/src/Granit.Wolverine/Internal/WolverineCurrentUserService.cs
@@ -29,7 +29,7 @@ namespace Granit.Wolverine.Internal;
 /// </para>
 /// <para>Compliance: no PII is logged.</para>
 /// </remarks>
-internal sealed class WolverineCurrentUserService(IHttpContextAccessor httpContextAccessor)
+public sealed class WolverineCurrentUserService(IHttpContextAccessor httpContextAccessor)
     : ICurrentUserService, IWolverineUserContextSetter
 {
     private static readonly AsyncLocal<string?> _overrideUserId = new();


### PR DESCRIPTION
As a Développeur, I cannot produce a Static Wolverine codegen artifact for a consumer host: `dotnet run -- codegen write` aborts with `ServiceLocationPolicy.NotAllowed`, so the production cold-start recipe documented in the Wolverine messaging guide (and hard-required with `TrimWolverineRuntimeCompilation=true`) is unbuildable.

## Repro

granit-showcase-dotnet (branch of MR !74), Granit `0.1.0-dev.4540`, WolverineFx `6.24.6`:

```bash
dotnet run --project src/Showcase.Host -- codegen write
```

```text
ServiceLocationPolicy.NotAllowed is in effect
Service Granit.Users.ICurrentUserService: Concrete type
  Granit.Wolverine.Internal.WolverineCurrentUserService is not public, so requires service location
Service Granit.Wolverine.Internal.IWolverineUserContextSetter: Concrete type
  Granit.Wolverine.Internal.WolverineCurrentUserService is not public, so requires service location
Service Granit.Activities.BackgroundJobs.Services.SendRemindersScanService:
  Dependency: Granit.Events.ILocalEventBus ->
  Granit.Events.Wolverine.Internal.WolverineLocalEventBus is not public, so requires service location
```

## Root cause

#2843 tightened the policy from `AllowedButWarn` (#2536) to `NotAllowed` on the premise that the problematic registrations were clean (direct `AddScoped<IFoo, TConcrete>` + `InternalsVisibleTo("WolverineHandlers")`). That premise does not hold for **consumer** hosts: their Static build compiles the generated sources into the *host* assembly (`Showcase.Host`), which no framework IVT grant can name — internal concretes therefore always degrade to service location in that mode and fail the assertion, regardless of how they are registered.

## Change

- `WolverineCurrentUserService`, `WolverineLocalEventBus`, and `WolverineHostReadiness` (exposed through the now-public event-bus constructor) become `public` in their `Internal` namespaces — the same shape as the already-public `IWolverineUserContextSetter`.
- The policy comment now states the actual contract: every concrete reachable from a handler chain must be public, not merely lambda-free.

`NotAllowed` itself is kept — it is the right fail-fast; the registrations were the bug.

## Out of scope

`Granit.Activities.EntityFrameworkCore.Internal.EfCoreActivityReader` (the fourth report in the repro) lives in granit-business — fixed there separately. Runtime was never affected: `WolverineFx.RuntimeCompilation` keeps `Static` falling back to a runtime scan, losing only the cold-start win.

## Verification

- `dotnet build` Granit.Wolverine + Granit.Events.Wolverine: clean.
- `Granit.Wolverine.Tests` 172/172, `Granit.Events.Wolverine.Tests` 28/28.
- Full `codegen write` validation on the showcase requires the next dev feed publish (both repos' fixes combined).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
