### PR TITLE
fix(fuzz): retarget QueryEngine harness at Granit.QueryEngine.Endpoints

### DIFF
--- a/.github/workflows/cifuzz-batch.yml
+++ b/.github/workflows/cifuzz-batch.yml
@@ -19,7 +19,7 @@ jobs:
           - name: queryengine
             project: fuzz/Granit.QueryEngine.Fuzz
             assemblies: >-
-              Granit.QueryEngine.AspNetCore.dll
+              Granit.QueryEngine.Endpoints.dll
               Granit.QueryEngine.Abstractions.dll
           - name: csv
             project: fuzz/Granit.DataExchange.Csv.Fuzz

--- a/.github/workflows/cifuzz-pr.yml
+++ b/.github/workflows/cifuzz-pr.yml
@@ -23,7 +23,7 @@ jobs:
           - name: queryengine
             project: fuzz/Granit.QueryEngine.Fuzz
             assemblies: >-
-              Granit.QueryEngine.AspNetCore.dll
+              Granit.QueryEngine.Endpoints.dll
               Granit.QueryEngine.Abstractions.dll
           - name: csv
             project: fuzz/Granit.DataExchange.Csv.Fuzz

--- a/fuzz/Granit.QueryEngine.Fuzz/Granit.QueryEngine.Fuzz.csproj
+++ b/fuzz/Granit.QueryEngine.Fuzz/Granit.QueryEngine.Fuzz.csproj
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Granit.QueryEngine.AspNetCore\Granit.QueryEngine.AspNetCore.csproj" />
+    <ProjectReference Include="..\..\src\Granit.QueryEngine.Endpoints\Granit.QueryEngine.Endpoints.csproj" />
   </ItemGroup>
 
 </Project>

--- a/fuzz/Granit.QueryEngine.Fuzz/Program.cs
+++ b/fuzz/Granit.QueryEngine.Fuzz/Program.cs
@@ -1,4 +1,4 @@
-using Granit.QueryEngine.AspNetCore.Binding;
+using Granit.QueryEngine.Endpoints.Binding;
 using Microsoft.AspNetCore.Http;
 using SharpFuzz;
 

--- a/fuzz/Granit.QueryEngine.Fuzz/README.md
+++ b/fuzz/Granit.QueryEngine.Fuzz/README.md
@@ -1,7 +1,7 @@
 # Granit.QueryEngine.Fuzz
 
 SharpFuzz + AFL++ harness around `QueryRequestBinder.BindAsync` from
-`Granit.QueryEngine.AspNetCore`.
+`Granit.QueryEngine.Endpoints`.
 
 ## What it fuzzes
 
@@ -9,7 +9,7 @@ The binder parses HTTP query strings into `QueryRequest`, including the brackete
 `filter[field.op]=value` and `presets[group]=name` syntax. The harness mutates the
 query-string body and asserts that the binder never throws an unexpected exception.
 
-- Target source: [`../../src/Granit.QueryEngine.AspNetCore/Binding/QueryRequestBinder.cs`](../../src/Granit.QueryEngine.AspNetCore/Binding/QueryRequestBinder.cs)
+- Target source: [`../../src/Granit.QueryEngine.Endpoints/Binding/QueryRequestBinder.cs`](../../src/Granit.QueryEngine.Endpoints/Binding/QueryRequestBinder.cs)
 - Method: `QueryRequestBinder.BindAsync(HttpContext, ParameterInfo)`
 
 ## Running locally
@@ -18,7 +18,7 @@ query-string body and asserts that the binder never throws an unexpected excepti
 sudo apt-get install -y afl++
 dotnet tool install -g SharpFuzz.CommandLine          # one-time
 dotnet publish fuzz/Granit.QueryEngine.Fuzz -c Release -o ./out/queryengine_fuzz
-sharpfuzz ./out/queryengine_fuzz/Granit.QueryEngine.AspNetCore.dll
+sharpfuzz ./out/queryengine_fuzz/Granit.QueryEngine.Endpoints.dll
 sharpfuzz ./out/queryengine_fuzz/Granit.QueryEngine.Abstractions.dll
 AFL_SKIP_CPUFREQ=1 afl-fuzz \
   -i fuzz/Granit.QueryEngine.Fuzz/seeds \

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -8,7 +8,7 @@ untrusted input. Each harness lives in its own subdirectory and uses
 
 | Harness | Module | Surface |
 | --- | --- | --- |
-| [`Granit.QueryEngine.Fuzz`](./Granit.QueryEngine.Fuzz/) | [`Granit.QueryEngine.AspNetCore`](../src/Granit.QueryEngine.AspNetCore/) | HTTP query-string binder (`QueryRequestBinder.BindAsync`) |
+| [`Granit.QueryEngine.Fuzz`](./Granit.QueryEngine.Fuzz/) | [`Granit.QueryEngine.Endpoints`](../src/Granit.QueryEngine.Endpoints/) | HTTP query-string binder (`QueryRequestBinder.BindAsync`) |
 | [`Granit.DataExchange.Csv.Fuzz`](./Granit.DataExchange.Csv.Fuzz/) | [`Granit.DataExchange.Csv`](../src/Granit.DataExchange.Csv/) | Sep-backed CSV parser (`SepCsvFileParser.ExtractHeadersAsync` + `ParseAsync`) |
 | [`Granit.DataExchange.Excel.Fuzz`](./Granit.DataExchange.Excel.Fuzz/) | [`Granit.DataExchange.Excel`](../src/Granit.DataExchange.Excel/) | Sylvan-backed Excel parser (`SylvanExcelFileParser.ExtractHeadersAsync` + `ParseAsync`) |
 | [`Granit.QueryEngine.AI.Fuzz`](./Granit.QueryEngine.AI.Fuzz/) | [`Granit.QueryEngine.AI`](../src/Granit.QueryEngine.AI/) | Post-LLM JSON deserialization (`LlmNaturalLanguageQueryTranslator.TryDeserializeAndConvert`) |
@@ -23,7 +23,7 @@ They are built and exercised exclusively by the `cifuzz-*` GitHub workflows.
 sudo apt-get install -y afl++
 dotnet tool install -g SharpFuzz.CommandLine   # one-time
 dotnet publish fuzz/Granit.QueryEngine.Fuzz -c Release -o ./out/queryengine_fuzz
-sharpfuzz ./out/queryengine_fuzz/Granit.QueryEngine.AspNetCore.dll
+sharpfuzz ./out/queryengine_fuzz/Granit.QueryEngine.Endpoints.dll
 sharpfuzz ./out/queryengine_fuzz/Granit.QueryEngine.Abstractions.dll
 AFL_SKIP_CPUFREQ=1 afl-fuzz \
   -i fuzz/Granit.QueryEngine.Fuzz/seeds \


### PR DESCRIPTION
## Problem

The ClusterFuzzLite workflows fail on the `queryengine` shard:

```
warning MSB9008: The referenced project ../../src/Granit.QueryEngine.AspNetCore/Granit.QueryEngine.AspNetCore.csproj does not exist.
error CS0246: The type or namespace name 'Granit' could not be found
```

`Granit.QueryEngine.AspNetCore` was renamed to `Granit.QueryEngine.Endpoints`, but the fuzz
harness kept the old project reference and namespace. Nothing in the solution builds `fuzz/`,
so the dangling reference never surfaced until the fuzz workflow ran.

## Changes

- `Granit.QueryEngine.Fuzz.csproj` — `ProjectReference` → `src/Granit.QueryEngine.Endpoints`
- `Program.cs` — `using Granit.QueryEngine.Endpoints.Binding;`
- `cifuzz-pr.yml` / `cifuzz-batch.yml` — instrumented assembly `Granit.QueryEngine.Endpoints.dll`
- `fuzz/README.md`, `fuzz/Granit.QueryEngine.Fuzz/README.md` — same rename

No behavioural change to the harness itself: same target method
(`QueryRequestBinder.BindAsync`), same seeds, same filtering.

## Verification

- All four harnesses publish clean (`dotnet publish -c Release`).
- Every assembly listed in the workflows' instrumentation step is present in its publish
  output — checked explicitly, because that step only emits a `::warning::` when an assembly
  is missing, so a wrong name would silently fuzz **uninstrumented** code instead of failing.
- `markdownlint-cli2` clean on both READMEs.

## Follow-up (not in this PR)

The missing-assembly `::warning::` is a false-green risk: it is exactly what would hide a
future rename on the instrumentation side. Worth turning into `exit 1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)