### PR TITLE
fix(tests): stop DocumentGeneratorTests clobbering NSubstitute's last call

### DIFF
--- a/tests/Granit.DocumentGeneration.Tests/Pipeline/DocumentGeneratorTests.cs
+++ b/tests/Granit.DocumentGeneration.Tests/Pipeline/DocumentGeneratorTests.cs
@@ -26,8 +26,14 @@ public sealed class DocumentGeneratorTests
 
     private static readonly byte[] PdfBytes = [0x25, 0x50, 0x44, 0x46]; // %PDF magic
 
-    private static readonly DocumentGenerationMetrics Metrics = CreateMetrics();
-    private static readonly ICurrentTenant Tenant = CreateTenant();
+    // Instance fields, deliberately not static. A static initializer runs lazily on the first
+    // static access of the class — and here that access is `PdfBytes`, read *inside* a
+    // `.Returns(...)` argument. Configuring these substitutes at that moment clobbers
+    // NSubstitute's pending last-call state ("Could not find a call to return from"), failing
+    // whichever test xUnit happens to run first. Field initializers run in the per-test
+    // constructor instead, before any call is recorded.
+    private readonly DocumentGenerationMetrics _metrics = CreateMetrics();
+    private readonly ICurrentTenant _tenant = CreateTenant();
 
     private static DocumentGenerationMetrics CreateMetrics()
     {
@@ -65,7 +71,7 @@ public sealed class DocumentGeneratorTests
                 Arg.Any<CancellationToken>())
             .Returns(new DocumentResult(PdfBytes, DocumentFormat.Pdf));
 
-        DocumentGenerator sut = new(textRenderer, [pdfRenderer], Metrics, Tenant);
+        DocumentGenerator sut = new(textRenderer, [pdfRenderer], _metrics, _tenant);
 
         // Act
         DocumentResult result = await sut.GenerateAsync(
@@ -98,7 +104,7 @@ public sealed class DocumentGeneratorTests
                 Arg.Any<CancellationToken>())
             .Returns(new DocumentResult(PdfBytes, DocumentFormat.Pdf));
 
-        DocumentGenerator sut = new(textRenderer, [pdfRenderer], Metrics, Tenant);
+        DocumentGenerator sut = new(textRenderer, [pdfRenderer], _metrics, _tenant);
 
         // Act — no targetFormat parameter
         DocumentResult result = await sut.GenerateAsync(
@@ -135,7 +141,7 @@ public sealed class DocumentGeneratorTests
                 Arg.Any<CancellationToken>())
             .Returns(new DocumentResult(new byte[] { 0x50, 0x4B }, DocumentFormat.Excel));
 
-        DocumentGenerator sut = new(textRenderer, [excelRenderer], Metrics, Tenant);
+        DocumentGenerator sut = new(textRenderer, [excelRenderer], _metrics, _tenant);
 
         // Act — override default Pdf with Excel
         DocumentResult result = await sut.GenerateAsync(
@@ -165,7 +171,7 @@ public sealed class DocumentGeneratorTests
         excelOnly.CanRender(DocumentFormat.Pdf).Returns(false);
         excelOnly.CanRender(DocumentFormat.Excel).Returns(true);
 
-        DocumentGenerator sut = new(textRenderer, [excelOnly], Metrics, Tenant);
+        DocumentGenerator sut = new(textRenderer, [excelOnly], _metrics, _tenant);
 
         // Act
         Func<Task> act = async () =>
@@ -203,7 +209,7 @@ public sealed class DocumentGeneratorTests
                 Arg.Any<CancellationToken>())
             .Returns(new DocumentResult(PdfBytes, DocumentFormat.Pdf));
 
-        DocumentGenerator sut = new(textRenderer, [renderer], Metrics, Tenant);
+        DocumentGenerator sut = new(textRenderer, [renderer], _metrics, _tenant);
 
         // Act
         await sut.GenerateAsync(
@@ -230,7 +236,7 @@ public sealed class DocumentGeneratorTests
 
         IDocumentRenderer renderer = Substitute.For<IDocumentRenderer>();
 
-        DocumentGenerator sut = new(textRenderer, [renderer], Metrics, Tenant);
+        DocumentGenerator sut = new(textRenderer, [renderer], _metrics, _tenant);
 
         // Act
         DocumentResult result = await sut.GenerateAsync(


### PR DESCRIPTION
## Problem

`Granit.DocumentGeneration.Tests` fails on `develop` — the `application` shard is red:

```
DocumentGeneratorTests.GenerateAsync_UsesDefaultFormatFromTemplateType [FAIL]
  NSubstitute.Exceptions.CouldNotSetReturnDueToNoLastCallException :
  Could not find a call to return from.
```

## Cause

`Metrics` and `Tenant` were built by **static** field initializers, so the class
initializer ran lazily on the first static access of the class. That access is `PdfBytes`,
read *inside* a `.Returns(...)` argument:

```csharp
pdfRenderer.RenderAsync(...)                      // records the pending call
    .Returns(new DocumentResult(PdfBytes, ...));  // cctor fires here
```

Configuring two more substitutes at that moment discards NSubstitute's pending last-call
state — exactly the case its own error message warns about ("avoid configuring other
substitutes within Returns()"). Whichever test xUnit ran first took the hit; the rest passed
because the cctor had already run, which is why only one of the 28 ever failed.

## Fix

Move both to **instance** fields. xUnit initialises them in the per-test constructor, before
any call is recorded, so the hazard cannot recur regardless of test order. This also matches
how the rest of the suite holds its substitutes (`private readonly ICurrentTenant _tenant = …`).

## Verification

- 28/28 green, three consecutive runs
- Green in isolation too — running the failing test **alone** reproduced the bug
  deterministically before this change, and passes now
- Full `application` shard builds and tests green
- `dotnet format --verify-no-changes` clean

Found while validating #3193; unrelated to that PR (the project's `packages.lock.json` is
byte-identical to `develop`), so it ships separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)