### PR TITLE
fix(openapi-generator): emit the workflow /transitions routes

### DIFF
--- a/src/Granit.OpenApi.Generator/GeneratorEndpoints.cs
+++ b/src/Granit.OpenApi.Generator/GeneratorEndpoints.cs
@@ -111,6 +111,9 @@ internal static class GeneratorEndpoints
         new("timeline", e => e.MapGranitTimeline()),
         new("validation", e => e.MapGranitValidation()),
         new("webhooks", e => e.MapGranitWebhooks()),
-        new("workflow", e => e.MapGranitWorkflow()),
+        // The /transitions pair is mapped by an extension generic over the host's state enum, hence the
+        // generator's placeholder enum (see GeneratorStubWorkflowDefinition) — without it the emitted
+        // workflow contract would cover the history route only.
+        new("workflow", e => e.MapGranitWorkflow().MapGranitWorkflowTransition<WorkflowState>()),
     ];
 }

--- a/src/Granit.OpenApi.Generator/GeneratorStubWorkflow.cs
+++ b/src/Granit.OpenApi.Generator/GeneratorStubWorkflow.cs
@@ -1,0 +1,48 @@
+using Granit.Workflow;
+
+namespace Granit.OpenApi.Generator;
+
+/// <summary>
+/// Placeholder workflow state enum registered only by the contract generator so the generic
+/// transition endpoints (<c>GET /transitions</c>, <c>POST /transitions</c>) can be mounted and appear
+/// in the emitted OpenAPI document.
+/// </summary>
+/// <remarks>
+/// <c>MapGranitWorkflowTransition&lt;TState&gt;</c> is generic over the host application's state enum,
+/// so those two routes materialize only once some enum is supplied — without this placeholder the
+/// workflow contract ships with the history route alone and the two <c>/transitions</c> routes the
+/// frontend legitimately calls read as orphan endpoints. The name is deliberately generic (not
+/// <c>GeneratorStub…</c>): the endpoints derive their <c>operationId</c> from
+/// <c>typeof(TState).Name</c>, so it lands in the published contract.
+/// </remarks>
+internal enum WorkflowState
+{
+    /// <summary>Initial state of the placeholder workflow.</summary>
+    Draft,
+
+    /// <summary>Terminal state of the placeholder workflow.</summary>
+    Published,
+}
+
+/// <summary>
+/// Minimal two-state workflow definition backing <see cref="WorkflowState"/>, registered only by the
+/// contract generator to satisfy the <c>IWorkflowManager&lt;TState&gt;</c> requirement of the generic
+/// transition endpoints (see <see cref="WorkflowState"/> for why the placeholder exists).
+/// </summary>
+/// <remarks>
+/// Mirrors <see cref="GeneratorStubGeocodingProvider"/>: it never runs at request time — the generator
+/// only probes minimal-API bindings — so the transition set is the smallest one that still describes a
+/// well-formed finite state machine.
+/// </remarks>
+internal sealed class GeneratorStubWorkflowDefinition : IWorkflowDefinition<WorkflowState>
+{
+    private static readonly WorkflowTransition<WorkflowState>[] AllTransitions =
+        [new() { From = WorkflowState.Draft, To = WorkflowState.Published }];
+
+    public WorkflowState InitialState => WorkflowState.Draft;
+
+    public IReadOnlyList<WorkflowTransition<WorkflowState>> Transitions => AllTransitions;
+
+    public IReadOnlyList<WorkflowTransition<WorkflowState>> GetAllowedTransitions(WorkflowState from) =>
+        [.. AllTransitions.Where(transition => transition.From.Equals(from))];
+}

--- a/src/Granit.OpenApi.Generator/Program.cs
+++ b/src/Granit.OpenApi.Generator/Program.cs
@@ -5,6 +5,7 @@ using Granit.Identity.Endpoints.Extensions;
 using Granit.OpenApi.Generation;
 using Granit.OpenApi.Generator;
 using Granit.Workflow.Endpoints.Extensions;
+using Granit.Workflow.Extensions;
 
 // All doc-gen orchestration (per-module document slicing, infra neutralization, the minimal-API
 // binding probe) lives in the shared Granit.OpenApi.Generation helper, so this entry point only
@@ -32,4 +33,10 @@ await OpenApiContractGenerator.RunAsync<GeneratorModule>(
             static sp => sp.GetRequiredService<GeneratorStubGeocodingProvider>());
         builder.Services.AddSingleton<IAddressAutocompleteProvider>(
             static sp => sp.GetRequiredService<GeneratorStubGeocodingProvider>());
+
+        // Same rationale for workflow: the two /transitions routes are mapped by an extension generic
+        // over the host's state enum and backed by IWorkflowManager<TState>, so a workflow-less graph
+        // emits the history route alone. Register a placeholder state machine so the generated document
+        // covers the full workflow surface (see GeneratorStubWorkflowDefinition).
+        builder.Services.AddWorkflow<WorkflowState>(new GeneratorStubWorkflowDefinition());
     });


### PR DESCRIPTION
Closes #3200.

## Problem

The generated `workflow` contract (vendored into `granit-front` as `contracts/openapi/workflow.json`) documented a single route:

```text
GET /workflow/{entityType}/{entityId}/history
```

`@granit/workflow` calls three, so `listTransitions` (`GET {basePath}/transitions?currentState=`) and `executeStateMachineTransition` (`POST {basePath}/transitions?currentState=`) had no contract entry. Route conformance therefore cannot be enabled for `workflow` in the frontend contract oracle (granit-front#989): it would flag two `orphan-endpoint`s that the frontend is right to call.

## Root cause

`MapGranitWorkflow()` maps only the read endpoints. The two `/transitions` routes ship from a separate extension, generic over the state enum:

```csharp
public static RouteGroupBuilder MapGranitWorkflowTransition<TState>(this RouteGroupBuilder group)
    where TState : struct, Enum
```

Generic route mappings do not materialize on their own — some concrete `TState` has to be supplied, and the endpoints are backed by `IWorkflowManager<TState>`, registered via `AddWorkflow<TState>(definition)`. The generator composes a workflow-less module graph, so the extension was never callable and the two routes silently fell out of the emitted document.

## Fix

Follows the existing `GeneratorStubGeocodingProvider` precedent — same class of problem (capability-gated surface absent from a provider-less graph, whose XML doc already names the symptom: *"without this stub the geocoding contract would ship with an empty `paths` object"*), same remedy:

- `GeneratorStubWorkflow.cs` — an `internal` placeholder state enum plus a minimal `IWorkflowDefinition<TState>` (`Draft → Published`), in the generator project only. It never runs at request time; the generator only probes minimal-API bindings.
- `AddWorkflow<WorkflowState>(new GeneratorStubWorkflowDefinition())` in `Program.cs`, next to the geocoding stub registration.
- `.MapGranitWorkflowTransition<WorkflowState>()` chained onto the `workflow` registry entry in `GeneratorEndpoints.cs`.

No production module is touched.

The enum is named `WorkflowState` rather than `GeneratorStubWorkflowState` on purpose: the transition endpoints derive their `operationId` from `typeof(TState).Name`, so the name lands in the published contract (`GetAvailableWorkflowStateTransitions`, `ExecuteWorkflowStateTransition`). Documented inline.

## Verification

```text
[('GET', '/workflow/transitions'),
 ('GET', '/workflow/{entityType}/{entityId}/history'),
 ('POST', '/workflow/transitions')]

['PagedResultOfWorkflowTransitionHistoryResponse', 'ProblemDetails',
 'WorkflowStatusResponse', 'WorkflowTransitionHistoryResponse',
 'WorkflowTransitionRequest', 'WorkflowTransitionResponse',
 'WorkflowTransitionResultResponse']
```

Both `/transitions` routes carry the required `currentState` query parameter. The history route is unchanged.

- Generated artifacts are gitignored (`generated/.gitignore`), so blast radius was checked by diffing a full baseline build of `develop` against a full build of this branch: **only `_workflow.json` differs, and its diff is purely additive** (0 removed lines).
- `dotnet build src/Granit.OpenApi.Generator --no-incremental` — 0 warnings, 0 errors.
- `dotnet format src/Granit.OpenApi.Generator --verify-no-changes` — clean.
- `dotnet test tests/Granit.ArchitectureTests --filter "FullyQualifiedName~OpenApi"` — 7/7 (registry completeness + tag conventions).
- `dotnet test tests/Granit.OpenApi.Generation.Tests` — 4/4.

## Follow-up (other repo)

Re-vendor `contracts/openapi/workflow.json` in `granit-front`, then enable route conformance for `workflow` in the contract oracle (granit-front#989).

🤖 Generated with [Claude Code](https://claude.com/claude-code)