### PR TITLE
fix(sonar): propagate cancellation tokens to async and Roslyn calls

### DIFF
--- a/src/Granit.Analyzers/AlterColumnWithoutContractAnalyzer.cs
+++ b/src/Granit.Analyzers/AlterColumnWithoutContractAnalyzer.cs
@@ -70,7 +70,7 @@ public sealed class AlterColumnWithoutContractAnalyzer : GranitMigrationAnalyzer
             return;
         }
 
-        ITypeSymbol? oldType = context.SemanticModel.GetTypeInfo(typeofExpr.Type).Type;
+        ITypeSymbol? oldType = context.SemanticModel.GetTypeInfo(typeofExpr.Type, context.CancellationToken).Type;
         if (oldType is null)
         {
             return;

--- a/src/Granit.Analyzers/DateTimeNowAnalyzer.cs
+++ b/src/Granit.Analyzers/DateTimeNowAnalyzer.cs
@@ -48,7 +48,7 @@ public sealed class DateTimeNowAnalyzer : SingleRuleAnalyzerBase
             return;
         }
 
-        ISymbol? symbol = context.SemanticModel.GetSymbolInfo(memberAccess).Symbol;
+        ISymbol? symbol = context.SemanticModel.GetSymbolInfo(memberAccess, context.CancellationToken).Symbol;
         if (symbol is not IPropertySymbol propertySymbol)
         {
             return;

--- a/src/Granit.Analyzers/DirectCookieAccessAnalyzer.cs
+++ b/src/Granit.Analyzers/DirectCookieAccessAnalyzer.cs
@@ -76,7 +76,7 @@ public sealed class DirectCookieAccessAnalyzer : SingleRuleAnalyzerBase
             return;
         }
 
-        ISymbol? symbol = context.SemanticModel.GetSymbolInfo(invocation).Symbol;
+        ISymbol? symbol = context.SemanticModel.GetSymbolInfo(invocation, context.CancellationToken).Symbol;
         if (symbol is not IMethodSymbol methodSymbol)
         {
             return;

--- a/src/Granit.Analyzers/GuidNewGuidAnalyzer.cs
+++ b/src/Granit.Analyzers/GuidNewGuidAnalyzer.cs
@@ -53,7 +53,7 @@ public sealed class GuidNewGuidAnalyzer : SingleRuleAnalyzerBase
             return;
         }
 
-        ISymbol? symbol = context.SemanticModel.GetSymbolInfo(invocation).Symbol;
+        ISymbol? symbol = context.SemanticModel.GetSymbolInfo(invocation, context.CancellationToken).Symbol;
         if (symbol is not IMethodSymbol methodSymbol)
         {
             return;

--- a/src/Granit.Analyzers/Internal/MigrationAnalyzerHelpers.cs
+++ b/src/Granit.Analyzers/Internal/MigrationAnalyzerHelpers.cs
@@ -86,7 +86,7 @@ internal static class MigrationAnalyzerHelpers
             return null;
         }
 
-        ISymbol? symbol = context.SemanticModel.GetSymbolInfo(invocation).Symbol;
+        ISymbol? symbol = context.SemanticModel.GetSymbolInfo(invocation, context.CancellationToken).Symbol;
         if (symbol is not IMethodSymbol methodSymbol)
         {
             return null;

--- a/src/Granit.Analyzers/PrivacyExportSubjectSubstitutionAnalyzer.cs
+++ b/src/Granit.Analyzers/PrivacyExportSubjectSubstitutionAnalyzer.cs
@@ -74,7 +74,7 @@ public sealed class PrivacyExportSubjectSubstitutionAnalyzer : SingleRuleAnalyze
             return;
         }
 
-        ISymbol? typeSymbol = context.SemanticModel.GetSymbolInfo(creation).Symbol;
+        ISymbol? typeSymbol = context.SemanticModel.GetSymbolInfo(creation, context.CancellationToken).Symbol;
         if (typeSymbol is not IMethodSymbol ctor || ctor.MethodKind != MethodKind.Constructor)
         {
             return;
@@ -91,8 +91,8 @@ public sealed class PrivacyExportSubjectSubstitutionAnalyzer : SingleRuleAnalyze
             return;
         }
 
-        ISymbol? subjectSymbol = context.SemanticModel.GetSymbolInfo(subjectArg.Expression).Symbol;
-        ISymbol? callerSymbol = context.SemanticModel.GetSymbolInfo(callerArg.Expression).Symbol;
+        ISymbol? subjectSymbol = context.SemanticModel.GetSymbolInfo(subjectArg.Expression, context.CancellationToken).Symbol;
+        ISymbol? callerSymbol = context.SemanticModel.GetSymbolInfo(callerArg.Expression, context.CancellationToken).Symbol;
 
         // Skip when either argument doesn't bind to a symbol (literals, method calls,
         // dynamic expressions) — over-flagging those would dwarf the true-positive rate.

--- a/src/Granit.Analyzers/SynchronousSaveChangesAnalyzer.cs
+++ b/src/Granit.Analyzers/SynchronousSaveChangesAnalyzer.cs
@@ -67,7 +67,7 @@ public sealed class SynchronousSaveChangesAnalyzer : SingleRuleAnalyzerBase
             return;
         }
 
-        ISymbol? symbol = context.SemanticModel.GetSymbolInfo(invocation).Symbol;
+        ISymbol? symbol = context.SemanticModel.GetSymbolInfo(invocation, context.CancellationToken).Symbol;
         if (symbol is not IMethodSymbol methodSymbol)
         {
             return;

--- a/src/Granit.Analyzers/TypedResultsBadRequestAnalyzer.cs
+++ b/src/Granit.Analyzers/TypedResultsBadRequestAnalyzer.cs
@@ -70,7 +70,7 @@ public sealed class TypedResultsBadRequestAnalyzer : SingleRuleAnalyzerBase
             return;
         }
 
-        ISymbol? symbol = context.SemanticModel.GetSymbolInfo(invocation).Symbol;
+        ISymbol? symbol = context.SemanticModel.GetSymbolInfo(invocation, context.CancellationToken).Symbol;
         if (symbol is not IMethodSymbol methodSymbol)
         {
             return;

--- a/src/Granit.Analyzers/UntypedResultsAnalyzer.cs
+++ b/src/Granit.Analyzers/UntypedResultsAnalyzer.cs
@@ -52,7 +52,7 @@ public sealed class UntypedResultsAnalyzer : SingleRuleAnalyzerBase
 
         string methodName = memberAccess.Name.Identifier.Text;
 
-        ISymbol? symbol = context.SemanticModel.GetSymbolInfo(invocation).Symbol;
+        ISymbol? symbol = context.SemanticModel.GetSymbolInfo(invocation, context.CancellationToken).Symbol;
         if (symbol is not IMethodSymbol methodSymbol)
         {
             return;

--- a/src/Granit.Http.Idempotency/Internal/IdempotencyMiddleware.cs
+++ b/src/Granit.Http.Idempotency/Internal/IdempotencyMiddleware.cs
@@ -381,7 +381,7 @@ internal sealed partial class IdempotencyMiddleware(
 
         if (entry.ResponseBody is { Length: > 0 })
         {
-            await context.Response.Body.WriteAsync(entry.ResponseBody).ConfigureAwait(false);
+            await context.Response.Body.WriteAsync(entry.ResponseBody, context.RequestAborted).ConfigureAwait(false);
         }
     }
 

--- a/src/Granit.OpenIddict.Endpoints/Endpoints/ConnectTokenEndpoints.cs
+++ b/src/Granit.OpenIddict.Endpoints/Endpoints/ConnectTokenEndpoints.cs
@@ -155,7 +155,7 @@ internal static partial class ConnectTokenEndpoints
             IOidcPrincipalFactory principalFactory = context.RequestServices
                 .GetRequiredService<IOidcPrincipalFactory>();
             ClaimsPrincipal principal = await principalFactory.CreateUserPrincipalAsync(
-                user, scopes, OpenIddictServerAspNetCoreDefaults.AuthenticationScheme)
+                user, scopes, OpenIddictServerAspNetCoreDefaults.AuthenticationScheme, context.RequestAborted)
                 .ConfigureAwait(false);
 
             string grantType = request.GrantType!;
@@ -311,7 +311,7 @@ internal static partial class ConnectTokenEndpoints
         ImmutableArray<string> scopes = request.GetScopes();
         IOidcPrincipalFactory principalFactory = context.RequestServices.GetRequiredService<IOidcPrincipalFactory>();
         ClaimsPrincipal principal = await principalFactory.CreateUserPrincipalAsync(
-            user, scopes, OpenIddictServerAspNetCoreDefaults.AuthenticationScheme)
+            user, scopes, OpenIddictServerAspNetCoreDefaults.AuthenticationScheme, context.RequestAborted)
             .ConfigureAwait(false);
 
         metrics.RecordTokenIssued(tenantId, TwoFactorGrantType);
@@ -410,7 +410,7 @@ internal static partial class ConnectTokenEndpoints
         ImmutableArray<string> scopes = request.GetScopes();
         IOidcPrincipalFactory principalFactory = context.RequestServices.GetRequiredService<IOidcPrincipalFactory>();
         ClaimsPrincipal principal = await principalFactory.CreateUserPrincipalAsync(
-            user, scopes, OpenIddictServerAspNetCoreDefaults.AuthenticationScheme)
+            user, scopes, OpenIddictServerAspNetCoreDefaults.AuthenticationScheme, context.RequestAborted)
             .ConfigureAwait(false);
 
         metrics.RecordTokenIssued(tenantId, PasskeyGrantType);

--- a/src/Granit.Privacy.Regulations.Cookies/Internal/RegulationBasedCookieConsentModelProvider.cs
+++ b/src/Granit.Privacy.Regulations.Cookies/Internal/RegulationBasedCookieConsentModelProvider.cs
@@ -20,7 +20,9 @@ internal sealed class RegulationBasedCookieConsentModelProvider(
             return info;
         }
 
-        PrivacyRegulationProfile profile = await regulationResolver.ResolveAsync().ConfigureAwait(false);
+        PrivacyRegulationProfile profile = await regulationResolver
+            .ResolveAsync(httpContext.RequestAborted)
+            .ConfigureAwait(false);
 
         ConsentModelInfo result = new(
             MapConsentMode(profile.CookieConsentModel),

--- a/src/Granit.Templating.Scriban/Internal/GranitTemplateLoader.cs
+++ b/src/Granit.Templating.Scriban/Internal/GranitTemplateLoader.cs
@@ -68,7 +68,7 @@ internal sealed class GranitTemplateLoader(IServiceProvider serviceProvider) : I
         foreach (ITemplateResolver resolver in resolvers)
         {
             TemplateDescriptor? descriptor = await resolver
-                .TryResolveAsync(culturalKey)
+                .TryResolveAsync(culturalKey, context.CancellationToken)
                 .ConfigureAwait(false);
 
             if (descriptor is not null)
@@ -84,7 +84,7 @@ internal sealed class GranitTemplateLoader(IServiceProvider serviceProvider) : I
             foreach (ITemplateResolver resolver in resolvers)
             {
                 TemplateDescriptor? descriptor = await resolver
-                    .TryResolveAsync(neutralKey)
+                    .TryResolveAsync(neutralKey, context.CancellationToken)
                     .ConfigureAwait(false);
 
                 if (descriptor is not null)


### PR DESCRIPTION
As a Backend Developer, I want every call that can observe cancellation to receive the token already in scope, so that analysis and requests stop promptly instead of running past their caller.

## Context

SonarCloud S6966 flagged 18 call sites that dropped an available `CancellationToken`.

## Changes

**Analyzers (11)** — `context.CancellationToken` now reaches `GetSymbolInfo` / `GetTypeInfo` in `AlterColumnWithoutContract`, `DateTimeNow`, `DirectCookieAccess`, `GuidNewGuid`, `MigrationAnalyzerHelpers`, `PrivacyExportSubjectSubstitution` (3 sites), `SynchronousSaveChanges`, `TypedResultsBadRequest` and `UntypedResults`. Without it an IDE analysis pass keeps binding symbols after the compilation is cancelled.

**Runtime (7)**

- `IdempotencyMiddleware` — the replay body write takes `context.RequestAborted`.
- `ConnectTokenEndpoints` — `CreateUserPrincipalAsync` takes `context.RequestAborted` on the three grants (refresh, two-factor, passkey).
- `RegulationBasedCookieConsentModelProvider` — `ResolveAsync` takes `httpContext.RequestAborted`.
- `GranitTemplateLoader` — the resolver chain takes Scriban's `TemplateContext.CancellationToken`, which also propagates the render timeout to I/O-backed resolvers (`StoreTemplateResolver` hits EF Core).

## Verification

Build, `dotnet format --verify-no-changes` and tests green on the five touched packages: Analyzers 126, Analyzers.CodeFixes 34, Http.Idempotency 114, Privacy.Regulations.Cookies 4, OpenIddict.Endpoints 136, Templating.Scriban 51.

No behaviour change beyond cancellation propagation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)