### PR TITLE
refactor(sonar): clear the remaining code-side backlog (28 issues)

### DIFF
--- a/src/Granit.DataExchange.EntityFrameworkCore/Internal/Import/Execution/EfImportExecutor.cs
+++ b/src/Granit.DataExchange.EntityFrameworkCore/Internal/Import/Execution/EfImportExecutor.cs
@@ -220,62 +220,75 @@ internal sealed partial class EfImportExecutor<TEntity, TContext> : IImportExecu
 
         foreach (RowOutcome<TEntity> row in batch)
         {
-            if (row.IsSkipped)
+            PendingRow? pendingRow = ClassifyRow(row, state);
+            if (pendingRow is not null)
             {
-                state.SkippedRows++;
-                continue;
+                pendingRows.Add(pendingRow);
             }
-
-            if (row.Error is not null || row.Entity is null)
-            {
-                state.FailedRows++;
-                state.Errors.Add(row.Error ?? new ImportRowError(
-                    row.RowNumber, ImportRowErrorKind.Conversion,
-                    [UnexpectedOutcomeErrorCode],
-                    "Row outcome carried neither an entity nor an error."));
-                continue;
-            }
-
-            TEntity entity = row.Entity;
-            RecordIdentity identity = row.Identity ?? RecordIdentity.Insert();
-
-            if (identity.Operation == RecordOperation.Skip)
-            {
-                state.SkippedRows++;
-                continue;
-            }
-
-            if (identity.Operation == RecordOperation.Ambiguous)
-            {
-                state.FailedRows++;
-                state.Errors.Add(new ImportRowError(
-                    row.RowNumber, ImportRowErrorKind.Identity,
-                    identity.ReasonCodes.Count > 0 ? identity.ReasonCodes : [IdentityReasonCodes.AmbiguousMatch],
-                    "Identity could not be resolved unambiguously."));
-                continue;
-            }
-
-            if (identity.Operation == RecordOperation.Insert)
-            {
-                pendingRows.Add(PendingRow.ForInsert(row, entity, identity.ExternalId));
-                continue;
-            }
-
-            // Update or Upsert — both require a key to look existing rows up by.
-            if (identity.Key is null)
-            {
-                state.FailedRows++;
-                state.Errors.Add(new ImportRowError(
-                    row.RowNumber, ImportRowErrorKind.Identity,
-                    [IdentityReasonCodes.AmbiguousMatch],
-                    $"Identity operation '{identity.Operation}' carried no key."));
-                continue;
-            }
-
-            pendingRows.Add(PendingRow.ForLookup(row, entity, identity.Key.Value, identity.KeyKind, identity.Operation));
         }
 
         return pendingRows;
+    }
+
+    /// <summary>
+    /// Classifies a single row: returns the <see cref="PendingRow"/> that still needs a
+    /// persistence decision, or <see langword="null"/> once the row has been accounted for on
+    /// <paramref name="state"/> as skipped or failed.
+    /// </summary>
+    private static PendingRow? ClassifyRow(RowOutcome<TEntity> row, ExecutionState state)
+    {
+        if (row.IsSkipped)
+        {
+            state.SkippedRows++;
+            return null;
+        }
+
+        if (row.Error is not null || row.Entity is null)
+        {
+            state.FailedRows++;
+            state.Errors.Add(row.Error ?? new ImportRowError(
+                row.RowNumber, ImportRowErrorKind.Conversion,
+                [UnexpectedOutcomeErrorCode],
+                "Row outcome carried neither an entity nor an error."));
+            return null;
+        }
+
+        TEntity entity = row.Entity;
+        RecordIdentity identity = row.Identity ?? RecordIdentity.Insert();
+
+        if (identity.Operation == RecordOperation.Skip)
+        {
+            state.SkippedRows++;
+            return null;
+        }
+
+        if (identity.Operation == RecordOperation.Ambiguous)
+        {
+            state.FailedRows++;
+            state.Errors.Add(new ImportRowError(
+                row.RowNumber, ImportRowErrorKind.Identity,
+                identity.ReasonCodes.Count > 0 ? identity.ReasonCodes : [IdentityReasonCodes.AmbiguousMatch],
+                "Identity could not be resolved unambiguously."));
+            return null;
+        }
+
+        if (identity.Operation == RecordOperation.Insert)
+        {
+            return PendingRow.ForInsert(row, entity, identity.ExternalId);
+        }
+
+        // Update or Upsert — both require a key to look existing rows up by.
+        if (identity.Key is null)
+        {
+            state.FailedRows++;
+            state.Errors.Add(new ImportRowError(
+                row.RowNumber, ImportRowErrorKind.Identity,
+                [IdentityReasonCodes.AmbiguousMatch],
+                $"Identity operation '{identity.Operation}' carried no key."));
+            return null;
+        }
+
+        return PendingRow.ForLookup(row, entity, identity.Key.Value, identity.KeyKind, identity.Operation);
     }
 
     /// <summary>

--- a/src/Granit.Diagnostics.Endpoints/Extensions/SecurityHeadersAuditEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Diagnostics.Endpoints/Extensions/SecurityHeadersAuditEndpointRouteBuilderExtensions.cs
@@ -24,8 +24,8 @@ public static class SecurityHeadersAuditEndpointRouteBuilderExtensions
         this IEndpointRouteBuilder endpoints,
         Action<SecurityHeadersAuditOptions>? configure = null)
     {
-        // Bound from Diagnostics:Endpoints:SecurityHeadersAudit by the module;
-        // the delegate overrides on top.
+        // Bound from Diagnostics:Endpoints:SecurityHeadersAudit by the module, with
+        // the delegate overriding on top.
         SecurityHeadersAuditOptions options =
             endpoints.ServiceProvider.GetService<IOptions<SecurityHeadersAuditOptions>>()?.Value ?? new();
         configure?.Invoke(options);

--- a/src/Granit.Http.Cookies.Endpoints/Endpoints/CookieConsentEndpoints.cs
+++ b/src/Granit.Http.Cookies.Endpoints/Endpoints/CookieConsentEndpoints.cs
@@ -60,8 +60,8 @@ internal static class CookieConsentEndpoints
         HttpContext context,
         CancellationToken cancellationToken)
     {
-        // Data minimisation at capture (GDPR Art. 5(1)(c)): irreversible IP masking;
-        // the factory truncates the user-agent — the ledger never sees a raw identifier.
+        // Data minimisation at capture (GDPR Art. 5(1)(c)): the IP masking is irreversible
+        // and the factory truncates the user-agent, so the ledger never sees a raw identifier.
         string? anonymizedIp = IpAddressAnonymizer.Mask(context.Connection.RemoteIpAddress);
         string userAgentHeader = context.Request.Headers.UserAgent.ToString();
 

--- a/src/Granit.Http.Cookies.EntityFrameworkCore/Extensions/CookiesEntityFrameworkCoreHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Http.Cookies.EntityFrameworkCore/Extensions/CookiesEntityFrameworkCoreHostApplicationBuilderExtensions.cs
@@ -44,8 +44,8 @@ public static class CookiesEntityFrameworkCoreHostApplicationBuilderExtensions
         builder.Services.AddGranitDbContext<CookiesDbContext>(configure);
 
         // Durable ledger replaces the base module's NullConsentLedger. RemoveAll + Add is
-        // deterministic in both wiring orders: registered first, the base TryAdd no-ops;
-        // registered second, the Null default is removed here.
+        // deterministic in both wiring orders: registered first, the base TryAdd no-ops,
+        // and registered second, the Null default is removed here.
         builder.Services.RemoveAll<IConsentLedger>();
         builder.Services.AddScoped<IConsentLedger, EfCoreConsentLedger>();
 

--- a/src/Granit.Http.Cookies/Domain/CookieConsentRecord.cs
+++ b/src/Granit.Http.Cookies/Domain/CookieConsentRecord.cs
@@ -26,7 +26,7 @@ namespace Granit.Http.Cookies.Domain;
 /// </para>
 /// </remarks>
 [AuditIgnore]
-public class CookieConsentRecord : CreationAuditedEntity, IMultiTenant
+public sealed class CookieConsentRecord : CreationAuditedEntity, IMultiTenant
 {
     /// <summary>Maximum stored length of the client User-Agent header.</summary>
     public const int MaxUserAgentLength = 256;

--- a/src/Granit.Http.Idempotency/Internal/IdempotencyMiddleware.cs
+++ b/src/Granit.Http.Idempotency/Internal/IdempotencyMiddleware.cs
@@ -309,24 +309,7 @@ internal sealed partial class IdempotencyMiddleware(
             return;
         }
 
-        // Capture response headers, filtering anything that must not be
-        // replayed to a later retry (Set-Cookie rotation, WWW-Authenticate
-        // challenges, etc. — see IdempotencyOptions.ExcludedResponseHeaders).
-        Dictionary<string, string[]> headers = [];
-        foreach (System.Collections.Generic.KeyValuePair<string, Microsoft.Extensions.Primitives.StringValues> h in context.Response.Headers)
-        {
-            if (_opts.ExcludedResponseHeaders.Contains(h.Key))
-            {
-                continue;
-            }
-
-            // HTTP header values are never null — null-suppression is intentional
-            string[] values = h.Value.ToArray()!;
-            if (values.Length > 0)
-            {
-                headers[h.Key] = values;
-            }
-        }
+        Dictionary<string, string[]> headers = CaptureReplayableHeaders(context);
 
         byte[] responseBody = captureStream.GetReadOnlySequence().ToArray();
 
@@ -350,6 +333,32 @@ internal sealed partial class IdempotencyMiddleware(
         {
             LogKeyExpiredBeforeTerminalWrite(_logger, redisKey);
         }
+    }
+
+    /// <summary>
+    /// Snapshots the response headers, dropping anything that must not be replayed to a later
+    /// retry (Set-Cookie rotation, WWW-Authenticate challenges — see
+    /// <see cref="IdempotencyOptions.ExcludedResponseHeaders"/>).
+    /// </summary>
+    private Dictionary<string, string[]> CaptureReplayableHeaders(HttpContext context)
+    {
+        Dictionary<string, string[]> headers = [];
+        foreach (System.Collections.Generic.KeyValuePair<string, Microsoft.Extensions.Primitives.StringValues> h in context.Response.Headers)
+        {
+            if (_opts.ExcludedResponseHeaders.Contains(h.Key))
+            {
+                continue;
+            }
+
+            // HTTP header values are never null — null-suppression is intentional
+            string[] values = h.Value.ToArray()!;
+            if (values.Length > 0)
+            {
+                headers[h.Key] = values;
+            }
+        }
+
+        return headers;
     }
 
     // =========================================================================

--- a/src/Granit.Http.ODataExposure/Extensions/ODataExposureEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Http.ODataExposure/Extensions/ODataExposureEndpointRouteBuilderExtensions.cs
@@ -711,8 +711,8 @@ public static class ODataExposureEndpointRouteBuilderExtensions
 
         // #1392 silent-clamp contract: an over-cap $top is pinned down to MaxTop BEFORE
         // validation so options.Validate() — which enforces the model-bound MaxTop set via
-        // SetMaxTop and would otherwise return 400 — accepts it. ApplyTo applies the same cap;
-        // the OData-MaxTop-Applied header was already emitted above from the original value.
+        // SetMaxTop and would otherwise return 400 — accepts it. ApplyTo applies the same cap,
+        // and the OData-MaxTop-Applied header was already emitted above from the original value.
         options = ClampTopToCap(options, httpContext, descriptor.MaxTop);
 
         // #3004 — the user's $filter is translated into the engine's strict predicate tree

--- a/src/Granit.Http.ODataExposure/Extensions/ODataExposureEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Http.ODataExposure/Extensions/ODataExposureEndpointRouteBuilderExtensions.cs
@@ -433,50 +433,64 @@ public static class ODataExposureEndpointRouteBuilderExtensions
     {
         foreach (string path in descriptor.ExpandWhitelist ?? [])
         {
-            if (string.IsNullOrWhiteSpace(path))
+            if (!string.IsNullOrWhiteSpace(path))
             {
-                continue;
+                ValidateExpandPath(path, descriptor, exportDefinitions, scalarsByType, navigationsByType, errors);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Walks one dotted <c>$expand</c> path segment by segment, recording the navigations it
+    /// traverses and the scalar whitelist of every type it reaches. Stops at the first bad
+    /// segment, appending the error in place.
+    /// </summary>
+    private static void ValidateExpandPath(
+        string path,
+        ODataEntitySetDescriptor descriptor,
+        IReadOnlyList<IExportDefinitionDescriptor> exportDefinitions,
+        Dictionary<Type, IReadOnlyList<string>> scalarsByType,
+        Dictionary<Type, HashSet<string>> navigationsByType,
+        List<string> errors)
+    {
+        Type currentType = descriptor.EntityType;
+        foreach (string segment in path.Split('.', StringSplitOptions.TrimEntries))
+        {
+            PropertyInfo? navigation = Array.Find(
+                currentType.GetProperties(BindingFlags.Public | BindingFlags.Instance),
+                p => string.Equals(p.Name, segment, StringComparison.OrdinalIgnoreCase));
+
+            if (navigation is null || !ODataEdmModelBuilder.IsNavigationOrCollection(navigation.PropertyType))
+            {
+                errors.Add(
+                    $"EntitySet '{descriptor.EntitySetName}' whitelists $expand path '{path}' but '{segment}' is not a navigation property on '{currentType.Name}'. Fix the path or remove it from ExpandWhitelist(...).");
+                break;
             }
 
-            Type currentType = descriptor.EntityType;
-            foreach (string segment in path.Split('.', StringSplitOptions.TrimEntries))
+            if (!navigationsByType.TryGetValue(currentType, out HashSet<string>? navigations))
             {
-                PropertyInfo? navigation = Array.Find(
-                    currentType.GetProperties(BindingFlags.Public | BindingFlags.Instance),
-                    p => string.Equals(p.Name, segment, StringComparison.OrdinalIgnoreCase));
+                navigations = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                navigationsByType[currentType] = navigations;
+            }
 
-                if (navigation is null || !ODataEdmModelBuilder.IsNavigationOrCollection(navigation.PropertyType))
+            navigations.Add(navigation.Name);
+
+            Type targetType = ODataEdmModelBuilder.ResolveNavigationTargetType(navigation.PropertyType);
+            if (!scalarsByType.ContainsKey(targetType))
+            {
+                IExportDefinitionDescriptor? export = exportDefinitions
+                    .FirstOrDefault(e => e.EntityType == targetType);
+                if (export is null)
                 {
                     errors.Add(
-                        $"EntitySet '{descriptor.EntitySetName}' whitelists $expand path '{path}' but '{segment}' is not a navigation property on '{currentType.Name}'. Fix the path or remove it from ExpandWhitelist(...).");
+                        $"EntitySet '{descriptor.EntitySetName}' whitelists $expand path '{path}' reaching target type '{targetType.Name}', which has no registered IExportDefinitionDescriptor. Per ADR-050 every type reachable through $expand needs an export-derived scalar whitelist — register an ExportDefinition for {targetType.Name} (services.AddExportDefinition<{targetType.Name}, {targetType.Name}ExportDefinition>()) or remove the path.");
                     break;
                 }
 
-                if (!navigationsByType.TryGetValue(currentType, out HashSet<string>? navigations))
-                {
-                    navigations = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-                    navigationsByType[currentType] = navigations;
-                }
-
-                navigations.Add(navigation.Name);
-
-                Type targetType = ODataEdmModelBuilder.ResolveNavigationTargetType(navigation.PropertyType);
-                if (!scalarsByType.ContainsKey(targetType))
-                {
-                    IExportDefinitionDescriptor? export = exportDefinitions
-                        .FirstOrDefault(e => e.EntityType == targetType);
-                    if (export is null)
-                    {
-                        errors.Add(
-                            $"EntitySet '{descriptor.EntitySetName}' whitelists $expand path '{path}' reaching target type '{targetType.Name}', which has no registered IExportDefinitionDescriptor. Per ADR-050 every type reachable through $expand needs an export-derived scalar whitelist — register an ExportDefinition for {targetType.Name} (services.AddExportDefinition<{targetType.Name}, {targetType.Name}ExportDefinition>()) or remove the path.");
-                        break;
-                    }
-
-                    scalarsByType[targetType] = ScalarFieldsOf(export);
-                }
-
-                currentType = targetType;
+                scalarsByType[targetType] = ScalarFieldsOf(export);
             }
+
+            currentType = targetType;
         }
     }
 
@@ -1028,58 +1042,80 @@ public static class ODataExposureEndpointRouteBuilderExtensions
     {
         foreach (ExpandedReferenceSelectItem item in items.OfType<ExpandedReferenceSelectItem>())
         {
-            IReadOnlyList<string> navSegments = [.. item.PathToNavigationProperty
-                .OfType<NavigationPropertySegment>()
-                .Select(s => s.NavigationProperty.Name)];
-            if (navSegments.Count == 0)
+            (ProblemHttpResult? Rejection, string Reason) result =
+                ValidateExpandItem(item, prefix, depth, descriptor, allowedExpandPaths);
+            if (result.Rejection is not null)
             {
-                continue;
+                return result;
             }
+        }
 
-            string path = prefix is null
-                ? string.Join('.', navSegments)
-                : $"{prefix}.{string.Join('.', navSegments)}";
-            int itemDepth = depth + navSegments.Count;
+        return (null, string.Empty);
+    }
 
-            long extraLevels = (item as ExpandedNavigationSelectItem)?.LevelsOption switch
-            {
-                null => 0,
-                { IsMaxLevel: true } => long.MaxValue,
-                { } levels => levels.Level - 1,
-            };
+    /// <summary>
+    /// Gates a single expand item: depth first (a too-deep path is a depth problem even when
+    /// un-whitelisted), then whitelist membership for the path and each <c>$levels</c>
+    /// repetition, then recursion into its own nested expands.
+    /// </summary>
+    private static (ProblemHttpResult? Rejection, string Reason) ValidateExpandItem(
+        ExpandedReferenceSelectItem item,
+        string? prefix,
+        int depth,
+        ODataEntitySetDescriptor descriptor,
+        FrozenSet<string> allowedExpandPaths)
+    {
+        IReadOnlyList<string> navSegments = [.. item.PathToNavigationProperty
+            .OfType<NavigationPropertySegment>()
+            .Select(s => s.NavigationProperty.Name)];
+        if (navSegments.Count == 0)
+        {
+            return (null, string.Empty);
+        }
 
-            if (extraLevels == long.MaxValue || itemDepth + extraLevels > descriptor.MaxExpansionDepth)
+        string path = prefix is null
+            ? string.Join('.', navSegments)
+            : $"{prefix}.{string.Join('.', navSegments)}";
+        int itemDepth = depth + navSegments.Count;
+
+        long extraLevels = (item as ExpandedNavigationSelectItem)?.LevelsOption switch
+        {
+            null => 0,
+            { IsMaxLevel: true } => long.MaxValue,
+            { } levels => levels.Level - 1,
+        };
+
+        if (extraLevels == long.MaxValue || itemDepth + extraLevels > descriptor.MaxExpansionDepth)
+        {
+            return (TypedResults.Problem(
+                detail: $"$expand nesting depth at '{path}' exceeds the maximum of {descriptor.MaxExpansionDepth} on the '{descriptor.EntitySetName}' EntitySet.",
+                statusCode: StatusCodes.Status400BadRequest,
+                title: "Expand depth exceeded"), "expand_depth_exceeded");
+        }
+
+        // $levels repeats the LAST navigation segment — each repetition is
+        // a deeper dotted path and must be whitelisted like explicit nesting.
+        string levelPath = path;
+        for (long level = 0; level <= extraLevels; level++)
+        {
+            if (!allowedExpandPaths.Contains(levelPath))
             {
                 return (TypedResults.Problem(
-                    detail: $"$expand nesting depth at '{path}' exceeds the maximum of {descriptor.MaxExpansionDepth} on the '{descriptor.EntitySetName}' EntitySet.",
+                    detail: $"$expand of '{levelPath}' is not permitted on the '{descriptor.EntitySetName}' EntitySet. Allowed paths: {string.Join(", ", allowedExpandPaths.Order(StringComparer.OrdinalIgnoreCase))}.",
                     statusCode: StatusCodes.Status400BadRequest,
-                    title: "Expand depth exceeded"), "expand_depth_exceeded");
+                    title: "Expand path not whitelisted"), "expand_not_whitelisted");
             }
 
-            // $levels repeats the LAST navigation segment — each repetition is
-            // a deeper dotted path and must be whitelisted like explicit nesting.
-            string levelPath = path;
-            for (long level = 0; level <= extraLevels; level++)
-            {
-                if (!allowedExpandPaths.Contains(levelPath))
-                {
-                    return (TypedResults.Problem(
-                        detail: $"$expand of '{levelPath}' is not permitted on the '{descriptor.EntitySetName}' EntitySet. Allowed paths: {string.Join(", ", allowedExpandPaths.Order(StringComparer.OrdinalIgnoreCase))}.",
-                        statusCode: StatusCodes.Status400BadRequest,
-                        title: "Expand path not whitelisted"), "expand_not_whitelisted");
-                }
+            levelPath = $"{levelPath}.{navSegments[^1]}";
+        }
 
-                levelPath = $"{levelPath}.{navSegments[^1]}";
-            }
-
-            if (item is ExpandedNavigationSelectItem { SelectAndExpand: { } nested })
+        if (item is ExpandedNavigationSelectItem { SelectAndExpand: { } nested })
+        {
+            (ProblemHttpResult? Rejection, string Reason) nestedResult =
+                ValidateExpandItems(nested.SelectedItems, path, itemDepth, descriptor, allowedExpandPaths);
+            if (nestedResult.Rejection is not null)
             {
-                (ProblemHttpResult? Rejection, string Reason) nestedResult =
-                    ValidateExpandItems(nested.SelectedItems, path, itemDepth, descriptor, allowedExpandPaths);
-                if (nestedResult.Rejection is not null)
-                {
-                    return nestedResult;
-                }
+                return nestedResult;
             }
         }
 

--- a/src/Granit.Identity.EntityFrameworkCore/GranitIdentityEntityFrameworkCoreModule.cs
+++ b/src/Granit.Identity.EntityFrameworkCore/GranitIdentityEntityFrameworkCoreModule.cs
@@ -25,13 +25,11 @@ namespace Granit.Identity.EntityFrameworkCore;
 public sealed class GranitIdentityEntityFrameworkCoreModule : GranitModule
 {
     /// <inheritdoc />
-    public override void ConfigureServices(ServiceConfigurationContext context)
-    {
-        // Durable session-security state store (risk verdicts, device trust, behavioural profile, single-use
-        // session-review decisions), persisting to the User DbContext. Overrides the in-memory default from
-        // Granit.Identity.Abstractions so verdicts, trusted devices, habitual profiles and review idempotency
-        // all survive restarts and span instances. The DbContext itself is registered by
-        // AddGranitIdentityEntityFrameworkCore.
+    // Durable session-security state store (risk verdicts, device trust, behavioural profile, single-use
+    // session-review decisions), persisting to the User DbContext. Overrides the in-memory default from
+    // Granit.Identity.Abstractions so verdicts, trusted devices, habitual profiles and review idempotency
+    // all survive restarts and span instances. The DbContext itself is registered by
+    // AddGranitIdentityEntityFrameworkCore.
+    public override void ConfigureServices(ServiceConfigurationContext context) =>
         context.Services.AddScoped<IIdentitySecurityStateStore, EfCoreIdentitySecurityStateStore>();
-    }
 }

--- a/src/Granit.Identity.Federated.Privacy/DataDeletion/IdentityFederatedPersonalDataDeletionHandler.cs
+++ b/src/Granit.Identity.Federated.Privacy/DataDeletion/IdentityFederatedPersonalDataDeletionHandler.cs
@@ -40,8 +40,8 @@ public class IdentityFederatedPersonalDataDeletionHandler
         ArgumentNullException.ThrowIfNull(currentTenant);
 
         // Distributed dispatch carries no ambient tenant — establish it from the event so the
-        // multi-tenant query filter exposes the rows the eraser's explicit predicate targets;
-        // without it the erasure silently no-ops on tenant-scoped mirrors while the saga acks.
+        // multi-tenant query filter exposes the rows the eraser's explicit predicate targets.
+        // Without it the erasure silently no-ops on tenant-scoped mirrors while the saga acks.
         // A null resolved scope (no tenant on the event, none ambient) erases across ALL
         // partitions: Art. 17 must not leave a mirror behind in any scope.
         Guid? tenantId = @event.TenantId ?? (currentTenant.IsAvailable ? currentTenant.Id : null);

--- a/src/Granit.Imaging.AI/Internal/LlmImageAnalyzer.cs
+++ b/src/Granit.Imaging.AI/Internal/LlmImageAnalyzer.cs
@@ -102,7 +102,7 @@ internal sealed partial class LlmImageAnalyzer(
     private static string NormalizeContentType(string contentType) =>
         AllowedContentTypes.Contains(contentType) ? contentType : "other";
 
-    // Preserves the analyzer's exception-based contract over the primitive's status codes;
+    // Preserves the analyzer's exception-based contract over the primitive's status codes.
     // ErrorMessage is PII-safe by the primitive's contract (never echoes model output).
     private static ImageAnalysis MapResult(StructuredCompletionResult<LlmAnalysisResponse> completion) =>
         completion.Status switch

--- a/src/Granit.Notifications.EntityFrameworkCore/Internal/EntityTrackingInterceptor.cs
+++ b/src/Granit.Notifications.EntityFrameworkCore/Internal/EntityTrackingInterceptor.cs
@@ -21,7 +21,7 @@ internal sealed class EntityTrackingInterceptor(
     // post-commit: publishing from SavingChangesAsync fired follower notifications for
     // saves that subsequently failed or rolled back. Keyed per context instance —
     // ConditionalWeakTable so a context that never completes cannot leak.
-    private readonly System.Runtime.CompilerServices.ConditionalWeakTable<DbContext, List<EntityStateChange>> _pendingChanges = new();
+    private readonly System.Runtime.CompilerServices.ConditionalWeakTable<DbContext, List<EntityStateChange>> _pendingChanges = [];
 
     /// <inheritdoc/>
     public override ValueTask<InterceptionResult<int>> SavingChangesAsync(

--- a/src/Granit.Observability/Extensions/ObservabilityServiceCollectionExtensions.cs
+++ b/src/Granit.Observability/Extensions/ObservabilityServiceCollectionExtensions.cs
@@ -193,8 +193,8 @@ public static class ObservabilityServiceCollectionExtensions
             .AddMeter("Granit.*");
 
         // Meters emitted by embedded third-party libraries under their own namespace
-        // (e.g. FusionCache's "ZiggyCreatures.Caching.Fusion") fall outside the wildcard;
-        // modules declare them via GranitMeterRegistry.Register().
+        // (e.g. FusionCache's "ZiggyCreatures.Caching.Fusion") fall outside the wildcard,
+        // so modules declare them via GranitMeterRegistry.Register().
         foreach (string meter in GranitMeterRegistry.GetRegisteredMeters())
         {
             metrics.AddMeter(meter);

--- a/src/Granit.OpenIddict.Endpoints/Endpoints/AdminOidcEndpoints.cs
+++ b/src/Granit.OpenIddict.Endpoints/Endpoints/AdminOidcEndpoints.cs
@@ -649,29 +649,6 @@ internal static class AdminOidcEndpoints
         (int size, int offset) = ResolvePaging(page, pageSize);
         var clientIdCache = new Dictionary<string, string?>(StringComparer.Ordinal);
 
-        async Task<AdminOidcAuthorizationResponse> BuildAsync(object auth)
-        {
-            string? id = await authorizationManager.GetIdAsync(auth, cancellationToken).ConfigureAwait(false);
-            var descriptor = new OpenIddictAuthorizationDescriptor();
-            await authorizationManager.PopulateAsync(descriptor, auth, cancellationToken).ConfigureAwait(false);
-
-            string? resolvedClientId = null;
-            if (descriptor.ApplicationId is not null
-                && !clientIdCache.TryGetValue(descriptor.ApplicationId, out resolvedClientId))
-            {
-                object? app = await applicationManager.FindByIdAsync(descriptor.ApplicationId, cancellationToken).ConfigureAwait(false);
-                resolvedClientId = app is not null
-                    ? await applicationManager.GetClientIdAsync(app, cancellationToken).ConfigureAwait(false)
-                    : null;
-                clientIdCache[descriptor.ApplicationId] = resolvedClientId;
-            }
-
-            return new AdminOidcAuthorizationResponse(
-                Guid.TryParse(id, out Guid parsedId) ? parsedId : Guid.Empty,
-                descriptor.Subject, resolvedClientId, descriptor.Status, descriptor.Type,
-                [.. descriptor.Scopes]);
-        }
-
         // A clientId filter is resolved to the internal application id — the manager filters
         // authorizations by application id, not by the public client_id.
         string? applicationId = null;
@@ -692,7 +669,9 @@ internal static class AdminOidcEndpoints
             var pageItems = new List<AdminOidcAuthorizationResponse>();
             await foreach (object auth in authorizationManager.ListAsync(size, offset, cancellationToken).ConfigureAwait(false))
             {
-                pageItems.Add(await BuildAsync(auth).ConfigureAwait(false));
+                pageItems.Add(await BuildAuthorizationResponseAsync(
+                    authorizationManager, applicationManager, clientIdCache, auth, cancellationToken)
+                    .ConfigureAwait(false));
             }
 
             long total = await authorizationManager.CountAsync(cancellationToken).ConfigureAwait(false);
@@ -719,11 +698,46 @@ internal static class AdminOidcEndpoints
         var results = new List<AdminOidcAuthorizationResponse>();
         foreach (object auth in allMatches.Skip(offset).Take(size))
         {
-            results.Add(await BuildAsync(auth).ConfigureAwait(false));
+            results.Add(await BuildAuthorizationResponseAsync(
+                    authorizationManager, applicationManager, clientIdCache, auth, cancellationToken)
+                    .ConfigureAwait(false));
         }
 
         return TypedResults.Ok(new PagedResult<AdminOidcAuthorizationResponse>(
             results, allMatches.Count, offset + results.Count < allMatches.Count));
+    }
+
+    /// <summary>
+    /// Projects one OpenIddict authorization onto its response shape, resolving the public
+    /// client_id through <paramref name="clientIdCache"/> so a page sharing an application
+    /// costs a single application lookup.
+    /// </summary>
+    private static async Task<AdminOidcAuthorizationResponse> BuildAuthorizationResponseAsync(
+        IOpenIddictAuthorizationManager authorizationManager,
+        IOpenIddictApplicationManager applicationManager,
+        Dictionary<string, string?> clientIdCache,
+        object auth,
+        CancellationToken cancellationToken)
+    {
+        string? id = await authorizationManager.GetIdAsync(auth, cancellationToken).ConfigureAwait(false);
+        var descriptor = new OpenIddictAuthorizationDescriptor();
+        await authorizationManager.PopulateAsync(descriptor, auth, cancellationToken).ConfigureAwait(false);
+
+        string? resolvedClientId = null;
+        if (descriptor.ApplicationId is not null
+            && !clientIdCache.TryGetValue(descriptor.ApplicationId, out resolvedClientId))
+        {
+            object? app = await applicationManager.FindByIdAsync(descriptor.ApplicationId, cancellationToken).ConfigureAwait(false);
+            resolvedClientId = app is not null
+                ? await applicationManager.GetClientIdAsync(app, cancellationToken).ConfigureAwait(false)
+                : null;
+            clientIdCache[descriptor.ApplicationId] = resolvedClientId;
+        }
+
+        return new AdminOidcAuthorizationResponse(
+            Guid.TryParse(id, out Guid parsedId) ? parsedId : Guid.Empty,
+            descriptor.Subject, resolvedClientId, descriptor.Status, descriptor.Type,
+            [.. descriptor.Scopes]);
     }
 
     /// <summary>

--- a/src/Granit.Persistence.EntityFrameworkCore/Conventions/GranitOwnershipIndexConvention.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/Conventions/GranitOwnershipIndexConvention.cs
@@ -20,52 +20,62 @@ internal sealed class GranitOwnershipIndexConvention : IModelFinalizingConventio
     {
         foreach (IConventionEntityType entityType in modelBuilder.Metadata.GetEntityTypes())
         {
-            if (!typeof(IOwnable).IsAssignableFrom(entityType.ClrType))
-            {
-                continue;
-            }
-
-            string? tableName = entityType.GetTableName();
-            if (tableName is null)
-            {
-                continue; // Keyless / TPH-derived / view-mapped — no own table to index.
-            }
-
-            bool isMultiTenant = typeof(IMultiTenant).IsAssignableFrom(entityType.ClrType);
-            string[] propertyNames = isMultiTenant
-                ? [nameof(IMultiTenant.TenantId), nameof(IOwnable.OwnerId)]
-                : [nameof(IOwnable.OwnerId)];
-
-            List<IConventionProperty> properties = [];
-            foreach (string name in propertyNames)
-            {
-                IConventionProperty? property = entityType.FindProperty(name);
-                if (property is null)
-                {
-                    properties.Clear();
-                    break;
-                }
-
-                properties.Add(property);
-            }
-
-            if (properties.Count == 0)
-            {
-                continue;
-            }
-
-            bool alreadyIndexed = entityType.GetIndexes().Any(idx =>
-                idx.Properties.Count == propertyNames.Length
-                && idx.Properties.Select(p => p.Name).SequenceEqual(propertyNames));
-
-            if (alreadyIndexed)
-            {
-                continue;
-            }
-
-            string suffix = isMultiTenant ? "tenant_owner" : "owner";
-            entityType.Builder.HasIndex(properties)
-                ?.Metadata.SetDatabaseName($"ix_{tableName}_{suffix}");
+            ApplyOwnershipIndex(entityType);
         }
     }
+
+    private static void ApplyOwnershipIndex(IConventionEntityType entityType)
+    {
+        if (!typeof(IOwnable).IsAssignableFrom(entityType.ClrType))
+        {
+            return;
+        }
+
+        string? tableName = entityType.GetTableName();
+        if (tableName is null)
+        {
+            return; // Keyless / TPH-derived / view-mapped — no own table to index.
+        }
+
+        bool isMultiTenant = typeof(IMultiTenant).IsAssignableFrom(entityType.ClrType);
+        string[] propertyNames = isMultiTenant
+            ? [nameof(IMultiTenant.TenantId), nameof(IOwnable.OwnerId)]
+            : [nameof(IOwnable.OwnerId)];
+
+        if (!TryResolveProperties(entityType, propertyNames, out List<IConventionProperty> properties)
+            || IsAlreadyIndexed(entityType, propertyNames))
+        {
+            return;
+        }
+
+        string suffix = isMultiTenant ? "tenant_owner" : "owner";
+        entityType.Builder.HasIndex(properties)
+            ?.Metadata.SetDatabaseName($"ix_{tableName}_{suffix}");
+    }
+
+    private static bool TryResolveProperties(
+        IConventionEntityType entityType,
+        string[] propertyNames,
+        out List<IConventionProperty> properties)
+    {
+        properties = [];
+        foreach (string name in propertyNames)
+        {
+            IConventionProperty? property = entityType.FindProperty(name);
+            if (property is null)
+            {
+                properties.Clear();
+                return false;
+            }
+
+            properties.Add(property);
+        }
+
+        return true;
+    }
+
+    private static bool IsAlreadyIndexed(IConventionEntityType entityType, string[] propertyNames) =>
+        entityType.GetIndexes().Any(idx =>
+            idx.Properties.Count == propertyNames.Length
+            && idx.Properties.Select(p => p.Name).SequenceEqual(propertyNames));
 }

--- a/src/Granit.Persistence.EntityFrameworkCore/Conventions/GranitTranslationConvention.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/Conventions/GranitTranslationConvention.cs
@@ -30,41 +30,66 @@ internal sealed class GranitTranslationConvention : IModelFinalizingConvention
                 continue;
             }
 
-            IConventionProperty? culture = entityType.FindProperty(nameof(ITranslation.Culture));
-            if (culture is not null)
-            {
-                if (culture.GetMaxLength() is null)
-                {
-                    culture.SetMaxLength(20);
-                }
+            ConfigureCulture(entityType);
+            ConfigureParentRelationship(modelBuilder, entityType, translationInterface);
+            ConfigureUniqueIndex(entityType);
+        }
+    }
 
-                culture.SetIsNullable(false);
-            }
+    private static void ConfigureCulture(IConventionEntityType entityType)
+    {
+        IConventionProperty? culture = entityType.FindProperty(nameof(ITranslation.Culture));
+        if (culture is null)
+        {
+            return;
+        }
 
-            Type parentType = translationInterface.GetGenericArguments()[0];
-            IConventionEntityType? parentEntityType = modelBuilder.Metadata.FindEntityType(parentType);
-            IConventionProperty? parentId = entityType.FindProperty(nameof(ITranslation.ParentId));
+        if (culture.GetMaxLength() is null)
+        {
+            culture.SetMaxLength(20);
+        }
 
-            if (parentEntityType is not null && parentId is not null)
-            {
-                IConventionForeignKeyBuilder? fkBuilder = entityType.Builder.HasRelationship(
-                    parentEntityType, [parentId], parentEntityType.FindPrimaryKey()!);
-                fkBuilder?.Metadata.SetDeleteBehavior(Microsoft.EntityFrameworkCore.DeleteBehavior.Cascade);
-                fkBuilder?.Metadata.SetDependentToPrincipal(
-                    entityType.ClrType.GetProperty(nameof(ITranslation<Entity>.Parent)));
-            }
+        culture.SetIsNullable(false);
+    }
 
-            IConventionProperty? cultureProperty = entityType.FindProperty(nameof(ITranslation.Culture));
-            if (parentId is not null && cultureProperty is not null)
-            {
-                IConventionProperty[] indexProperties = [parentId, cultureProperty];
-                bool exists = entityType.GetIndexes().Any(i =>
-                    i.Properties.Select(p => p.Name).SequenceEqual(indexProperties.Select(p => p.Name)));
-                if (!exists)
-                {
-                    entityType.Builder.HasIndex(indexProperties)?.Metadata.SetIsUnique(true);
-                }
-            }
+    private static void ConfigureParentRelationship(
+        IConventionModelBuilder modelBuilder,
+        IConventionEntityType entityType,
+        Type translationInterface)
+    {
+        Type parentType = translationInterface.GetGenericArguments()[0];
+        IConventionEntityType? parentEntityType = modelBuilder.Metadata.FindEntityType(parentType);
+        IConventionProperty? parentId = entityType.FindProperty(nameof(ITranslation.ParentId));
+
+        if (parentEntityType is null || parentId is null)
+        {
+            return;
+        }
+
+        IConventionForeignKeyBuilder? fkBuilder = entityType.Builder.HasRelationship(
+            parentEntityType, [parentId], parentEntityType.FindPrimaryKey()!);
+        fkBuilder?.Metadata.SetDeleteBehavior(Microsoft.EntityFrameworkCore.DeleteBehavior.Cascade);
+        fkBuilder?.Metadata.SetDependentToPrincipal(
+            entityType.ClrType.GetProperty(nameof(ITranslation<Entity>.Parent)));
+    }
+
+    private static void ConfigureUniqueIndex(IConventionEntityType entityType)
+    {
+        IConventionProperty? parentId = entityType.FindProperty(nameof(ITranslation.ParentId));
+        IConventionProperty? culture = entityType.FindProperty(nameof(ITranslation.Culture));
+
+        if (parentId is null || culture is null)
+        {
+            return;
+        }
+
+        IConventionProperty[] indexProperties = [parentId, culture];
+        bool exists = entityType.GetIndexes().Any(i =>
+            i.Properties.Select(p => p.Name).SequenceEqual(indexProperties.Select(p => p.Name)));
+
+        if (!exists)
+        {
+            entityType.Builder.HasIndex(indexProperties)?.Metadata.SetIsUnique(true);
         }
     }
 }

--- a/tests/Granit.DataExchange.EntityFrameworkCore.Tests/Infrastructure/TestAppDbContext.cs
+++ b/tests/Granit.DataExchange.EntityFrameworkCore.Tests/Infrastructure/TestAppDbContext.cs
@@ -10,9 +10,7 @@ internal sealed class TestAppDbContext(DbContextOptions<TestAppDbContext> option
 {
     public DbSet<TestEntity> TestEntities { get; set; } = null!;
 
-    protected override void OnModelCreating(ModelBuilder modelBuilder)
-    {
-        // A unique constraint the executor's poison-row-isolation tests can violate on purpose.
+    // A unique constraint the executor's poison-row-isolation tests can violate on purpose.
+    protected override void OnModelCreating(ModelBuilder modelBuilder) =>
         modelBuilder.Entity<TestEntity>().HasIndex(e => e.Niss).IsUnique();
-    }
 }

--- a/tests/Granit.OpenIddict.Tests/Options/GranitOpenIddictOptionsTests.cs
+++ b/tests/Granit.OpenIddict.Tests/Options/GranitOpenIddictOptionsTests.cs
@@ -22,10 +22,8 @@ public sealed class GranitOpenIddictOptionsTests
     }
 
     [Fact]
-    public void WithFapi2Profile_DoesNotRequireJar()
-    {
-        // FAPI 2.0 mandates PAR, not JAR (JAR is FAPI 1 Advanced). Forcing RequireJar broke
-        // the normal PAR-only flow — clients pushing plain params get no `request` object.
+    // FAPI 2.0 mandates PAR, not JAR (JAR is FAPI 1 Advanced). Forcing RequireJar broke
+    // the normal PAR-only flow — clients pushing plain params get no `request` object.
+    public void WithFapi2Profile_DoesNotRequireJar() =>
         new GranitOpenIddictOptions().WithFapi2Profile().RequireJar.ShouldBeFalse();
-    }
 }

--- a/tests/Granit.Persistence.EntityFrameworkCore.Hosting.Tests/GranitMigrateOptionsTests.cs
+++ b/tests/Granit.Persistence.EntityFrameworkCore.Hosting.Tests/GranitMigrateOptionsTests.cs
@@ -41,11 +41,9 @@ public sealed class GranitMigrateOptionsTests
     }
 
     [Fact]
-    public void IsDistributedLockRequired_UnknownEnvironment_FailsClosed()
-    {
-        // No IHostEnvironment available (bare DI, tools) → production assumption.
+    // No IHostEnvironment available (bare DI, tools) → production assumption.
+    public void IsDistributedLockRequired_UnknownEnvironment_FailsClosed() =>
         new GranitMigrateOptions().IsDistributedLockRequired(null).ShouldBeTrue();
-    }
 
     private sealed class FakeEnvironment(string name) : IHostEnvironment
     {
@@ -56,9 +54,7 @@ public sealed class GranitMigrateOptionsTests
     }
 
     [Fact]
-    public void SectionName_is_the_documented_configuration_section()
-    {
-        // Contract with appsettings/Helm overlays — renaming silently orphans deployed config.
+    // Contract with appsettings/Helm overlays — renaming silently orphans deployed config.
+    public void SectionName_is_the_documented_configuration_section() =>
         GranitMigrateOptions.SectionName.ShouldBe("Persistence:Migrate");
-    }
 }

--- a/tests/Granit.QueryEngine.Abstractions.Tests/FilterOperatorInferenceTests.cs
+++ b/tests/Granit.QueryEngine.Abstractions.Tests/FilterOperatorInferenceTests.cs
@@ -26,10 +26,7 @@ public sealed class FilterOperatorInferenceTests
     }
 
     [Fact]
-    public void Unsupported_Type_Offers_No_Operators()
-    {
-        FilterOperatorInference.GetOperators(typeof(Uri)).ShouldBeEmpty();
-    }
+    public void Unsupported_Type_Offers_No_Operators() => FilterOperatorInference.GetOperators(typeof(Uri)).ShouldBeEmpty();
 
     [Fact]
     public void Single_Argument_Overload_Never_Offers_Null_Checks()
@@ -82,12 +79,10 @@ public sealed class FilterOperatorInferenceTests
     }
 
     [Fact]
-    public void Nullable_Overload_On_Unsupported_Type_Stays_Empty()
-    {
-        // A nullable column of an unsupported type still filters nothing — null checks are
-        // only offered on top of a non-empty base operator set.
+    // A nullable column of an unsupported type still filters nothing — null checks are
+    // only offered on top of a non-empty base operator set.
+    public void Nullable_Overload_On_Unsupported_Type_Stays_Empty() =>
         FilterOperatorInference.GetOperators(typeof(Uri), isNullableColumn: true).ShouldBeEmpty();
-    }
 
     [Theory]
     [InlineData(typeof(string), true)]
@@ -96,8 +91,5 @@ public sealed class FilterOperatorInferenceTests
     [InlineData(typeof(int), false)]
     [InlineData(typeof(Guid), false)]
     [InlineData(typeof(DayOfWeek), false)]
-    public void IsNullableColumnType_Distinguishes_Reference_And_Nullable_Value_Types(Type clrType, bool expected)
-    {
-        FilterOperatorInference.IsNullableColumnType(clrType).ShouldBe(expected);
-    }
+    public void IsNullableColumnType_Distinguishes_Reference_And_Nullable_Value_Types(Type clrType, bool expected) => FilterOperatorInference.IsNullableColumnType(clrType).ShouldBe(expected);
 }

--- a/tests/Granit.QueryEngine.Abstractions.Tests/QueryPredicateTests.cs
+++ b/tests/Granit.QueryEngine.Abstractions.Tests/QueryPredicateTests.cs
@@ -77,16 +77,10 @@ public sealed class QueryPredicateTests
     }
 
     [Fact]
-    public void And_Rejects_Empty_Operands()
-    {
-        Should.Throw<ArgumentException>(() => QueryPredicate.And());
-    }
+    public void And_Rejects_Empty_Operands() => Should.Throw<ArgumentException>(() => QueryPredicate.And());
 
     [Fact]
-    public void Or_Rejects_Empty_Operands()
-    {
-        Should.Throw<ArgumentException>(() => QueryPredicate.Or());
-    }
+    public void Or_Rejects_Empty_Operands() => Should.Throw<ArgumentException>(() => QueryPredicate.Or());
 
     [Fact]
     public void And_Rejects_Null_Operand()
@@ -96,10 +90,7 @@ public sealed class QueryPredicateTests
     }
 
     [Fact]
-    public void Not_Rejects_Null_Operand()
-    {
-        Should.Throw<ArgumentNullException>(() => QueryPredicate.Not(null!));
-    }
+    public void Not_Rejects_Null_Operand() => Should.Throw<ArgumentNullException>(() => QueryPredicate.Not(null!));
 
     [Fact]
     public void Factories_Compose_Nested_Trees()

--- a/tests/Granit.QueryEngine.Abstractions.Tests/QueryPredicateValidationExceptionTests.cs
+++ b/tests/Granit.QueryEngine.Abstractions.Tests/QueryPredicateValidationExceptionTests.cs
@@ -41,8 +41,5 @@ public sealed class QueryPredicateValidationExceptionTests
     }
 
     [Fact]
-    public void Rejects_Empty_Error_List()
-    {
-        Should.Throw<ArgumentException>(() => new QueryPredicateValidationException([]));
-    }
+    public void Rejects_Empty_Error_List() => Should.Throw<ArgumentException>(() => new QueryPredicateValidationException([]));
 }


### PR DESCRIPTION
As a Backend Developer, I want the last Sonar findings that live in the code cleared, so that what remains in the backlog is only server-side configuration.

Clears 28 of the 90 open issues. The 62 left are all SonarCloud-side settings (architecture model, quality profile, waivers) — none of them are fixable from the repository.

## S125 — "commented out code" (7): all false positives

Every one of the seven is explanatory prose whose sentence happened to wrap after a semicolon, which the S125 heuristic reads as a statement:

```
// Data minimisation at capture (GDPR Art. 5(1)(c)): irreversible IP masking;
// the factory truncates the user-agent — the ledger never sees a raw identifier.
```

Deleting them would drop exactly the "why" the code cannot carry (GDPR Art. 5(1)(c) minimisation, the RemoveAll+Add ordering contract, the ADR-062 clamp contract, the tenant scope required for Art. 17 erasure). The wording is preserved verbatim; only the line break and the connector move.

## S3776 — cognitive complexity (7): real refactors

Each method is split along the seam it already had, with no behaviour change:

| Method | Was | Extracted |
| --- | --- | --- |
| `GranitOwnershipIndexConvention` | 19 | per-entity body, property resolution, de-duplication check |
| `GranitTranslationConvention` | 18 | culture, parent relationship, unique index |
| `ODataExposure.ValidateExpandItems` | 21 | per-item gate |
| `ODataExposure.ValidateExpandClosure` | 19 | per-path walk |
| `AdminOidcEndpoints.ListAuthorizationsAsync` | 18 | `BuildAsync` local function hoisted to a static method |
| `EfImportExecutor.ClassifyBatch` | 17 | `ClassifyRow`, returning null once the row is accounted for |
| `IdempotencyMiddleware.ExecuteAndCaptureAsync` | 17 | `CaptureReplayableHeaders` |

No extraction pushed a signature past the 7-parameter limit — trading S3776 for S107 would have been no gain.

## Roslyn style (14)

IDE0022 applied with `dotnet format style`; where the fixer stranded a comment between `=>` and the expression, the comment moved above the signature. `CookieConsentRecord` is sealed (every sibling entity on `CreationAuditedEntity` already is, and nothing derives from it). One collection expression for a `ConditionalWeakTable` initializer.

## Verification

Build with zero warnings and `dotnet format --verify-no-changes` clean on every touched project. Tests green: ArchitectureTests 641, Persistence.EntityFrameworkCore 405, OpenIddict 285, QueryEngine.Abstractions 221, ODataExposure 143, OpenIddict.Endpoints 136, Http.Cookies 132, Http.Idempotency 114, DataExchange.EntityFrameworkCore 78, plus 6 more suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)