### PR TITLE
fix(background-jobs): resolve handlers the way Wolverine does

### DIFF
--- a/src/Granit.BackgroundJobs/Granit.BackgroundJobs.csproj
+++ b/src/Granit.BackgroundJobs/Granit.BackgroundJobs.csproj
@@ -13,6 +13,11 @@
     <InternalsVisibleTo Include="Granit.BackgroundJobs.EntityFrameworkCore" />
     <InternalsVisibleTo Include="Granit.BackgroundJobs.EntityFrameworkCore.Tests" />
     <InternalsVisibleTo Include="Granit.BackgroundJobs.Wolverine.Tests" />
+    <!-- The handler-resolution architecture rule runs the real BackgroundJobHandlerResolver
+         against every satellite's job type. -->
+    <InternalsVisibleTo Include="Granit.ArchitectureTests" />
+    <!-- Channel-path smoke test over a job/handler pair shipped by a real satellite (#3206). -->
+    <InternalsVisibleTo Include="Granit.Auditing.BackgroundJobs.Tests" />
     <!-- Required by NSubstitute (Castle.DynamicProxy) to mock internal interfaces in tests -->
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
   </ItemGroup>

--- a/src/Granit.BackgroundJobs/Internal/BackgroundJobHandlerResolver.cs
+++ b/src/Granit.BackgroundJobs/Internal/BackgroundJobHandlerResolver.cs
@@ -1,0 +1,125 @@
+using System.Collections.Concurrent;
+using System.Reflection;
+using Granit.Reflection;
+
+namespace Granit.BackgroundJobs.Internal;
+
+/// <summary>
+/// Resolves the handler method for a background job message, mirroring Wolverine's
+/// discovery rule so the in-process channel path and the Wolverine path bind the
+/// same handler for the same message.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Wolverine binds a handler method on the <b>type of its first parameter</b>. The class
+/// name only gates discovery — it must end in <c>Handler</c> or <c>Consumer</c> — and the
+/// method must be named <c>Handle</c>, <c>Handles</c>, <c>Consume</c>, <c>Consumes</c> or an
+/// <c>Async</c> variant. So <c>MarkOverdueHandler.HandleAsync(MarkOverdueJob, …)</c> handles
+/// <c>MarkOverdueJob</c>, which is the shape every <c>Granit.{Module}.BackgroundJobs</c>
+/// satellite ships (CLAUDE.md documents the handler as <c>{Action}Handler</c>).
+/// </para>
+/// <para>
+/// Candidates are ranked so the resolution is deterministic: an exactly-named
+/// <c>{MessageTypeName}Handler</c> wins outright, then a handler whose first parameter is
+/// exactly the message type, then one accepting a base type or interface. A tie at the best
+/// rank is an ambiguity the caller must fix, so it throws rather than picking arbitrarily —
+/// silently running one of two sweeps is worse than a loud failure.
+/// </para>
+/// </remarks>
+internal static class BackgroundJobHandlerResolver
+{
+    private static readonly string[] HandlerMethodNames =
+        ["HandleAsync", "Handle", "HandlesAsync", "Handles", "ConsumeAsync", "Consume", "ConsumesAsync", "Consumes"];
+
+    private static readonly string[] HandlerTypeSuffixes = ["Handler", "Consumer"];
+
+    private static readonly ConcurrentDictionary<Type, HandlerBinding> Cache = new();
+
+    /// <summary>
+    /// Returns the handler type and method bound to <paramref name="messageType"/>.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// When the message assembly exposes no matching handler, or more than one equally
+    /// good candidate.
+    /// </exception>
+    internal static HandlerBinding Resolve(Type messageType)
+    {
+        ArgumentNullException.ThrowIfNull(messageType);
+
+        return Cache.GetOrAdd(messageType, static type => ResolveCore(type));
+    }
+
+    private static HandlerBinding ResolveCore(Type messageType)
+    {
+        List<Candidate> candidates = [];
+
+        foreach (Type type in messageType.Assembly.GetLoadableTypes())
+        {
+            if (!IsHandlerCandidate(type))
+            {
+                continue;
+            }
+
+            foreach (MethodInfo method in type.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static))
+            {
+                if (!HandlerMethodNames.Contains(method.Name, StringComparer.Ordinal)
+                    || method.GetParameters() is not [{ } first, ..]
+                    || !first.ParameterType.IsAssignableFrom(messageType))
+                {
+                    continue;
+                }
+
+                candidates.Add(new Candidate(type, method, Rank(type, first.ParameterType, messageType)));
+            }
+        }
+
+        if (candidates.Count == 0)
+        {
+            throw new InvalidOperationException(
+                $"No handler found in assembly '{messageType.Assembly.GetName().Name}' for message type " +
+                $"'{messageType.Name}'. Expected a public non-generic type whose name ends in 'Handler' or " +
+                "'Consumer', exposing a public HandleAsync/Handle (or Consume/Consumes) method taking " +
+                $"'{messageType.Name}' as its first parameter.");
+        }
+
+        int bestRank = candidates.Min(c => c.Rank);
+        List<Candidate> best = [.. candidates.Where(c => c.Rank == bestRank)
+            .OrderBy(c => c.HandlerType.FullName, StringComparer.Ordinal)];
+
+        // Several methods on the same handler type (overloads on the same message) are
+        // still an ambiguity — only a single distinct binding is invocable here.
+        if (best.Count > 1)
+        {
+            throw new InvalidOperationException(
+                $"Ambiguous handler for message type '{messageType.Name}' in assembly " +
+                $"'{messageType.Assembly.GetName().Name}': " +
+                string.Join(", ", best.Select(c => $"{c.HandlerType.Name}.{c.Method.Name}")) +
+                ". Keep exactly one handler method per job in the message's assembly.");
+        }
+
+        return new HandlerBinding(best[0].HandlerType, best[0].Method);
+    }
+
+    /// <summary>
+    /// A concrete or static class whose name gates Wolverine discovery. Static classes are
+    /// <c>abstract</c> + <c>sealed</c> at the CLR level, so only genuinely abstract types
+    /// are excluded.
+    /// </summary>
+    private static bool IsHandlerCandidate(Type type) =>
+        !type.IsInterface
+        && !type.IsGenericTypeDefinition
+        && (!type.IsAbstract || type.IsSealed)
+        && HandlerTypeSuffixes.Any(suffix => type.Name.EndsWith(suffix, StringComparison.Ordinal));
+
+    private static int Rank(Type handlerType, Type parameterType, Type messageType) =>
+        handlerType.Name == messageType.Name + "Handler" ? 0
+        : parameterType == messageType ? 1
+        : 2;
+
+    private readonly record struct Candidate(Type HandlerType, MethodInfo Method, int Rank);
+
+    /// <summary>
+    /// The handler type and the method to invoke for a given message type.
+    /// </summary>
+    internal readonly record struct HandlerBinding(Type HandlerType, MethodInfo Method);
+}

--- a/src/Granit.BackgroundJobs/Internal/BackgroundJobWorker.cs
+++ b/src/Granit.BackgroundJobs/Internal/BackgroundJobWorker.cs
@@ -17,13 +17,12 @@ namespace Granit.BackgroundJobs.Internal;
 /// for the in-process dispatch path.
 /// </summary>
 /// <remarks>
-/// Handler resolution follows the Wolverine convention: a type named
-/// <c>{MessageTypeName}Handler</c> in the message's assembly, exposing a public
-/// <c>HandleAsync</c> (or <c>Handle</c>) method whose first parameter is the message.
-/// Remaining parameters are resolved from the DI scope; a trailing
-/// <see cref="CancellationToken"/> is honoured. Static handler classes are supported —
-/// instance handlers are resolved from DI or activated via
-/// <see cref="ActivatorUtilities"/>.
+/// Handler resolution is delegated to <see cref="BackgroundJobHandlerResolver"/>, which
+/// mirrors Wolverine's binding rule (the handler method's first parameter type, not the
+/// handler class name) so both dispatch paths invoke the same handler. Remaining method
+/// parameters are resolved from the DI scope; a <see cref="CancellationToken"/> parameter
+/// is honoured. Static handler classes are supported — instance handlers are resolved from
+/// DI or activated via <see cref="ActivatorUtilities"/>.
 /// </remarks>
 internal sealed partial class BackgroundJobWorker(
     Channel<BackgroundJobEnvelope> channel,
@@ -32,8 +31,6 @@ internal sealed partial class BackgroundJobWorker(
     BackgroundJobsMetrics metrics,
     ILogger<BackgroundJobWorker> logger) : BackgroundService
 {
-    private static readonly string[] HandlerMethodNames = ["HandleAsync", "Handle"];
-
     /// <inheritdoc/>
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
@@ -78,7 +75,7 @@ internal sealed partial class BackgroundJobWorker(
         long startTimestamp = Stopwatch.GetTimestamp();
         try
         {
-            // Invoke the handler by resolving the Wolverine-convention HandleAsync method.
+            // Invoke the handler Wolverine would bind for this message type.
             await InvokeHandlerAsync(scope.ServiceProvider, envelope.Message, cancellationToken)
                 .ConfigureAwait(false);
 
@@ -126,43 +123,16 @@ internal sealed partial class BackgroundJobWorker(
     }
 
     /// <summary>
-    /// Resolves the handler for the message type and invokes its handle method.
-    /// Wolverine convention: the handler type name is <c>{MessageTypeName}Handler</c>;
-    /// the method is <c>HandleAsync</c> or <c>Handle</c> with the message as first
-    /// parameter, services from the scope for the remaining parameters, and an optional
-    /// <see cref="CancellationToken"/>.
+    /// Resolves the handler for the message type via <see cref="BackgroundJobHandlerResolver"/>
+    /// and invokes its handle method: the message as first argument, services from the scope
+    /// for the remaining parameters, and the ambient <see cref="CancellationToken"/>.
     /// </summary>
     private static async Task InvokeHandlerAsync(
         IServiceProvider services,
         object message,
         CancellationToken cancellationToken)
     {
-        Type messageType = message.GetType();
-        string expectedHandlerName = $"{messageType.Name}Handler";
-
-        Type? handlerType = messageType.Assembly
-            .GetTypes()
-            .FirstOrDefault(t => t.Name == expectedHandlerName && !t.IsInterface && !t.IsGenericTypeDefinition);
-
-        if (handlerType is null)
-        {
-            throw new InvalidOperationException(
-                $"No handler '{expectedHandlerName}' found in assembly '{messageType.Assembly.GetName().Name}' " +
-                $"for message type '{messageType.Name}'.");
-        }
-
-        MethodInfo? method = handlerType
-            .GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static)
-            .FirstOrDefault(m => HandlerMethodNames.Contains(m.Name)
-                && m.GetParameters() is [{ } first, ..]
-                && first.ParameterType.IsAssignableFrom(messageType));
-
-        if (method is null)
-        {
-            throw new InvalidOperationException(
-                $"Handler '{handlerType.Name}' does not have a public HandleAsync/Handle method " +
-                $"taking '{messageType.Name}' as its first parameter.");
-        }
+        (Type handlerType, MethodInfo method) = BackgroundJobHandlerResolver.Resolve(message.GetType());
 
         ParameterInfo[] parameters = method.GetParameters();
         object?[] args = new object?[parameters.Length];

--- a/tests/Granit.ArchitectureTests/BackgroundJobConventionTests.cs
+++ b/tests/Granit.ArchitectureTests/BackgroundJobConventionTests.cs
@@ -1,5 +1,9 @@
 using System.Text.RegularExpressions;
+using Granit.ArchitectureTests.Abstractions;
 using Granit.ArchitectureTests.Abstractions.Rules;
+using Granit.BackgroundJobs;
+using Granit.BackgroundJobs.Internal;
+using Granit.Reflection;
 using Shouldly;
 using Xunit;
 
@@ -12,6 +16,7 @@ namespace Granit.ArchitectureTests;
 /// <item><c>[RecurringJob]</c> requires <c>IBackgroundJob</c></item>
 /// <item><c>IBackgroundJob</c> types must reside in a <c>Jobs/</c> folder</item>
 /// <item>Jobs must not live in a <c>*.Wolverine</c> package</item>
+/// <item>every <c>IBackgroundJob</c> resolves a handler on the channel path</item>
 /// </list>
 /// </summary>
 public sealed partial class BackgroundJobConventionTests
@@ -109,6 +114,49 @@ public sealed partial class BackgroundJobConventionTests
             "IBackgroundJob types must not live in *.Wolverine packages — move them to a " +
             "*.BackgroundJobs sub-project's Jobs/ folder. " +
             $"Violators: {string.Join(", ", violations)}");
+    }
+
+    /// <summary>
+    /// Every <c>IBackgroundJob</c> must bind a handler under the in-process channel worker's
+    /// rule, not only under Wolverine's. The two dispatch paths are advertised as equivalent
+    /// and the channel path is the documented default — a job that only resolves under
+    /// Wolverine fails silently forever on that default (#3206).
+    /// </summary>
+    [Fact]
+    public void Jobs_must_resolve_a_handler_on_the_channel_path()
+    {
+        List<Type> jobs =
+        [
+            .. ArchitectureLoader.LoadAssemblies("Granit.", typeof(BackgroundJobConventionTests).Assembly)
+                .SelectMany(static a => a.GetLoadableTypes())
+                .Where(static t => typeof(IBackgroundJob).IsAssignableFrom(t)
+                    && t is { IsInterface: false, IsAbstract: false, IsGenericTypeDefinition: false })
+                .OrderBy(static t => t.FullName, StringComparer.Ordinal),
+        ];
+
+        // Guard against a green run caused by an empty scan (missing ProjectReference).
+        jobs.ShouldNotBeEmpty("No IBackgroundJob types found — the satellite packages are " +
+            "probably not referenced by Granit.ArchitectureTests.csproj.");
+
+        List<string> violations = [];
+
+        foreach (Type job in jobs)
+        {
+            try
+            {
+                BackgroundJobHandlerResolver.Resolve(job);
+            }
+            catch (InvalidOperationException ex)
+            {
+                violations.Add($"{job.FullName}: {ex.Message}");
+            }
+        }
+
+        violations.ShouldBeEmpty(
+            "Every IBackgroundJob must have exactly one handler in its own assembly: a public " +
+            "non-generic type whose name ends in 'Handler'/'Consumer', with a public HandleAsync/Handle " +
+            "method taking the job as first parameter. " +
+            $"Violators:{Environment.NewLine}{string.Join(Environment.NewLine, violations)}");
     }
 
     private static string FindRepoRoot()

--- a/tests/Granit.Auditing.BackgroundJobs.Tests/SatelliteJobChannelPathTests.cs
+++ b/tests/Granit.Auditing.BackgroundJobs.Tests/SatelliteJobChannelPathTests.cs
@@ -1,0 +1,82 @@
+using System.Diagnostics.Metrics;
+using System.Threading.Channels;
+using Granit.Auditing.BackgroundJobs.Jobs;
+using Granit.BackgroundJobs;
+using Granit.BackgroundJobs.Abstractions;
+using Granit.BackgroundJobs.Diagnostics;
+using Granit.BackgroundJobs.Internal;
+using Granit.Timing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Xunit;
+
+namespace Granit.Auditing.BackgroundJobs.Tests;
+
+/// <summary>
+/// Drives this satellite's recurring job through the in-process channel path — dispatcher,
+/// channel, worker, handler — with no Wolverine runtime, i.e. the configuration
+/// <c>GranitBackgroundJobsModule</c> wires by default.
+/// </summary>
+/// <remarks>
+/// Regression cover for #3206: the worker used to demand a <c>{MessageTypeName}Handler</c>
+/// type, which no satellite ships (they ship <c>{Action}Handler</c> per CLAUDE.md), so every
+/// recurring job failed on the documented default. The tests in
+/// <c>Granit.BackgroundJobs.Tests</c> could not catch it because their fixtures lived in the
+/// worker's own test assembly and happened to follow the stricter name; this one binds a job
+/// and a handler that really ship together in a satellite package.
+/// </remarks>
+public sealed class SatelliteJobChannelPathTests
+{
+    [Fact]
+    public async Task ChannelPath_AuditRetentionCleanupJob_InvokesTheSatelliteHandler()
+    {
+        IAuditRetentionCleanupService cleanup = Substitute.For<IAuditRetentionCleanupService>();
+        IBackgroundJobStoreWriter storeWriter = Substitute.For<IBackgroundJobStoreWriter>();
+        IBackgroundJobStoreReader storeReader = Substitute.For<IBackgroundJobStoreReader>();
+
+        var channel = Channel.CreateUnbounded<BackgroundJobEnvelope>();
+        ChannelBackgroundJobDispatcher dispatcher = new(channel, TimeProvider.System);
+
+        ServiceCollection services = new();
+        services.AddSingleton(cleanup);
+        services.AddSingleton(storeWriter);
+        services.AddSingleton(storeReader);
+        services.AddSingleton<IBackgroundJobDispatcher>(dispatcher);
+        services.AddMetrics();
+        await using ServiceProvider provider = services.BuildServiceProvider();
+
+        IClock clock = Substitute.For<IClock>();
+        clock.Now.Returns(new DateTimeOffset(2026, 3, 1, 2, 0, 0, TimeSpan.Zero));
+
+        BackgroundJobsMetrics metrics = new(provider.GetRequiredService<IMeterFactory>());
+        BackgroundJobWorker worker = new(
+            channel,
+            provider.GetRequiredService<IServiceScopeFactory>(),
+            clock,
+            metrics,
+            NullLogger<BackgroundJobWorker>.Instance);
+
+        // AuditRetentionCleanupJob carries [RecurringJob], so the worker takes the recurring
+        // path: store writes around the run, then a reschedule that stops at the substituted
+        // reader returning no definition.
+        await dispatcher.PublishAsync(
+            new AuditRetentionCleanupJob(),
+            cancellationToken: TestContext.Current.CancellationToken);
+        channel.Writer.Complete();
+
+        await worker.StartAsync(TestContext.Current.CancellationToken);
+        await WaitUntilAsync(() => cleanup.ReceivedCalls().Any());
+        await worker.StopAsync(TestContext.Current.CancellationToken);
+
+        await cleanup.Received(1).ExecuteAsync(Arg.Any<CancellationToken>());
+    }
+
+    private static async Task WaitUntilAsync(Func<bool> condition)
+    {
+        for (int attempt = 0; attempt < 50 && !condition(); attempt++)
+        {
+            await Task.Delay(20);
+        }
+    }
+}

--- a/tests/Granit.BackgroundJobs.Tests/Internal/BackgroundJobHandlerResolverTests.cs
+++ b/tests/Granit.BackgroundJobs.Tests/Internal/BackgroundJobHandlerResolverTests.cs
@@ -1,0 +1,181 @@
+using Granit.BackgroundJobs.Internal;
+using Shouldly;
+using Xunit;
+
+namespace Granit.BackgroundJobs.Tests.Internal;
+
+/// <summary>
+/// Covers the Wolverine-equivalent binding rule: the handler is found by the type of the
+/// handle method's first parameter, not by the handler class name (#3206).
+/// </summary>
+public sealed class BackgroundJobHandlerResolverTests
+{
+    [Fact]
+    public void Resolve_HandlerNamedAfterTheAction_BindsTheJob()
+    {
+        // The shape every Granit.{Module}.BackgroundJobs satellite ships: the job is
+        // {Action}Job, the handler {Action}Handler — no "Job" in the handler name.
+        BackgroundJobHandlerResolver.HandlerBinding binding =
+            BackgroundJobHandlerResolver.Resolve(typeof(SatelliteShapedJob));
+
+        binding.HandlerType.ShouldBe(typeof(SatelliteShapedHandler));
+        binding.Method.Name.ShouldBe("HandleAsync");
+    }
+
+    [Fact]
+    public void Resolve_HandlerNamedAfterTheJob_BindsTheJob()
+    {
+        BackgroundJobHandlerResolver.HandlerBinding binding =
+            BackgroundJobHandlerResolver.Resolve(typeof(ExactlyNamedJob));
+
+        binding.HandlerType.ShouldBe(typeof(ExactlyNamedJobHandler));
+    }
+
+    [Fact]
+    public void Resolve_ExactlyNamedHandlerWins_OverAnAssignableFallback()
+    {
+        // PreferredJobHandler takes the job exactly; BaseJobConsumer takes the base type
+        // and would otherwise be a candidate too.
+        BackgroundJobHandlerResolver.HandlerBinding binding =
+            BackgroundJobHandlerResolver.Resolve(typeof(PreferredJob));
+
+        binding.HandlerType.ShouldBe(typeof(PreferredJobHandler));
+    }
+
+    [Fact]
+    public void Resolve_ConsumerSuffixAndConsumeMethod_BindsTheJob()
+    {
+        BackgroundJobHandlerResolver.HandlerBinding binding =
+            BackgroundJobHandlerResolver.Resolve(typeof(ConsumedJob));
+
+        binding.HandlerType.ShouldBe(typeof(ConsumedJobConsumer));
+        binding.Method.Name.ShouldBe("Consume");
+    }
+
+    [Fact]
+    public void Resolve_StaticHandlerClass_BindsTheJob()
+    {
+        BackgroundJobHandlerResolver.HandlerBinding binding =
+            BackgroundJobHandlerResolver.Resolve(typeof(StaticallyHandledJob));
+
+        binding.HandlerType.ShouldBe(typeof(StaticallyHandledHandler));
+    }
+
+    [Fact]
+    public void Resolve_NoHandlerInAssembly_Throws()
+    {
+        InvalidOperationException ex = Should.Throw<InvalidOperationException>(
+            () => BackgroundJobHandlerResolver.Resolve(typeof(UnhandledJob)));
+
+        ex.Message.ShouldContain(nameof(UnhandledJob));
+    }
+
+    [Fact]
+    public void Resolve_TypeWithoutHandlerSuffix_IsNotACandidate()
+    {
+        // NotAHandlerNamedType has the right method shape but the wrong class name —
+        // Wolverine would not discover it either.
+        Should.Throw<InvalidOperationException>(
+            () => BackgroundJobHandlerResolver.Resolve(typeof(WronglyNamedHandlerJob)));
+    }
+
+    [Fact]
+    public void Resolve_TwoEquallyGoodHandlers_ThrowsRatherThanPickingOne()
+    {
+        InvalidOperationException ex = Should.Throw<InvalidOperationException>(
+            () => BackgroundJobHandlerResolver.Resolve(typeof(AmbiguousJob)));
+
+        ex.Message.ShouldContain("Ambiguous");
+        ex.Message.ShouldContain(nameof(FirstAmbiguousHandler));
+        ex.Message.ShouldContain(nameof(SecondAmbiguousHandler));
+    }
+
+    [Fact]
+    public void Resolve_CalledTwice_ReturnsTheSameBinding()
+    {
+        BackgroundJobHandlerResolver.HandlerBinding first =
+            BackgroundJobHandlerResolver.Resolve(typeof(SatelliteShapedJob));
+        BackgroundJobHandlerResolver.HandlerBinding second =
+            BackgroundJobHandlerResolver.Resolve(typeof(SatelliteShapedJob));
+
+        second.ShouldBe(first);
+    }
+
+    // =========================================================================
+    // Test doubles
+    // =========================================================================
+
+    public sealed record SatelliteShapedJob : IBackgroundJob;
+
+    public sealed class SatelliteShapedHandler
+    {
+        public static Task HandleAsync(SatelliteShapedJob job, CancellationToken cancellationToken) =>
+            Task.CompletedTask;
+    }
+
+    public sealed record ExactlyNamedJob : IBackgroundJob;
+
+    public sealed class ExactlyNamedJobHandler
+    {
+        public static Task HandleAsync(ExactlyNamedJob job, CancellationToken cancellationToken) =>
+            Task.CompletedTask;
+    }
+
+    public abstract record BaseJob : IBackgroundJob;
+
+    public sealed record PreferredJob : BaseJob;
+
+    public sealed class PreferredJobHandler
+    {
+        public static Task HandleAsync(PreferredJob job, CancellationToken cancellationToken) =>
+            Task.CompletedTask;
+    }
+
+    public sealed class BaseJobConsumer
+    {
+        public static Task ConsumeAsync(BaseJob job, CancellationToken cancellationToken) =>
+            Task.CompletedTask;
+    }
+
+    public sealed record ConsumedJob : IBackgroundJob;
+
+    public sealed class ConsumedJobConsumer
+    {
+        public static void Consume(ConsumedJob job)
+        {
+            // No-op: the resolver only needs the binding, not a side effect.
+        }
+    }
+
+    public sealed record StaticallyHandledJob : IBackgroundJob;
+
+    public static class StaticallyHandledHandler
+    {
+        public static Task HandleAsync(StaticallyHandledJob job, CancellationToken cancellationToken) =>
+            Task.CompletedTask;
+    }
+
+    public sealed record UnhandledJob : IBackgroundJob;
+
+    public sealed record WronglyNamedHandlerJob : IBackgroundJob;
+
+    public sealed class WronglyNamedHandlerListener
+    {
+        public static Task HandleAsync(WronglyNamedHandlerJob job, CancellationToken cancellationToken) =>
+            Task.CompletedTask;
+    }
+
+    public sealed record AmbiguousJob : IBackgroundJob;
+
+    public sealed class FirstAmbiguousHandler
+    {
+        public static Task HandleAsync(AmbiguousJob job, CancellationToken cancellationToken) =>
+            Task.CompletedTask;
+    }
+
+    public sealed class SecondAmbiguousHandler
+    {
+        public static Task HandleAsync(AmbiguousJob job, CancellationToken cancellationToken) =>
+            Task.CompletedTask;
+    }
+}

--- a/tests/Granit.BackgroundJobs.Tests/Internal/BackgroundJobWorkerTests.cs
+++ b/tests/Granit.BackgroundJobs.Tests/Internal/BackgroundJobWorkerTests.cs
@@ -354,6 +354,18 @@ public sealed class BackgroundJobWorkerTests
         await _cleanupService.Received(1).CleanupAsync(Arg.Any<CancellationToken>());
     }
 
+    [Fact]
+    public async Task ProcessAsync_HandlerNamedAfterTheAction_IsStillInvoked()
+    {
+        // Regression #3206: satellites ship {Action}Handler, not {Action}JobHandler.
+        // The channel path must bind it exactly like Wolverine does.
+        var envelope = new BackgroundJobEnvelope(new SweepExpiredJob());
+
+        await RunWorkerWithEnvelopeAsync(envelope);
+
+        await _cleanupService.Received(1).CleanupAsync(Arg.Any<CancellationToken>());
+    }
+
     // =========================================================================
     // Handler resolution — missing handler
     // =========================================================================
@@ -447,6 +459,21 @@ public sealed class BackgroundJobWorkerTests
     public interface IFakeCleanupService
     {
         Task CleanupAsync(CancellationToken cancellationToken);
+    }
+
+    /// <summary>
+    /// The naming every <c>Granit.{Module}.BackgroundJobs</c> satellite actually uses:
+    /// <c>{Action}Job</c> handled by <c>{Action}Handler</c> (CLAUDE.md §Background Jobs).
+    /// </summary>
+    public sealed record SweepExpiredJob : IBackgroundJob;
+
+    public sealed class SweepExpiredHandler
+    {
+        public static Task HandleAsync(
+            SweepExpiredJob job,
+            IFakeCleanupService service,
+            CancellationToken cancellationToken) =>
+            service.CleanupAsync(cancellationToken);
     }
 
     public static class ServiceInjectedJobHandler


### PR DESCRIPTION
Closes #3206.

## Problem

`BackgroundJobWorker` — the in-process (non-Wolverine) dispatch path — resolved handlers by demanding a type named `{MessageTypeName}Handler` in the message's assembly. No `Granit.*.BackgroundJobs` satellite ships that name: they ship `{Action}Handler`, which is what [`CLAUDE.md`](CLAUDE.md) documents *and* what Wolverine actually binds — Wolverine keys on the **type of the handle method's first parameter**, the class name only gating discovery.

So `MarkOverdueHandler.HandleAsync(MarkOverdueJob, …)` is a valid Wolverine handler that the channel worker refused. Every recurring job threw `InvalidOperationException` before reaching its handler on the configuration the docs present as the default — and the worker caught, logged, recorded the failure and rescheduled, so the job kept "running" every cycle while never doing any work.

Silently disarmed on that default: `AuditRetentionCleanupJob`, `DeletionDeadlineEnforcerJob`, `DataExchangeRetentionSweepJob`, `ConversationRetentionCleanupJob` (GDPR Art. 17 / ISO 27001 A.18), plus `OpenIddictKeyRotationJob`, `SigningKeyRotationScanJob`, `OpenIddictTokenCleanupJob`, `OpenIddictIdleSessionEnforcementJob`, `BffExpiredSessionCleanupJob`, `ExpiringApiKeyScannerJob`.

## Fix

Handler resolution moves to `BackgroundJobHandlerResolver`, mirroring Wolverine's rule: a public non-generic `*Handler`/`*Consumer` type exposing a `Handle`/`Handles`/`Consume`/`Consumes` (or `*Async`) method whose first parameter accepts the message.

- Candidates are **ranked** — exact `{Message}Handler` name, then exact parameter type, then an assignable base — so existing hosts see no behaviour change.
- A tie at the best rank **throws** instead of arbitrarily running one of two sweeps; only one binding is invocable on this path, and picking silently is worse than failing loudly.
- Bindings are **cached per message type**, dropping the `Assembly.GetTypes()` scan that ran on every single job execution.
- The class XML doc no longer mis-states the Wolverine convention.

This takes the issue's preferred option: no handler renames, `CLAUDE.md`'s documented convention stays intact, and the two dispatch paths become equivalent as advertised.

## Tests

All three fail against the old rule and pass against the fix (verified by temporarily restoring the strict lookup):

| Where | What |
| --- | --- |
| `Granit.ArchitectureTests` | `Jobs_must_resolve_a_handler_on_the_channel_path` runs the **real resolver** over every `IBackgroundJob` in the referenced satellites — 17 recurring jobs plus the on-demand ones. Guards against a green run on an empty scan. |
| `Granit.BackgroundJobs.Tests` | resolver unit tests (satellite naming, `*Consumer`/`Consume`, static handler classes, exact-name ranking over an assignable fallback, missing handler, wrong class suffix, ambiguity, caching) + a worker test driving a satellite-shaped pair |
| `Granit.Auditing.BackgroundJobs.Tests` | channel-path smoke test — dispatcher → channel → worker → handler, no Wolverine runtime — over `AuditRetentionCleanupJob`/`AuditRetentionCleanupHandler`, a pair that really ships together in a satellite package |

The smoke test lives in the satellite's own test project rather than `Granit.BackgroundJobs.Tests.Integration` so it needs no new `ProjectReference`; adding one there re-resolved the floating `10.*`/`6.*` versions and churned the lock file with an unrelated EF Core / Wolverine bump.

## Verification

- `Granit.BackgroundJobs.Tests` 122/122, `Granit.Auditing.BackgroundJobs.Tests` 3/3, `Granit.BackgroundJobs.Tests.Integration` 4/4, `Granit.BackgroundJobs.Wolverine.Tests` 36/36
- `Granit.ArchitectureTests` 642 tests, 0 failures attributable to this change (2 local-only failures come from untracked `bin`/`obj` residue of packages deleted in c12f9174)
- `dotnet format --verify-no-changes` clean on the `infrastructure`, `security` and `architecture` shards
- No lock-file changes; all three test projects are already registered in `.github/test-shards.json`

## Follow-up

`granit-business` ships 19 recurring jobs with the same `{Action}Handler` naming — all fixed by this change once it lands in a dev package, with no edits on that side. The equivalent architecture rule is worth porting to its arch-test suite.